### PR TITLE
Add polygon rendering and particle emission controls

### DIFF
--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -1,13 +1,45 @@
 import {
+  SceneColor,
   SceneGradientStop,
   SceneSize,
+  SceneVector2,
 } from "../logic/services/SceneObjectManager";
 
-export type BrickType = "classic" | "smallSquareGray";
+export type BrickType = "classic" | "smallSquareGray" | "blueRadial";
+
+export interface BrickStrokeConfig {
+  color: SceneColor;
+  width: number;
+}
+
+export interface BrickLinearFillConfig {
+  type: "linear";
+  start?: SceneVector2;
+  end?: SceneVector2;
+  stops: readonly SceneGradientStop[];
+}
+
+export interface BrickRadialFillConfig {
+  type: "radial";
+  center?: SceneVector2;
+  radius?: number;
+  stops: readonly SceneGradientStop[];
+}
+
+export interface BrickSolidFillConfig {
+  type: "solid";
+  color: SceneColor;
+}
+
+export type BrickFillConfig =
+  | BrickLinearFillConfig
+  | BrickRadialFillConfig
+  | BrickSolidFillConfig;
 
 export interface BrickConfig {
   size: SceneSize;
-  gradientStops: readonly SceneGradientStop[];
+  fill: BrickFillConfig;
+  stroke?: BrickStrokeConfig;
 }
 
 const CLASSIC_GRADIENT: readonly SceneGradientStop[] = [
@@ -22,14 +54,42 @@ const SMALL_SQUARE_GRAY_GRADIENT: readonly SceneGradientStop[] = [
   { offset: 1, color: { r: 0.45, g: 0.45, b: 0.5, a: 1 } },
 ] as const;
 
+const BLUE_RADIAL_GRADIENT: readonly SceneGradientStop[] = [
+  { offset: 0, color: { r: 0.65, g: 0.8, b: 1, a: 1 } },
+  { offset: 0.4, color: { r: 0.35, g: 0.6, b: 0.95, a: 0.9 } },
+  { offset: 1, color: { r: 0.15, g: 0.25, b: 0.7, a: 0.6 } },
+] as const;
+
 const BRICK_DB: Record<BrickType, BrickConfig> = {
   classic: {
     size: { width: 60, height: 30 },
-    gradientStops: CLASSIC_GRADIENT,
+    fill: {
+      type: "linear",
+      start: { x: 0, y: -15 },
+      end: { x: 0, y: 15 },
+      stops: CLASSIC_GRADIENT,
+    },
+    stroke: { color: { r: 0.55, g: 0.4, b: 0.05, a: 1 }, width: 2 },
   },
   smallSquareGray: {
     size: { width: 32, height: 32 },
-    gradientStops: SMALL_SQUARE_GRAY_GRADIENT,
+    fill: {
+      type: "linear",
+      start: { x: -8, y: 0 },
+      end: { x: 8, y: 0 },
+      stops: SMALL_SQUARE_GRAY_GRADIENT,
+    },
+    stroke: { color: { r: 0.3, g: 0.3, b: 0.35, a: 1 }, width: 1.5 },
+  },
+  blueRadial: {
+    size: { width: 48, height: 48 },
+    fill: {
+      type: "radial",
+      center: { x: 0, y: 0 },
+      radius: 28,
+      stops: BLUE_RADIAL_GRADIENT,
+    },
+    stroke: { color: { r: 0.1, g: 0.15, b: 0.45, a: 1 }, width: 2.4 },
   },
 };
 

--- a/src/db/explosions-db.ts
+++ b/src/db/explosions-db.ts
@@ -1,4 +1,9 @@
-import { SceneColor, SceneGradientStop } from "../logic/services/SceneObjectManager";
+import {
+  FILL_TYPES,
+  SceneColor,
+  SceneFill,
+  SceneGradientStop,
+} from "../logic/services/SceneObjectManager";
 
 export type ExplosionType = "plasmoid" | "magnetic";
 
@@ -23,6 +28,9 @@ export interface ExplosionEmitterConfig {
    */
   spawnRadiusMultiplier: number;
   color: SceneColor;
+  arc?: number;
+  direction?: number;
+  fill?: SceneFill;
 }
 
 export interface ExplosionConfig {
@@ -44,6 +52,22 @@ const MAGNETIC_WAVE_GRADIENT_STOPS: readonly SceneGradientStop[] = [
   { offset: 1, color: { r: 0.25, g: 0.05, b: 0.7, a: 0 } },
 ] as const;
 
+const DEFAULT_EMITTER_FILL: SceneFill = {
+  fillType: FILL_TYPES.SOLID,
+  color: { r: 1, g: 0.85, b: 0.55, a: 1 },
+};
+
+const MAGNETIC_EMITTER_FILL: SceneFill = {
+  fillType: FILL_TYPES.RADIAL_GRADIENT,
+  start: { x: 0, y: 0 },
+  end: 8,
+  stops: [
+    { offset: 0, color: { r: 1, g: 1, b: 1, a: 0.95 } },
+    { offset: 0.4, color: { r: 0.7, g: 0.6, b: 1, a: 0.6 } },
+    { offset: 1, color: { r: 0.4, g: 0.2, b: 0.9, a: 0 } },
+  ],
+};
+
 const DEFAULT_EMITTER: ExplosionEmitterConfig = {
   emissionDurationMs: 700,
   particlesPerSecond: 260,
@@ -55,6 +79,9 @@ const DEFAULT_EMITTER: ExplosionEmitterConfig = {
   spawnRadius: { min: 0, max: 12 },
   spawnRadiusMultiplier: 1.5,
   color: { r: 1, g: 0.85, b: 0.55, a: 1 },
+  arc: Math.PI * 2,
+  direction: 0,
+  fill: DEFAULT_EMITTER_FILL,
 };
 
 const EXPLOSION_DB: Record<ExplosionType, ExplosionConfig> = {
@@ -81,6 +108,9 @@ const EXPLOSION_DB: Record<ExplosionType, ExplosionConfig> = {
     emitter: {
       ...DEFAULT_EMITTER,
       color: { r: 1, g: 1, b: 1, a: 1 },
+      fill: MAGNETIC_EMITTER_FILL,
+      arc: Math.PI / 2,
+      direction: Math.PI,
     },
   },
 };

--- a/src/logic/modules/BricksModule.ts
+++ b/src/logic/modules/BricksModule.ts
@@ -18,16 +18,35 @@ const MAX_BRICKS = 2000;
 const DEFAULT_BRICK_TYPE: BrickType = "smallSquareGray";
 
 const createBrickFill = (config: BrickConfig) => {
-  const halfHeight = config.size.height / 2;
-  return {
-    fillType: FILL_TYPES.LINEAR_GRADIENT,
-    start: { x: 0, y: -halfHeight },
-    end: { x: 0, y: halfHeight },
-    stops: config.gradientStops.map((stop) => ({
-      offset: stop.offset,
-      color: { ...stop.color },
-    })),
-  };
+  const fill = config.fill;
+  switch (fill.type) {
+    case "solid":
+      return {
+        fillType: FILL_TYPES.SOLID,
+        color: { ...fill.color },
+      };
+    case "radial":
+      return {
+        fillType: FILL_TYPES.RADIAL_GRADIENT,
+        start: fill.center ? { ...fill.center } : undefined,
+        end: fill.radius,
+        stops: fill.stops.map((stop) => ({
+          offset: stop.offset,
+          color: { ...stop.color },
+        })),
+      };
+    case "linear":
+    default:
+      return {
+        fillType: FILL_TYPES.LINEAR_GRADIENT,
+        start: fill.start ? { ...fill.start } : undefined,
+        end: fill.end ? { ...fill.end } : undefined,
+        stops: fill.stops.map((stop) => ({
+          offset: stop.offset,
+          color: { ...stop.color },
+        })),
+      };
+  }
 };
 
 export const BRICK_COUNT_BRIDGE_KEY = "bricks/count";
@@ -150,6 +169,12 @@ export class BricksModule implements GameModule {
         size: { ...config.size },
         fill: createBrickFill(config),
         rotation: brick.rotation,
+        stroke: config.stroke
+          ? {
+              color: { ...config.stroke.color },
+              width: config.stroke.width,
+            }
+          : undefined,
       });
       this.objectIds.add(id);
     });

