### PR TITLE
Add triangle primitive and bullet tail renderer

### DIFF
--- a/src/ui/renderers/objects/BulletObjectRenderer.ts
+++ b/src/ui/renderers/objects/BulletObjectRenderer.ts
@@ -1,12 +1,67 @@
 import { ObjectRegistration, ObjectRenderer } from "./ObjectRenderer";
-import { SceneObjectInstance } from "../../../logic/services/SceneObjectManager";
-import { createDynamicCirclePrimitive } from "../primitives";
+import {
+  FILL_TYPES,
+  SceneLinearGradientFill,
+  SceneObjectInstance,
+  SceneVector2,
+} from "../../../logic/services/SceneObjectManager";
+import {
+  createDynamicCirclePrimitive,
+  createDynamicTrianglePrimitive,
+} from "../primitives";
+
+const TAIL_LENGTH_MULTIPLIER = 4.5;
+const TAIL_WIDTH_MULTIPLIER = 1.75;
+const TAIL_START_COLOR = { r: 0.25, g: 0.45, b: 1, a: 0.65 } as const;
+const TAIL_END_COLOR = { r: 0.05, g: 0.15, b: 0.6, a: 0 } as const;
+
+const getBulletRadius = (instance: SceneObjectInstance): number => {
+  const size = instance.data.size;
+  if (!size) {
+    return 0;
+  }
+  return Math.max(size.width, size.height) / 2;
+};
+
+const createTailVertices = (
+  instance: SceneObjectInstance
+): [SceneVector2, SceneVector2, SceneVector2] => {
+  const radius = getBulletRadius(instance);
+  const tailLength = radius * TAIL_LENGTH_MULTIPLIER;
+  const tailHalfWidth = (radius * TAIL_WIDTH_MULTIPLIER) / 2;
+  return [
+    { x: -radius, y: 0 },
+    { x: -radius - tailLength, y: tailHalfWidth },
+    { x: -radius - tailLength, y: -tailHalfWidth },
+  ];
+};
+
+const createTailFill = (instance: SceneObjectInstance): SceneLinearGradientFill => {
+  const radius = getBulletRadius(instance);
+  const tailLength = radius * TAIL_LENGTH_MULTIPLIER;
+  const halfLength = tailLength / 2;
+  return {
+    fillType: FILL_TYPES.LINEAR_GRADIENT,
+    start: { x: halfLength, y: 0 },
+    end: { x: -halfLength, y: 0 },
+    stops: [
+      { offset: 0, color: { ...TAIL_START_COLOR } },
+      { offset: 1, color: { ...TAIL_END_COLOR } },
+    ],
+  };
+};
 
 export class BulletObjectRenderer extends ObjectRenderer {
   public register(instance: SceneObjectInstance): ObjectRegistration {
     return {
       staticPrimitives: [],
-      dynamicPrimitives: [createDynamicCirclePrimitive(instance)],
+      dynamicPrimitives: [
+        createDynamicTrianglePrimitive(instance, {
+          getVertices: createTailVertices,
+          getFill: createTailFill,
+        }),
+        createDynamicCirclePrimitive(instance),
+      ],
     };
   }
 }