--- a/src/ui/renderers/objects/ObjectsRendererManager.ts
+++ b/src/ui/renderers/objects/ObjectsRendererManager.ts
@@ -10,6 +10,7 @@ import {
   SceneFill,
   SceneObjectInstance,
   SceneObjectManager,
+  SceneStroke,
 } from "../../../logic/services/SceneObjectManager";
 
 interface ManagedObject {
@@ -265,6 +266,7 @@ export class ObjectsRendererManager {
         size: instance.data.size ? { ...instance.data.size } : undefined,
         color: instance.data.color ? { ...instance.data.color } : undefined,
         fill: cloneFill(instance.data.fill),
+        stroke: cloneStroke(instance.data.stroke),
         rotation:
           typeof instance.data.rotation === "number"
             ? instance.data.rotation
@@ -308,4 +310,14 @@ const cloneFill = (fill: SceneFill): SceneFill => {
         color: { r: 1, g: 1, b: 1, a: 1 },
       };
   }
+};
+
+const cloneStroke = (stroke: SceneStroke | undefined): SceneStroke | undefined => {
+  if (!stroke) {
+    return undefined;
+  }
+  return {
+    color: { ...stroke.color },
+    width: stroke.width,
+  };
 };

--- a/src/ui/renderers/objects/PolygonObjectRenderer.ts
+++ b/src/ui/renderers/objects/PolygonObjectRenderer.ts
@@ -1,0 +1,99 @@
+import { ObjectRegistration, ObjectRenderer } from "./ObjectRenderer";
+import {
+  SceneObjectInstance,
+  SceneVector2,
+  SceneStroke,
+} from "../../../logic/services/SceneObjectManager";
+import {
+  createStaticPolygonPrimitive,
+  createStaticPolygonStrokePrimitive,
+} from "../primitives";
+
+interface PolygonCustomData {
+  vertices?: SceneVector2[];
+  offset?: SceneVector2;
+}
+
+const DEFAULT_VERTICES: SceneVector2[] = [
+  { x: -20, y: -20 },
+  { x: 20, y: -20 },
+  { x: 0, y: 30 },
+];
+
+const isVector = (value: unknown): value is SceneVector2 =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as SceneVector2).x === "number" &&
+  typeof (value as SceneVector2).y === "number";
+
+const normalizeVertices = (vertices: SceneVector2[] | undefined): SceneVector2[] => {
+  if (!Array.isArray(vertices)) {
+    return DEFAULT_VERTICES.map((vertex) => ({ ...vertex }));
+  }
+  const sanitized = vertices
+    .filter((vertex) => isVector(vertex))
+    .map((vertex) => ({ x: vertex.x, y: vertex.y }));
+  if (sanitized.length < 3) {
+    return DEFAULT_VERTICES.map((vertex) => ({ ...vertex }));
+  }
+  return sanitized;
+};
+
+const normalizeOffset = (offset: SceneVector2 | undefined): SceneVector2 | undefined => {
+  if (!offset || !isVector(offset)) {
+    return undefined;
+  }
+  return { x: offset.x, y: offset.y };
+};
+
+const extractCustomData = (
+  instance: SceneObjectInstance
+): { vertices: SceneVector2[]; offset?: SceneVector2 } => {
+  const payload = instance.data.customData as PolygonCustomData | undefined;
+  if (!payload || typeof payload !== "object") {
+    return { vertices: DEFAULT_VERTICES.map((vertex) => ({ ...vertex })) };
+  }
+  return {
+    vertices: normalizeVertices(payload.vertices),
+    offset: normalizeOffset(payload.offset),
+  };
+};
+
+const hasStroke = (stroke: SceneStroke | undefined): stroke is SceneStroke =>
+  !!stroke && typeof stroke.width === "number" && stroke.width > 0;
+
+export class PolygonObjectRenderer extends ObjectRenderer {
+  public register(instance: SceneObjectInstance): ObjectRegistration {
+    const { vertices, offset } = extractCustomData(instance);
+    const rotation = instance.data.rotation ?? 0;
+    const primitives = [];
+
+    if (hasStroke(instance.data.stroke)) {
+      const strokePrimitive = createStaticPolygonStrokePrimitive({
+        center: instance.data.position,
+        vertices,
+        stroke: instance.data.stroke,
+        rotation,
+        offset,
+      });
+      if (strokePrimitive) {
+        primitives.push(strokePrimitive);
+      }
+    }
+
+    primitives.push(
+      createStaticPolygonPrimitive({
+        center: instance.data.position,
+        vertices,
+        fill: instance.data.fill,
+        rotation,
+        offset,
+      })
+    );
+
+    return {
+      staticPrimitives: primitives,
+      dynamicPrimitives: [],
+    };
+  }
+}