--- a/src/ui/renderers/primitives/TrianglePrimitive.ts
+++ b/src/ui/renderers/primitives/TrianglePrimitive.ts
@@ -1,0 +1,267 @@
+import {
+  SceneFill,
+  SceneObjectInstance,
+  SceneVector2,
+} from "../../../logic/services/SceneObjectManager";
+import {
+  DynamicPrimitive,
+  StaticPrimitive,
+  VERTEX_COMPONENTS,
+  transformObjectPoint,
+} from "../objects/ObjectRenderer";
+import {
+  copyFillComponents,
+  createFillVertexComponents,
+} from "./fill";
+
+interface TrianglePrimitiveOptions {
+  center: SceneVector2;
+  vertices: TriangleVertices;
+  fill: SceneFill;
+  rotation?: number;
+  offset?: SceneVector2;
+}
+
+interface DynamicTrianglePrimitiveOptions {
+  vertices?: TriangleVertices;
+  getVertices?: (instance: SceneObjectInstance) => TriangleVertices;
+  fill?: SceneFill;
+  getFill?: (instance: SceneObjectInstance) => SceneFill;
+  offset?: SceneVector2;
+}
+
+type TriangleVertices = [SceneVector2, SceneVector2, SceneVector2];
+
+type TriangleGeometry = {
+  centerOffset: SceneVector2;
+  size: { width: number; height: number };
+};
+
+const VERTEX_COUNT = 3;
+const MIN_SIZE = 1e-6;
+
+const cloneVertex = (vertex: SceneVector2): SceneVector2 => ({
+  x: vertex.x,
+  y: vertex.y,
+});
+
+const cloneVertices = (vertices: TriangleVertices): TriangleVertices => [
+  cloneVertex(vertices[0]!),
+  cloneVertex(vertices[1]!),
+  cloneVertex(vertices[2]!),
+];
+
+const resolveVertices = (
+  options: DynamicTrianglePrimitiveOptions,
+  instance: SceneObjectInstance
+): TriangleVertices => {
+  if (typeof options.getVertices === "function") {
+    return cloneVertices(options.getVertices(instance));
+  }
+  if (options.vertices) {
+    return cloneVertices(options.vertices);
+  }
+  return [
+    { x: 0, y: 0 },
+    { x: 0, y: 0 },
+    { x: 0, y: 0 },
+  ];
+};
+
+const resolveFill = (
+  options: DynamicTrianglePrimitiveOptions,
+  instance: SceneObjectInstance
+): SceneFill => {
+  if (typeof options.getFill === "function") {
+    return options.getFill(instance);
+  }
+  if (options.fill) {
+    return options.fill;
+  }
+  return instance.data.fill;
+};
+
+const computeGeometry = (vertices: TriangleVertices): TriangleGeometry => {
+  let minX = vertices[0]!.x;
+  let maxX = vertices[0]!.x;
+  let minY = vertices[0]!.y;
+  let maxY = vertices[0]!.y;
+
+  for (let i = 1; i < vertices.length; i += 1) {
+    const vertex = vertices[i]!;
+    if (vertex.x < minX) {
+      minX = vertex.x;
+    }
+    if (vertex.x > maxX) {
+      maxX = vertex.x;
+    }
+    if (vertex.y < minY) {
+      minY = vertex.y;
+    }
+    if (vertex.y > maxY) {
+      maxY = vertex.y;
+    }
+  }
+
+  const centerOffset = {
+    x: (minX + maxX) / 2,
+    y: (minY + maxY) / 2,
+  };
+
+  const width = Math.max(MIN_SIZE, maxX - minX);
+  const height = Math.max(MIN_SIZE, maxY - minY);
+
+  return {
+    centerOffset,
+    size: { width, height },
+  };
+};
+
+const pushVertex = (
+  target: Float32Array,
+  offset: number,
+  x: number,
+  y: number,
+  fillComponents: Float32Array
+): number => {
+  target[offset + 0] = x;
+  target[offset + 1] = y;
+  copyFillComponents(target, offset, fillComponents);
+  return offset + VERTEX_COMPONENTS;
+};
+
+const assignVertex = (
+  target: Float32Array,
+  offset: number,
+  x: number,
+  y: number,
+  fillComponents: Float32Array
+): boolean => {
+  let changed = false;
+  if (target[offset + 0] !== x) {
+    target[offset + 0] = x;
+    changed = true;
+  }
+  if (target[offset + 1] !== y) {
+    target[offset + 1] = y;
+    changed = true;
+  }
+  for (let i = 0; i < fillComponents.length; i += 1) {
+    const index = offset + 2 + i;
+    const value = fillComponents[i] ?? 0;
+    if (target[index] !== value) {
+      target[index] = value;
+      changed = true;
+    }
+  }
+  return changed;
+};
+
+const buildTriangleData = (
+  center: SceneVector2,
+  rotation: number,
+  vertices: TriangleVertices,
+  fillComponents: Float32Array
+): Float32Array => {
+  const data = new Float32Array(VERTEX_COUNT * VERTEX_COMPONENTS);
+  let writeOffset = 0;
+  for (let i = 0; i < vertices.length; i += 1) {
+    const point = transformObjectPoint(center, rotation, vertices[i]);
+    writeOffset = pushVertex(data, writeOffset, point.x, point.y, fillComponents);
+  }
+  return data;
+};
+
+const updateTriangleData = (
+  target: Float32Array,
+  center: SceneVector2,
+  rotation: number,
+  vertices: TriangleVertices,
+  fillComponents: Float32Array
+): boolean => {
+  let offset = 0;
+  let changed = false;
+  for (let i = 0; i < vertices.length; i += 1) {
+    const point = transformObjectPoint(center, rotation, vertices[i]);
+    if (assignVertex(target, offset, point.x, point.y, fillComponents)) {
+      changed = true;
+    }
+    offset += VERTEX_COMPONENTS;
+  }
+  return changed;
+};
+
+export const createStaticTrianglePrimitive = (
+  options: TrianglePrimitiveOptions
+): StaticPrimitive => {
+  const rotation = options.rotation ?? 0;
+  const origin = transformObjectPoint(
+    options.center,
+    options.rotation,
+    options.offset
+  );
+  const vertices = cloneVertices(options.vertices);
+  const geometry = computeGeometry(vertices);
+  const fillCenter = transformObjectPoint(
+    origin,
+    rotation,
+    geometry.centerOffset
+  );
+  const fillComponents = createFillVertexComponents({
+    fill: options.fill,
+    center: fillCenter,
+    rotation,
+    size: geometry.size,
+  });
+
+  return {
+    data: buildTriangleData(origin, rotation, vertices, fillComponents),
+  };
+};
+
+export const createDynamicTrianglePrimitive = (
+  instance: SceneObjectInstance,
+  options: DynamicTrianglePrimitiveOptions = {}
+): DynamicPrimitive => {
+  const initialVertices = resolveVertices(options, instance);
+  let geometry = computeGeometry(initialVertices);
+  const getCenter = (target: SceneObjectInstance): SceneVector2 =>
+    transformObjectPoint(target.data.position, target.data.rotation, options.offset);
+
+  let origin = getCenter(instance);
+  let rotation = instance.data.rotation ?? 0;
+  let fillCenter = transformObjectPoint(origin, rotation, geometry.centerOffset);
+  let fillComponents = createFillVertexComponents({
+    fill: resolveFill(options, instance),
+    center: fillCenter,
+    rotation,
+    size: geometry.size,
+  });
+
+  const data = buildTriangleData(origin, rotation, initialVertices, fillComponents);
+
+  return {
+    data,
+    update(target: SceneObjectInstance) {
+      const nextVertices = resolveVertices(options, target);
+      geometry = computeGeometry(nextVertices);
+      origin = getCenter(target);
+      rotation = target.data.rotation ?? 0;
+      fillCenter = transformObjectPoint(origin, rotation, geometry.centerOffset);
+      fillComponents = createFillVertexComponents({
+        fill: resolveFill(options, target),
+        center: fillCenter,
+        rotation,
+        size: geometry.size,
+      });
+      const changed = updateTriangleData(
+        data,
+        origin,
+        rotation,
+        nextVertices,
+        fillComponents
+      );
+      return changed ? data : null;
+    },
+  };
+};

--- a/src/ui/renderers/primitives/index.ts
+++ b/src/ui/renderers/primitives/index.ts
@@ -4,3 +4,7 @@ export {
   createDynamicCirclePrimitive,
 } from "./CirclePrimitive";
 export { createParticleSystemPrimitive } from "./ParticleSystemPrimitive";
+export {
+  createStaticTrianglePrimitive,
+  createDynamicTrianglePrimitive,
+} from "./TrianglePrimitive";


### PR DESCRIPTION
## Summary
- add a reusable triangle primitive with dynamic updates for transforms and fills
- render bullet tails with the triangle primitive and a blue gradient
- randomize bullet direction, propagate rotation, and clean up bullets when leaving bounds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e00ba6d4a8832084582509a677b9db