--- a/src/ui/renderers/objects/index.ts
+++ b/src/ui/renderers/objects/index.ts
@@ -3,6 +3,7 @@ import { BulletObjectRenderer } from "./BulletObjectRenderer";
 import { ObjectsRendererManager } from "./ObjectsRendererManager";
 import { ObjectRenderer } from "./ObjectRenderer";
 import { ExplosionObjectRenderer } from "./ExplosionObjectRenderer";
+import { PolygonObjectRenderer } from "./PolygonObjectRenderer";
 
 export { ObjectsRendererManager } from "./ObjectsRendererManager";
 export type { SyncInstructions, DynamicBufferUpdate } from "./ObjectsRendererManager";
@@ -23,6 +24,7 @@ export const createObjectsRendererManager = (): ObjectsRendererManager => {
     ["brick", new BrickObjectRenderer()],
     ["bullet", new BulletObjectRenderer()],
     ["explosion", new ExplosionObjectRenderer()],
+    ["polygon", new PolygonObjectRenderer()],
   ]);
   return new ObjectsRendererManager(renderers);
 };

--- a/src/ui/renderers/primitives/PolygonPrimitive.ts
+++ b/src/ui/renderers/primitives/PolygonPrimitive.ts
@@ -1,0 +1,404 @@
+import {
+  FILL_TYPES,
+  SceneFill,
+  SceneObjectInstance,
+  SceneVector2,
+  SceneStroke,
+} from "../../../logic/services/SceneObjectManager";
+import {
+  DynamicPrimitive,
+  StaticPrimitive,
+  VERTEX_COMPONENTS,
+  transformObjectPoint,
+} from "../objects/ObjectRenderer";
+import {
+  copyFillComponents,
+  createFillVertexComponents,
+} from "./fill";
+
+interface PolygonPrimitiveOptions {
+  center: SceneVector2;
+  vertices: SceneVector2[];
+  fill: SceneFill;
+  rotation?: number;
+  offset?: SceneVector2;
+}
+
+interface DynamicPolygonPrimitiveOptions {
+  vertices?: SceneVector2[];
+  getVertices?: (instance: SceneObjectInstance) => SceneVector2[];
+  fill?: SceneFill;
+  getFill?: (instance: SceneObjectInstance) => SceneFill;
+  offset?: SceneVector2;
+}
+
+interface PolygonStrokeOptions {
+  center: SceneVector2;
+  vertices: SceneVector2[];
+  stroke: SceneStroke;
+  rotation?: number;
+  offset?: SceneVector2;
+}
+
+type PolygonVertices = SceneVector2[];
+
+type PolygonGeometry = {
+  centerOffset: SceneVector2;
+  size: { width: number; height: number };
+};
+
+const MIN_VERTEX_COUNT = 3;
+const MIN_SIZE = 1e-6;
+
+const cloneVertex = (vertex: SceneVector2): SceneVector2 => ({
+  x: vertex.x,
+  y: vertex.y,
+});
+
+const cloneVertices = (vertices: PolygonVertices): PolygonVertices =>
+  vertices.map((vertex) => cloneVertex(vertex));
+
+const ensureVertices = (vertices: SceneVector2[] | undefined): PolygonVertices => {
+  if (!vertices || vertices.length < MIN_VERTEX_COUNT) {
+    return [
+      { x: -10, y: -10 },
+      { x: 10, y: -10 },
+      { x: 0, y: 15 },
+    ];
+  }
+  return vertices.map((vertex) => ({
+    x: typeof vertex.x === "number" ? vertex.x : 0,
+    y: typeof vertex.y === "number" ? vertex.y : 0,
+  }));
+};
+
+const resolveVertices = (
+  options: DynamicPolygonPrimitiveOptions,
+  instance: SceneObjectInstance
+): PolygonVertices => {
+  if (typeof options.getVertices === "function") {
+    return ensureVertices(options.getVertices(instance));
+  }
+  if (options.vertices) {
+    return ensureVertices(options.vertices);
+  }
+  const data = instance.data.customData as
+    | { vertices?: SceneVector2[] }
+    | undefined;
+  return ensureVertices(data?.vertices);
+};
+
+const resolveFill = (
+  options: DynamicPolygonPrimitiveOptions,
+  instance: SceneObjectInstance
+): SceneFill => {
+  if (typeof options.getFill === "function") {
+    return options.getFill(instance);
+  }
+  if (options.fill) {
+    return options.fill;
+  }
+  return instance.data.fill;
+};
+
+const computeGeometry = (vertices: PolygonVertices): PolygonGeometry => {
+  if (vertices.length < MIN_VERTEX_COUNT) {
+    return {
+      centerOffset: { x: 0, y: 0 },
+      size: { width: MIN_SIZE, height: MIN_SIZE },
+    };
+  }
+  let minX = vertices[0]!.x;
+  let maxX = vertices[0]!.x;
+  let minY = vertices[0]!.y;
+  let maxY = vertices[0]!.y;
+
+  for (let i = 1; i < vertices.length; i += 1) {
+    const vertex = vertices[i]!;
+    if (vertex.x < minX) {
+      minX = vertex.x;
+    }
+    if (vertex.x > maxX) {
+      maxX = vertex.x;
+    }
+    if (vertex.y < minY) {
+      minY = vertex.y;
+    }
+    if (vertex.y > maxY) {
+      maxY = vertex.y;
+    }
+  }
+
+  const centerOffset = {
+    x: (minX + maxX) / 2,
+    y: (minY + maxY) / 2,
+  };
+
+  const width = Math.max(MIN_SIZE, maxX - minX);
+  const height = Math.max(MIN_SIZE, maxY - minY);
+
+  return {
+    centerOffset,
+    size: { width, height },
+  };
+};
+
+const pushVertex = (
+  target: Float32Array,
+  offset: number,
+  x: number,
+  y: number,
+  fillComponents: Float32Array
+): number => {
+  target[offset + 0] = x;
+  target[offset + 1] = y;
+  copyFillComponents(target, offset, fillComponents);
+  return offset + VERTEX_COMPONENTS;
+};
+
+const assignVertex = (
+  target: Float32Array,
+  offset: number,
+  x: number,
+  y: number,
+  fillComponents: Float32Array
+): boolean => {
+  let changed = false;
+  if (target[offset + 0] !== x) {
+    target[offset + 0] = x;
+    changed = true;
+  }
+  if (target[offset + 1] !== y) {
+    target[offset + 1] = y;
+    changed = true;
+  }
+  for (let i = 0; i < fillComponents.length; i += 1) {
+    const index = offset + 2 + i;
+    const value = fillComponents[i] ?? 0;
+    if (target[index] !== value) {
+      target[index] = value;
+      changed = true;
+    }
+  }
+  return changed;
+};
+
+const buildPolygonData = (
+  center: SceneVector2,
+  rotation: number,
+  vertices: PolygonVertices,
+  fillComponents: Float32Array
+): Float32Array => {
+  const triangleCount = Math.max(vertices.length - 2, 0);
+  if (triangleCount <= 0) {
+    return new Float32Array(0);
+  }
+  const transformed = vertices.map((vertex) =>
+    transformObjectPoint(center, rotation, vertex)
+  );
+  const data = new Float32Array(triangleCount * 3 * VERTEX_COMPONENTS);
+  let writeOffset = 0;
+  const anchor = transformed[0]!;
+  for (let i = 1; i < transformed.length - 1; i += 1) {
+    writeOffset = pushVertex(
+      data,
+      writeOffset,
+      anchor.x,
+      anchor.y,
+      fillComponents
+    );
+    const current = transformed[i]!;
+    writeOffset = pushVertex(
+      data,
+      writeOffset,
+      current.x,
+      current.y,
+      fillComponents
+    );
+    const next = transformed[i + 1]!;
+    writeOffset = pushVertex(data, writeOffset, next.x, next.y, fillComponents);
+  }
+  return data;
+};
+
+const updatePolygonData = (
+  target: Float32Array,
+  center: SceneVector2,
+  rotation: number,
+  vertices: PolygonVertices,
+  fillComponents: Float32Array
+): boolean => {
+  const triangleCount = Math.max(vertices.length - 2, 0);
+  if (triangleCount <= 0) {
+    if (target.length === 0) {
+      return false;
+    }
+    for (let i = 0; i < target.length; i += 1) {
+      if (target[i] !== 0) {
+        target[i] = 0;
+      }
+    }
+    return true;
+  }
+  const transformed = vertices.map((vertex) =>
+    transformObjectPoint(center, rotation, vertex)
+  );
+  let offset = 0;
+  let changed = false;
+  const anchor = transformed[0]!;
+  for (let i = 1; i < transformed.length - 1; i += 1) {
+    changed =
+      assignVertex(target, offset, anchor.x, anchor.y, fillComponents) || changed;
+    offset += VERTEX_COMPONENTS;
+
+    const current = transformed[i]!;
+    changed =
+      assignVertex(target, offset, current.x, current.y, fillComponents) ||
+      changed;
+    offset += VERTEX_COMPONENTS;
+
+    const next = transformed[i + 1]!;
+    changed =
+      assignVertex(target, offset, next.x, next.y, fillComponents) || changed;
+    offset += VERTEX_COMPONENTS;
+  }
+  return changed;
+};
+
+const expandVertices = (
+  vertices: PolygonVertices,
+  centerOffset: SceneVector2,
+  strokeWidth: number
+): PolygonVertices => {
+  if (strokeWidth <= 0) {
+    return cloneVertices(vertices);
+  }
+  return vertices.map((vertex) => {
+    const dir = {
+      x: vertex.x - centerOffset.x,
+      y: vertex.y - centerOffset.y,
+    };
+    const length = Math.hypot(dir.x, dir.y);
+    if (length === 0) {
+      return {
+        x: vertex.x + strokeWidth,
+        y: vertex.y,
+      };
+    }
+    const scale = (length + strokeWidth) / Math.max(length, 1e-6);
+    return {
+      x: centerOffset.x + dir.x * scale,
+      y: centerOffset.y + dir.y * scale,
+    };
+  });
+};
+
+const createStrokeFill = (stroke: SceneStroke): SceneFill => ({
+  fillType: FILL_TYPES.SOLID,
+  color: {
+    r: stroke.color.r,
+    g: stroke.color.g,
+    b: stroke.color.b,
+    a: typeof stroke.color.a === "number" ? stroke.color.a : 1,
+  },
+});
+
+export const createStaticPolygonPrimitive = (
+  options: PolygonPrimitiveOptions
+): StaticPrimitive => {
+  const { center, vertices, fill, rotation, offset } = options;
+  const origin = transformObjectPoint(center, rotation, offset);
+  const geometry = computeGeometry(vertices);
+  const fillCenter = transformObjectPoint(
+    origin,
+    rotation ?? 0,
+    geometry.centerOffset
+  );
+  const fillComponents = createFillVertexComponents({
+    fill,
+    center: fillCenter,
+    rotation: rotation ?? 0,
+    size: geometry.size,
+  });
+  return {
+    data: buildPolygonData(origin, rotation ?? 0, vertices, fillComponents),
+  };
+};
+
+export const createDynamicPolygonPrimitive = (
+  instance: SceneObjectInstance,
+  options: DynamicPolygonPrimitiveOptions = {}
+): DynamicPrimitive => {
+  const initialVertices = resolveVertices(options, instance);
+  let vertexCount = initialVertices.length;
+  let geometry = computeGeometry(initialVertices);
+  const getCenter = (target: SceneObjectInstance): SceneVector2 =>
+    transformObjectPoint(target.data.position, target.data.rotation, options.offset);
+
+  let origin = getCenter(instance);
+  let rotation = instance.data.rotation ?? 0;
+  let fillCenter = transformObjectPoint(origin, rotation, geometry.centerOffset);
+  let fillComponents = createFillVertexComponents({
+    fill: resolveFill(options, instance),
+    center: fillCenter,
+    rotation,
+    size: geometry.size,
+  });
+
+  let data = buildPolygonData(origin, rotation, initialVertices, fillComponents);
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return data;
+    },
+    update(target: SceneObjectInstance) {
+      const nextVertices = resolveVertices(options, target);
+      const nextVertexCount = nextVertices.length;
+      geometry = computeGeometry(nextVertices);
+      origin = getCenter(target);
+      rotation = target.data.rotation ?? 0;
+      fillCenter = transformObjectPoint(origin, rotation, geometry.centerOffset);
+      fillComponents = createFillVertexComponents({
+        fill: resolveFill(options, target),
+        center: fillCenter,
+        rotation,
+        size: geometry.size,
+      });
+
+      if (nextVertexCount !== vertexCount) {
+        vertexCount = nextVertexCount;
+        data = buildPolygonData(origin, rotation, nextVertices, fillComponents);
+        return data;
+      }
+
+      const changed = updatePolygonData(
+        data,
+        origin,
+        rotation,
+        nextVertices,
+        fillComponents
+      );
+      return changed ? data : null;
+    },
+  };
+
+  return primitive;
+};
+
+export const createStaticPolygonStrokePrimitive = (
+  options: PolygonStrokeOptions
+): StaticPrimitive | null => {
+  const { stroke, vertices } = options;
+  if (!stroke || stroke.width <= 0) {
+    return null;
+  }
+  const geometry = computeGeometry(vertices);
+  const expanded = expandVertices(vertices, geometry.centerOffset, stroke.width);
+  return createStaticPolygonPrimitive({
+    center: options.center,
+    vertices: expanded,
+    fill: createStrokeFill(stroke),
+    rotation: options.rotation,
+    offset: options.offset,
+  });
+};

--- a/src/ui/renderers/primitives/index.ts
+++ b/src/ui/renderers/primitives/index.ts
@@ -8,3 +8,8 @@ export {
   createStaticTrianglePrimitive,
   createDynamicTrianglePrimitive,
 } from "./TrianglePrimitive";
+export {
+  createStaticPolygonPrimitive,
+  createDynamicPolygonPrimitive,
+  createStaticPolygonStrokePrimitive,
+} from "./PolygonPrimitive";


### PR DESCRIPTION
## Summary
- add reusable polygon primitives and renderer registration for scene polygons
- support configurable strokes for scene objects and bricks, including a new blue radial brick definition
- extend particle emitters with directional control and gradient fills for explosions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0b7293cac8320b437887b43286489