### PR TITLE
Add map selection support with map module

### DIFF
--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -76,6 +76,8 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
     destructubleData: {
       maxHp: 25,
       armor: 2,
+      baseDamage: 3,
+      brickKnockBack: 20,
     }
   },
   smallSquareGray: {
@@ -90,6 +92,8 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
     destructubleData: {
       maxHp: 5,
       armor: 0,
+      baseDamage: 2,
+      brickKnockBack: 20,
     }
   },
   blueRadial: {
@@ -104,6 +108,8 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
     destructubleData: {
       maxHp: 125,
       armor: 10,
+      baseDamage: 10,
+      brickKnockBack: 20,
     }
   },
 };

--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -77,7 +77,8 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       maxHp: 25,
       armor: 2,
       baseDamage: 3,
-      brickKnockBack: 20,
+      brickKnockBackDistance: 20,
+      brickKnockBackSpeed: 40,
     }
   },
   smallSquareGray: {
@@ -93,7 +94,8 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       maxHp: 5,
       armor: 0,
       baseDamage: 2,
-      brickKnockBack: 20,
+      brickKnockBackDistance: 20,
+      brickKnockBackSpeed: 40,
     }
   },
   blueRadial: {
@@ -109,7 +111,8 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       maxHp: 125,
       armor: 10,
       baseDamage: 10,
-      brickKnockBack: 20,
+      brickKnockBackDistance: 20,
+      brickKnockBackSpeed: 40,
     }
   },
 };

--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -79,6 +79,7 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       baseDamage: 3,
       brickKnockBackDistance: 20,
       brickKnockBackSpeed: 40,
+      physicalSize: 28,
     }
   },
   smallSquareGray: {
@@ -96,6 +97,7 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       baseDamage: 2,
       brickKnockBackDistance: 20,
       brickKnockBackSpeed: 40,
+      physicalSize: 16,
     }
   },
   blueRadial: {
@@ -113,6 +115,7 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       baseDamage: 10,
       brickKnockBackDistance: 20,
       brickKnockBackSpeed: 40,
+      physicalSize: 24,
     }
   },
 };

--- a/src/db/maps-db.ts
+++ b/src/db/maps-db.ts
@@ -1,5 +1,6 @@
 import { BrickType } from "./bricks-db";
-import { SceneSize } from "../logic/services/SceneObjectManager";
+import { SceneSize, SceneVector2 } from "../logic/services/SceneObjectManager";
+import { PlayerUnitType } from "./player-units-db";
 
 export type MapId = "initial";
 
@@ -12,6 +13,7 @@ export interface MapConfig {
   readonly name: string;
   readonly size: SceneSize;
   readonly bricks: readonly MapBrickGroupConfig[];
+  readonly playerUnits?: readonly MapPlayerUnitConfig[];
 }
 
 export interface MapListEntry {
@@ -22,6 +24,11 @@ export interface MapListEntry {
   readonly brickTypes: readonly BrickType[];
 }
 
+export interface MapPlayerUnitConfig {
+  readonly type: PlayerUnitType;
+  readonly position: SceneVector2;
+}
+
 const MAPS_DB: Record<MapId, MapConfig> = {
   initial: {
     name: "Initial Grounds",
@@ -30,6 +37,12 @@ const MAPS_DB: Record<MapId, MapConfig> = {
       {
         type: "smallSquareGray",
         count: 2000,
+      },
+    ],
+    playerUnits: [
+      {
+        type: "bluePentagon",
+        position: { x: 100, y: 100 },
       },
     ],
   },

--- a/src/db/maps-db.ts
+++ b/src/db/maps-db.ts
@@ -1,0 +1,63 @@
+import { BrickType } from "./bricks-db";
+import { SceneSize } from "../logic/services/SceneObjectManager";
+
+export type MapId = "initial";
+
+export interface MapBrickGroupConfig {
+  readonly type: BrickType;
+  readonly count: number;
+}
+
+export interface MapConfig {
+  readonly name: string;
+  readonly size: SceneSize;
+  readonly bricks: readonly MapBrickGroupConfig[];
+}
+
+export interface MapListEntry {
+  readonly id: MapId;
+  readonly name: string;
+  readonly size: SceneSize;
+  readonly brickCount: number;
+  readonly brickTypes: readonly BrickType[];
+}
+
+const MAPS_DB: Record<MapId, MapConfig> = {
+  initial: {
+    name: "Initial Grounds",
+    size: { width: 4000, height: 4000 },
+    bricks: [
+      {
+        type: "smallSquareGray",
+        count: 2000,
+      },
+    ],
+  },
+};
+
+export const MAP_IDS = Object.keys(MAPS_DB) as MapId[];
+
+export const getMapConfig = (mapId: MapId): MapConfig => {
+  const config = MAPS_DB[mapId];
+  if (!config) {
+    throw new Error(`Unknown map: ${mapId}`);
+  }
+  return config;
+};
+
+export const isMapId = (value: unknown): value is MapId =>
+  typeof value === "string" && Object.prototype.hasOwnProperty.call(MAPS_DB, value);
+
+export const getMapList = (): MapListEntry[] =>
+  MAP_IDS.map((mapId) => {
+    const config = MAPS_DB[mapId];
+    const brickCount = config.bricks.reduce((total, group) => total + group.count, 0);
+    const brickTypes = Array.from(new Set(config.bricks.map((group) => group.type)));
+    return {
+      id: mapId,
+      name: config.name,
+      size: { ...config.size },
+      brickCount,
+      brickTypes,
+    };
+  });

--- a/src/db/player-units-db.ts
+++ b/src/db/player-units-db.ts
@@ -45,11 +45,11 @@ export interface PlayerUnitConfig {
 }
 
 const BLUE_PENTAGON_VERTICES: readonly SceneVector2[] = [
-  { x: 0, y: -18 },
-  { x: 17, y: -6 },
-  { x: 11, y: 16 },
-  { x: -11, y: 16 },
-  { x: -17, y: -6 },
+  { x: 0, y: -6 },
+  { x: 17/3, y: -2 },
+  { x: 11/3, y: 16/3 },
+  { x: -11/3, y: 16/3 },
+  { x: -17/3, y: -2 },
 ];
 
 const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
@@ -58,7 +58,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
     renderer: {
       kind: "polygon",
       vertices: BLUE_PENTAGON_VERTICES,
-      fill: { r: 0.2, g: 0.45, b: 0.95, a: 1 },
+      fill: { r: 0.2, g: 0.75, b: 0.95, a: 1 },
       stroke: {
         color: { r: 0.05, g: 0.15, b: 0.4, a: 1 },
         width: 2,
@@ -70,7 +70,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
     baseAttackDamage: 2,
     baseAttackInterval: 1,
     baseAttackDistance: 5,
-    moveSpeed: 30,
+    moveSpeed: 80,
     moveAcceleration: 30,
     mass: 1.2,
     physicalSize: 12,
@@ -78,12 +78,12 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
       particlesPerSecond: 120,
       particleLifetimeMs: 550,
       fadeStartMs: 300,
-      baseSpeed: 0.18,
-      speedVariation: 0.08,
+      baseSpeed: 0.09,
+      speedVariation: 0.03,
       sizeRange: { min: 1.2, max: 2.4 },
-      spread: Math.PI / 2.5,
+      spread: Math.PI / 5.5,
       offset: { x: -0.35, y: 0 },
-      color: { r: 0.2, g: 0.45, b: 0.95, a: 0.55 },
+      color: { r: 0.2, g: 0.85, b: 0.95, a: 0.35 },
       maxParticles: 80,
     },
   },

--- a/src/db/player-units-db.ts
+++ b/src/db/player-units-db.ts
@@ -24,6 +24,8 @@ export interface PlayerUnitConfig {
   readonly baseAttackInterval: number; // seconds
   readonly baseAttackDistance: number;
   readonly moveSpeed: number; // units per second
+  readonly moveAcceleration: number; // force units per second^2 before mass
+  readonly mass: number;
 }
 
 const BLUE_PENTAGON_VERTICES: readonly SceneVector2[] = [
@@ -53,6 +55,8 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
     baseAttackInterval: 1,
     baseAttackDistance: 5,
     moveSpeed: 15,
+    moveAcceleration: 30,
+    mass: 1.2,
   },
 };
 

--- a/src/db/player-units-db.ts
+++ b/src/db/player-units-db.ts
@@ -1,4 +1,4 @@
-import { SceneColor, SceneVector2 } from "../logic/services/SceneObjectManager";
+import { SceneColor, SceneFill, SceneVector2 } from "../logic/services/SceneObjectManager";
 
 export type PlayerUnitType = "bluePentagon";
 
@@ -15,6 +15,20 @@ export interface PlayerUnitRendererPolygonConfig {
 
 export type PlayerUnitRendererConfig = PlayerUnitRendererPolygonConfig;
 
+export interface PlayerUnitEmitterConfig {
+  particlesPerSecond: number;
+  particleLifetimeMs: number;
+  fadeStartMs: number;
+  baseSpeed: number;
+  speedVariation: number;
+  sizeRange: { min: number; max: number };
+  spread: number;
+  offset: SceneVector2;
+  color: SceneColor;
+  fill?: SceneFill;
+  maxParticles?: number;
+}
+
 export interface PlayerUnitConfig {
   readonly name: string;
   readonly renderer: PlayerUnitRendererConfig;
@@ -26,6 +40,8 @@ export interface PlayerUnitConfig {
   readonly moveSpeed: number; // units per second
   readonly moveAcceleration: number; // force units per second^2 before mass
   readonly mass: number;
+  readonly physicalSize: number;
+  readonly emitter?: PlayerUnitEmitterConfig;
 }
 
 const BLUE_PENTAGON_VERTICES: readonly SceneVector2[] = [
@@ -54,9 +70,22 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
     baseAttackDamage: 2,
     baseAttackInterval: 1,
     baseAttackDistance: 5,
-    moveSpeed: 15,
+    moveSpeed: 30,
     moveAcceleration: 30,
     mass: 1.2,
+    physicalSize: 12,
+    emitter: {
+      particlesPerSecond: 120,
+      particleLifetimeMs: 550,
+      fadeStartMs: 300,
+      baseSpeed: 0.18,
+      speedVariation: 0.08,
+      sizeRange: { min: 1.2, max: 2.4 },
+      spread: Math.PI / 2.5,
+      offset: { x: -0.35, y: 0 },
+      color: { r: 0.2, g: 0.45, b: 0.95, a: 0.55 },
+      maxParticles: 80,
+    },
   },
 };
 

--- a/src/db/player-units-db.ts
+++ b/src/db/player-units-db.ts
@@ -48,11 +48,11 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
       offset: { x: 0, y: 0 },
     },
     maxHp: 40,
-    armor: 3,
-    baseAttackDamage: 8,
+    armor: 1,
+    baseAttackDamage: 2,
     baseAttackInterval: 1,
     baseAttackDistance: 5,
-    moveSpeed: 75,
+    moveSpeed: 15,
   },
 };
 

--- a/src/db/player-units-db.ts
+++ b/src/db/player-units-db.ts
@@ -1,0 +1,70 @@
+import { SceneColor, SceneVector2 } from "../logic/services/SceneObjectManager";
+
+export type PlayerUnitType = "bluePentagon";
+
+export interface PlayerUnitRendererPolygonConfig {
+  kind: "polygon";
+  vertices: readonly SceneVector2[];
+  fill: SceneColor;
+  stroke?: {
+    color: SceneColor;
+    width: number;
+  };
+  offset?: SceneVector2;
+}
+
+export type PlayerUnitRendererConfig = PlayerUnitRendererPolygonConfig;
+
+export interface PlayerUnitConfig {
+  readonly name: string;
+  readonly renderer: PlayerUnitRendererConfig;
+  readonly maxHp: number;
+  readonly armor: number;
+  readonly baseAttackDamage: number;
+  readonly baseAttackInterval: number; // seconds
+  readonly baseAttackDistance: number;
+  readonly moveSpeed: number; // units per second
+}
+
+const BLUE_PENTAGON_VERTICES: readonly SceneVector2[] = [
+  { x: 0, y: -18 },
+  { x: 17, y: -6 },
+  { x: 11, y: 16 },
+  { x: -11, y: 16 },
+  { x: -17, y: -6 },
+];
+
+const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
+  bluePentagon: {
+    name: "Blue Vanguard",
+    renderer: {
+      kind: "polygon",
+      vertices: BLUE_PENTAGON_VERTICES,
+      fill: { r: 0.2, g: 0.45, b: 0.95, a: 1 },
+      stroke: {
+        color: { r: 0.05, g: 0.15, b: 0.4, a: 1 },
+        width: 2,
+      },
+      offset: { x: 0, y: 0 },
+    },
+    maxHp: 40,
+    armor: 3,
+    baseAttackDamage: 8,
+    baseAttackInterval: 1,
+    baseAttackDistance: 5,
+    moveSpeed: 75,
+  },
+};
+
+export const PLAYER_UNIT_TYPES = Object.keys(PLAYER_UNITS_DB) as PlayerUnitType[];
+
+export const getPlayerUnitConfig = (type: PlayerUnitType): PlayerUnitConfig => {
+  const config = PLAYER_UNITS_DB[type];
+  if (!config) {
+    throw new Error(`Unknown player unit type: ${type}`);
+  }
+  return config;
+};
+
+export const isPlayerUnitType = (value: unknown): value is PlayerUnitType =>
+  typeof value === "string" && Object.prototype.hasOwnProperty.call(PLAYER_UNITS_DB, value);

--- a/src/logic/core/Application.ts
+++ b/src/logic/core/Application.ts
@@ -39,6 +39,7 @@ export class Application {
     const playerUnitsModule = new PlayerUnitsModule({
       scene: sceneObjects,
       bricks: bricksModule,
+      bridge: this.dataBridge,
     });
     this.mapModule = new MapModule({
       scene: sceneObjects,

--- a/src/logic/core/Application.ts
+++ b/src/logic/core/Application.ts
@@ -11,6 +11,7 @@ import { BulletModule } from "../modules/BulletModule";
 import { ExplosionModule } from "../modules/ExplosionModule";
 import { MapId } from "../../db/maps-db";
 import { PlayerUnitsModule } from "../modules/PlayerUnitsModule";
+import { MovementService } from "../services/MovementService";
 
 export class Application {
   private serviceContainer = new ServiceContainer();
@@ -22,11 +23,13 @@ export class Application {
     const saveManager = new SaveManager();
     const gameLoop = new GameLoop();
     const sceneObjects = new SceneObjectManager();
+    const movementService = new MovementService();
 
     this.serviceContainer.register("bridge", this.dataBridge);
     this.serviceContainer.register("saveManager", saveManager);
     this.serviceContainer.register("gameLoop", gameLoop);
     this.serviceContainer.register("sceneObjects", sceneObjects);
+    this.serviceContainer.register("movement", movementService);
 
     const timeModule = new TestTimeModule({
       bridge: this.dataBridge,
@@ -40,6 +43,7 @@ export class Application {
       scene: sceneObjects,
       bricks: bricksModule,
       bridge: this.dataBridge,
+      movement: movementService,
     });
     this.mapModule = new MapModule({
       scene: sceneObjects,

--- a/src/logic/core/Application.ts
+++ b/src/logic/core/Application.ts
@@ -6,13 +6,16 @@ import { GameLoop } from "../services/GameLoop";
 import { TestTimeModule } from "../modules/TestTimeModule";
 import { SceneObjectManager } from "../services/SceneObjectManager";
 import { BricksModule } from "../modules/BricksModule";
+import { MapModule } from "../modules/MapModule";
 import { BulletModule } from "../modules/BulletModule";
 import { ExplosionModule } from "../modules/ExplosionModule";
+import { MapId } from "../../db/maps-db";
 
 export class Application {
   private serviceContainer = new ServiceContainer();
   private dataBridge = new DataBridge();
   private modules: GameModule[] = [];
+  private mapModule: MapModule;
 
   constructor() {
     const saveManager = new SaveManager();
@@ -32,6 +35,11 @@ export class Application {
       scene: sceneObjects,
       bridge: this.dataBridge,
     });
+    this.mapModule = new MapModule({
+      scene: sceneObjects,
+      bridge: this.dataBridge,
+      bricks: bricksModule,
+    });
 
     const explosionModule = new ExplosionModule({
       scene: sceneObjects,
@@ -44,6 +52,7 @@ export class Application {
 
     this.registerModule(timeModule);
     this.registerModule(bricksModule);
+    this.registerModule(this.mapModule);
     this.registerModule(explosionModule);
     this.registerModule(bulletModule);
   }
@@ -91,6 +100,10 @@ export class Application {
 
   public getSaveManager(): SaveManager {
     return this.serviceContainer.get<SaveManager>("saveManager");
+  }
+
+  public selectMap(mapId: MapId): void {
+    this.mapModule.selectMap(mapId);
   }
 
   private registerModule(module: GameModule): void {

--- a/src/logic/core/Application.ts
+++ b/src/logic/core/Application.ts
@@ -10,6 +10,7 @@ import { MapModule } from "../modules/MapModule";
 import { BulletModule } from "../modules/BulletModule";
 import { ExplosionModule } from "../modules/ExplosionModule";
 import { MapId } from "../../db/maps-db";
+import { PlayerUnitsModule } from "../modules/PlayerUnitsModule";
 
 export class Application {
   private serviceContainer = new ServiceContainer();
@@ -35,10 +36,15 @@ export class Application {
       scene: sceneObjects,
       bridge: this.dataBridge,
     });
+    const playerUnitsModule = new PlayerUnitsModule({
+      scene: sceneObjects,
+      bricks: bricksModule,
+    });
     this.mapModule = new MapModule({
       scene: sceneObjects,
       bridge: this.dataBridge,
       bricks: bricksModule,
+      playerUnits: playerUnitsModule,
     });
 
     const explosionModule = new ExplosionModule({
@@ -52,6 +58,7 @@ export class Application {
 
     this.registerModule(timeModule);
     this.registerModule(bricksModule);
+    this.registerModule(playerUnitsModule);
     this.registerModule(this.mapModule);
     this.registerModule(explosionModule);
     this.registerModule(bulletModule);

--- a/src/logic/interfaces/destructuble.ts
+++ b/src/logic/interfaces/destructuble.ts
@@ -2,4 +2,6 @@ export interface DestructubleData {
     hp?: number;
     maxHp: number;
     armor: number;
+    baseDamage?: number;
+    brickKnockBack?: number;
 }

--- a/src/logic/interfaces/destructuble.ts
+++ b/src/logic/interfaces/destructuble.ts
@@ -5,4 +5,5 @@ export interface DestructubleData {
     baseDamage?: number;
     brickKnockBackDistance?: number;
     brickKnockBackSpeed?: number;
+    physicalSize?: number;
 }

--- a/src/logic/interfaces/destructuble.ts
+++ b/src/logic/interfaces/destructuble.ts
@@ -3,5 +3,6 @@ export interface DestructubleData {
     maxHp: number;
     armor: number;
     baseDamage?: number;
-    brickKnockBack?: number;
+    brickKnockBackDistance?: number;
+    brickKnockBackSpeed?: number;
 }

--- a/src/logic/modules/BricksModule.ts
+++ b/src/logic/modules/BricksModule.ts
@@ -42,6 +42,7 @@ const createBrickFill = (config: BrickConfig) => {
 };
 
 export const BRICK_COUNT_BRIDGE_KEY = "bricks/count";
+export const BRICK_TOTAL_HP_BRIDGE_KEY = "bricks/totalHp";
 
 export interface BrickData {
   position: SceneVector2;
@@ -85,7 +86,7 @@ export class BricksModule implements GameModule {
   constructor(private readonly options: BricksModuleOptions) {}
 
   public initialize(): void {
-    this.pushCount();
+    this.pushStats();
   }
 
   public reset(): void {
@@ -98,7 +99,7 @@ export class BricksModule implements GameModule {
       this.applyBricks(parsed);
       return;
     }
-    this.pushCount();
+    this.pushStats();
   }
 
   public save(): unknown {
@@ -168,6 +169,7 @@ export class BricksModule implements GameModule {
       return { destroyed: true, brick: null };
     }
 
+    this.pushStats();
     return { destroyed: false, brick: this.cloneState(brick) };
   }
 
@@ -220,7 +222,7 @@ export class BricksModule implements GameModule {
       this.brickOrder.push(state);
     });
 
-    this.pushCount();
+    this.pushStats();
   }
 
   private createBrickState(brick: BrickData): InternalBrickState {
@@ -268,7 +270,7 @@ export class BricksModule implements GameModule {
     this.options.scene.removeObject(brick.sceneObjectId);
     this.bricks.delete(brick.id);
     this.brickOrder = this.brickOrder.filter((item) => item.id !== brick.id);
-    this.pushCount();
+    this.pushStats();
   }
 
   private clearSceneObjects(): void {
@@ -279,8 +281,13 @@ export class BricksModule implements GameModule {
     this.brickOrder = [];
   }
 
-  private pushCount(): void {
+  private pushStats(): void {
+    let totalHp = 0;
+    this.brickOrder.forEach((brick) => {
+      totalHp += brick.hp;
+    });
     this.options.bridge.setValue(BRICK_COUNT_BRIDGE_KEY, this.bricks.size);
+    this.options.bridge.setValue(BRICK_TOTAL_HP_BRIDGE_KEY, totalHp);
   }
 
   private clampToMap(position: SceneVector2): SceneVector2 {

--- a/src/logic/modules/BricksModule.ts
+++ b/src/logic/modules/BricksModule.ts
@@ -1,21 +1,13 @@
 import { DataBridge } from "../core/DataBridge";
 import { GameModule } from "../core/types";
-import {
-  BRICK_TYPES,
-  BrickConfig,
-  BrickType,
-  getBrickConfig,
-  isBrickType,
-} from "../../db/bricks-db";
+import { BrickConfig, BrickType, getBrickConfig, isBrickType } from "../../db/bricks-db";
 import {
   FILL_TYPES,
   SceneObjectManager,
   SceneVector2,
 } from "../services/SceneObjectManager";
 
-const MIN_BRICKS = 1000;
-const MAX_BRICKS = 2000;
-const DEFAULT_BRICK_TYPE: BrickType = "smallSquareGray";
+const DEFAULT_BRICK_TYPE: BrickType = "classic";
 
 const createBrickFill = (config: BrickConfig) => {
   const fill = config.fill;
@@ -51,7 +43,7 @@ const createBrickFill = (config: BrickConfig) => {
 
 export const BRICK_COUNT_BRIDGE_KEY = "bricks/count";
 
-interface BrickData {
+export interface BrickData {
   position: SceneVector2;
   rotation: number;
   type: BrickType;
@@ -79,7 +71,7 @@ export class BricksModule implements GameModule {
   }
 
   public reset(): void {
-    this.applyBricks(this.generateRandomBricks());
+    this.applyBricks([]);
   }
 
   public load(data: unknown | undefined): void {
@@ -103,6 +95,10 @@ export class BricksModule implements GameModule {
 
   public tick(_deltaMs: number): void {
     // Bricks are static for now.
+  }
+
+  public setBricks(bricks: BrickData[]): void {
+    this.applyBricks(bricks);
   }
 
   private parseSaveData(data: unknown): BrickSaveData | null {
@@ -137,21 +133,6 @@ export class BricksModule implements GameModule {
     });
 
     return { bricks: sanitized };
-  }
-
-  private generateRandomBricks(): BrickData[] {
-    const count = Math.floor(Math.random() * (MAX_BRICKS - MIN_BRICKS + 1)) + MIN_BRICKS;
-    const bricks: BrickData[] = [];
-
-    for (let i = 0; i < count; i += 1) {
-      bricks.push({
-        position: this.getRandomPosition(),
-        rotation: Math.random() * Math.PI * 2,
-        type: this.getRandomBrickType(),
-      });
-    }
-
-    return bricks;
   }
 
   private applyBricks(bricks: BrickData[]): void {
@@ -201,18 +182,6 @@ export class BricksModule implements GameModule {
     };
   }
 
-  private getRandomPosition(): SceneVector2 {
-    const { width, height } = this.options.scene.getMapSize();
-    return {
-      x: Math.random() * width,
-      y: Math.random() * height,
-    };
-  }
-
-  private getRandomBrickType(): BrickType {
-    const index = Math.floor(Math.random() * BRICK_TYPES.length);
-    return BRICK_TYPES[index] ?? DEFAULT_BRICK_TYPE;
-  }
 }
 
 const clamp = (value: number, min: number, max: number): number => {

--- a/src/logic/modules/BricksModule.ts
+++ b/src/logic/modules/BricksModule.ts
@@ -60,7 +60,8 @@ export interface BrickRuntimeState {
   maxHp: number;
   armor: number;
   baseDamage: number;
-  brickKnockBack: number;
+  brickKnockBackDistance: number;
+  brickKnockBackSpeed: number;
 }
 
 interface BricksModuleOptions {
@@ -231,7 +232,11 @@ export class BricksModule implements GameModule {
     const destructuble = config.destructubleData;
     const maxHp = Math.max(destructuble?.maxHp ?? 1, 1);
     const baseDamage = Math.max(destructuble?.baseDamage ?? 0, 0);
-    const brickKnockBack = Math.max(destructuble?.brickKnockBack ?? 0, 0);
+    const brickKnockBackDistance = Math.max(destructuble?.brickKnockBackDistance ?? 0, 0);
+    const brickKnockBackSpeed = sanitizeKnockBackSpeed(
+      destructuble?.brickKnockBackSpeed,
+      brickKnockBackDistance
+    );
     const armor = Math.max(destructuble?.armor ?? 0, 0);
     const hp = sanitizeHp(brick.hp ?? destructuble?.hp ?? maxHp, maxHp);
 
@@ -261,7 +266,8 @@ export class BricksModule implements GameModule {
       maxHp,
       armor,
       baseDamage,
-      brickKnockBack,
+      brickKnockBackDistance,
+      brickKnockBackSpeed,
       sceneObjectId,
     };
   }
@@ -313,11 +319,25 @@ export class BricksModule implements GameModule {
       maxHp: state.maxHp,
       armor: state.armor,
       baseDamage: state.baseDamage,
-      brickKnockBack: state.brickKnockBack,
+      brickKnockBackDistance: state.brickKnockBackDistance,
+      brickKnockBackSpeed: state.brickKnockBackSpeed,
     };
   }
 
 }
+
+const sanitizeKnockBackSpeed = (
+  value: number | undefined,
+  distance: number
+): number => {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  if (distance > 0) {
+    return distance * 2;
+  }
+  return 0;
+};
 
 const clamp = (value: number, min: number, max: number): number => {
   if (Number.isNaN(value) || !Number.isFinite(value)) {

--- a/src/logic/modules/BricksModule.ts
+++ b/src/logic/modules/BricksModule.ts
@@ -62,6 +62,7 @@ export interface BrickRuntimeState {
   baseDamage: number;
   brickKnockBackDistance: number;
   brickKnockBackSpeed: number;
+  physicalSize: number;
 }
 
 interface BricksModuleOptions {
@@ -238,6 +239,10 @@ export class BricksModule implements GameModule {
       brickKnockBackDistance
     );
     const armor = Math.max(destructuble?.armor ?? 0, 0);
+    const physicalSize = Math.max(
+      destructuble?.physicalSize ?? Math.max(config.size.width, config.size.height) / 2,
+      0
+    );
     const hp = sanitizeHp(brick.hp ?? destructuble?.hp ?? maxHp, maxHp);
 
     const position = this.clampToMap(brick.position);
@@ -268,6 +273,7 @@ export class BricksModule implements GameModule {
       baseDamage,
       brickKnockBackDistance,
       brickKnockBackSpeed,
+      physicalSize,
       sceneObjectId,
     };
   }
@@ -321,6 +327,7 @@ export class BricksModule implements GameModule {
       baseDamage: state.baseDamage,
       brickKnockBackDistance: state.brickKnockBackDistance,
       brickKnockBackSpeed: state.brickKnockBackSpeed,
+      physicalSize: state.physicalSize,
     };
   }
 

--- a/src/logic/modules/BulletModule.ts
+++ b/src/logic/modules/BulletModule.ts
@@ -145,7 +145,7 @@ export class BulletModule implements GameModule {
     if (deltaMs <= 0) {
       return;
     }
-    for (let i = 0; i < 2; i += 1) {
+    for (let i = 0; i < 0; i += 1) {
       this.spawnBulletByType(this.getRandomBulletType());
     }
     this.updateBullets(deltaMs);

--- a/src/logic/modules/MapModule.ts
+++ b/src/logic/modules/MapModule.ts
@@ -1,0 +1,132 @@
+import { DataBridge } from "../core/DataBridge";
+import { GameModule } from "../core/types";
+import { SceneObjectManager, SceneSize } from "../services/SceneObjectManager";
+import { BricksModule, BrickData } from "./BricksModule";
+import {
+  MapConfig,
+  MapId,
+  MapListEntry,
+  getMapConfig,
+  getMapList,
+  isMapId,
+} from "../../db/maps-db";
+
+export const MAP_LIST_BRIDGE_KEY = "maps/list";
+export const MAP_SELECTED_BRIDGE_KEY = "maps/selected";
+
+interface MapModuleOptions {
+  scene: SceneObjectManager;
+  bridge: DataBridge;
+  bricks: BricksModule;
+}
+
+interface MapSaveData {
+  mapId: MapId;
+}
+
+const DEFAULT_MAP_ID: MapId = "initial";
+
+export class MapModule implements GameModule {
+  public readonly id = "maps";
+
+  private selectedMapId: MapId | null = null;
+
+  constructor(private readonly options: MapModuleOptions) {}
+
+  public initialize(): void {
+    this.pushMapList();
+    this.ensureSelection(false);
+  }
+
+  public reset(): void {
+    this.ensureSelection(true);
+  }
+
+  public load(data: unknown | undefined): void {
+    const parsed = this.parseSaveData(data);
+    if (parsed) {
+      this.selectedMapId = parsed.mapId;
+      this.applyMap(parsed.mapId, { generateBricks: false });
+      return;
+    }
+    this.pushSelectedMap();
+  }
+
+  public save(): unknown {
+    return {
+      mapId: this.selectedMapId ?? DEFAULT_MAP_ID,
+    } satisfies MapSaveData;
+  }
+
+  public tick(_deltaMs: number): void {
+    // Map logic is static for now.
+  }
+
+  public selectMap(mapId: MapId): void {
+    if (!isMapId(mapId)) {
+      return;
+    }
+    this.selectedMapId = mapId;
+    this.applyMap(mapId, { generateBricks: true });
+  }
+
+  private ensureSelection(generateBricks: boolean): void {
+    const mapId = this.selectedMapId ?? DEFAULT_MAP_ID;
+    this.selectedMapId = mapId;
+    this.applyMap(mapId, { generateBricks });
+  }
+
+  private applyMap(mapId: MapId, options: { generateBricks: boolean }): void {
+    const config = getMapConfig(mapId);
+    this.options.scene.setMapSize(config.size);
+    if (options.generateBricks) {
+      const bricks = this.generateBricks(config);
+      this.options.bricks.setBricks(bricks);
+    }
+    this.pushSelectedMap();
+  }
+
+  private generateBricks(config: MapConfig): BrickData[] {
+    const bricks: BrickData[] = [];
+    config.bricks.forEach((group) => {
+      for (let index = 0; index < group.count; index += 1) {
+        bricks.push({
+          position: this.getRandomPosition(config.size),
+          rotation: Math.random() * Math.PI * 2,
+          type: group.type,
+        });
+      }
+    });
+    return bricks;
+  }
+
+  private getRandomPosition(size: SceneSize): BrickData["position"] {
+    return {
+      x: Math.random() * size.width,
+      y: Math.random() * size.height,
+    };
+  }
+
+  private pushMapList(): void {
+    const list = getMapList();
+    this.options.bridge.setValue<MapListEntry[]>(MAP_LIST_BRIDGE_KEY, list);
+  }
+
+  private pushSelectedMap(): void {
+    this.options.bridge.setValue<MapId | null>(MAP_SELECTED_BRIDGE_KEY, this.selectedMapId);
+  }
+
+  private parseSaveData(data: unknown): MapSaveData | null {
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      "mapId" in data &&
+      isMapId((data as { mapId: unknown }).mapId)
+    ) {
+      return { mapId: (data as { mapId: MapId }).mapId };
+    }
+    return null;
+  }
+}
+
+export type { MapListEntry };

--- a/src/logic/modules/PlayerUnitsModule.ts
+++ b/src/logic/modules/PlayerUnitsModule.ts
@@ -8,6 +8,8 @@ import {
   isPlayerUnitType,
 } from "../../db/player-units-db";
 
+const ATTACK_DISTANCE_EPSILON = 0.001;
+
 export interface PlayerUnitSpawnData {
   readonly type: PlayerUnitType;
   readonly position: SceneVector2;
@@ -213,7 +215,10 @@ export class PlayerUnitsModule implements GameModule {
     };
     const distance = Math.hypot(direction.x, direction.y);
 
-    if (distance > unit.baseAttackDistance) {
+    const attackRange = unit.baseAttackDistance;
+    const withinAttackRange = distance <= attackRange + ATTACK_DISTANCE_EPSILON;
+
+    if (!withinAttackRange) {
       this.moveTowards(unit, direction, distance, deltaSeconds);
       this.scene.updateObject(unit.objectId, {
         position: { ...unit.position },

--- a/src/logic/modules/PlayerUnitsModule.ts
+++ b/src/logic/modules/PlayerUnitsModule.ts
@@ -1,0 +1,397 @@
+import { GameModule } from "../core/types";
+import { SceneObjectManager, SceneVector2, FILL_TYPES } from "../services/SceneObjectManager";
+import { BricksModule, BrickRuntimeState } from "./BricksModule";
+import {
+  PlayerUnitType,
+  getPlayerUnitConfig,
+  PlayerUnitRendererConfig,
+  isPlayerUnitType,
+} from "../../db/player-units-db";
+
+export interface PlayerUnitSpawnData {
+  readonly type: PlayerUnitType;
+  readonly position: SceneVector2;
+  readonly hp?: number;
+  readonly attackCooldown?: number;
+}
+
+interface PlayerUnitsModuleOptions {
+  scene: SceneObjectManager;
+  bricks: BricksModule;
+}
+
+interface PlayerUnitSaveData {
+  readonly units: PlayerUnitSpawnData[];
+}
+
+interface PlayerUnitState {
+  id: string;
+  type: PlayerUnitType;
+  position: SceneVector2;
+  hp: number;
+  maxHp: number;
+  armor: number;
+  baseAttackDamage: number;
+  baseAttackInterval: number;
+  baseAttackDistance: number;
+  moveSpeed: number;
+  attackCooldown: number;
+  targetBrickId: string | null;
+  objectId: string;
+  renderer: PlayerUnitRendererConfig;
+}
+
+export class PlayerUnitsModule implements GameModule {
+  public readonly id = "playerUnits";
+
+  private readonly scene: SceneObjectManager;
+  private readonly bricks: BricksModule;
+
+  private units = new Map<string, PlayerUnitState>();
+  private unitOrder: PlayerUnitState[] = [];
+  private idCounter = 0;
+
+  constructor(options: PlayerUnitsModuleOptions) {
+    this.scene = options.scene;
+    this.bricks = options.bricks;
+  }
+
+  public initialize(): void {
+    // Units are spawned by the map module.
+  }
+
+  public reset(): void {
+    this.applyUnits([]);
+  }
+
+  public load(data: unknown | undefined): void {
+    const parsed = this.parseSaveData(data);
+    if (parsed) {
+      this.applyUnits(parsed.units);
+    }
+  }
+
+  public save(): unknown {
+    return {
+      units: this.unitOrder.map((unit) => ({
+        type: unit.type,
+        position: { ...unit.position },
+        hp: unit.hp,
+        attackCooldown: unit.attackCooldown,
+      })),
+    } satisfies PlayerUnitSaveData;
+  }
+
+  public tick(deltaMs: number): void {
+    if (this.unitOrder.length === 0) {
+      return;
+    }
+    const deltaSeconds = Math.max(deltaMs, 0) / 1000;
+    const unitsSnapshot = [...this.unitOrder];
+    unitsSnapshot.forEach((unit) => {
+      if (!this.units.has(unit.id)) {
+        return;
+      }
+      this.updateUnit(unit, deltaSeconds);
+    });
+  }
+
+  public setUnits(units: PlayerUnitSpawnData[]): void {
+    this.applyUnits(units);
+  }
+
+  private parseSaveData(data: unknown): PlayerUnitSaveData | null {
+    if (
+      typeof data !== "object" ||
+      data === null ||
+      !("units" in data) ||
+      !Array.isArray((data as { units: unknown }).units)
+    ) {
+      return null;
+    }
+
+    const sanitized: PlayerUnitSpawnData[] = [];
+    (data as PlayerUnitSaveData).units.forEach((unit) => {
+      if (
+        unit &&
+        typeof unit === "object" &&
+        "position" in unit &&
+        typeof unit.position === "object" &&
+        unit.position !== null &&
+        typeof unit.position.x === "number" &&
+        typeof unit.position.y === "number"
+      ) {
+        const type = sanitizeUnitType((unit as PlayerUnitSpawnData).type);
+        sanitized.push({
+          type,
+          position: this.clampToMap(unit.position as SceneVector2),
+          hp: sanitizeNumber((unit as PlayerUnitSpawnData).hp),
+          attackCooldown: sanitizeNumber((unit as PlayerUnitSpawnData).attackCooldown),
+        });
+      }
+    });
+
+    return { units: sanitized };
+  }
+
+  private applyUnits(units: PlayerUnitSpawnData[]): void {
+    this.clearUnits();
+    this.idCounter = 0;
+
+    units.forEach((unit) => {
+      const state = this.createUnitState(unit);
+      this.units.set(state.id, state);
+      this.unitOrder.push(state);
+    });
+  }
+
+  private createUnitState(unit: PlayerUnitSpawnData): PlayerUnitState {
+    const type = sanitizeUnitType(unit.type);
+    const config = getPlayerUnitConfig(type);
+
+    const position = this.clampToMap(unit.position);
+    const maxHp = Math.max(config.maxHp, 1);
+    const hp = clampNumber(unit.hp ?? maxHp, 0, maxHp);
+    const attackCooldown = clampNumber(unit.attackCooldown ?? 0, 0, config.baseAttackInterval);
+
+    const objectId = this.scene.addObject("playerUnit", {
+      position,
+      fill: {
+        fillType: FILL_TYPES.SOLID,
+        color: { ...config.renderer.fill },
+      },
+      stroke: config.renderer.stroke
+        ? {
+            color: { ...config.renderer.stroke.color },
+            width: config.renderer.stroke.width,
+          }
+        : undefined,
+      rotation: 0,
+      customData: {
+        renderer: {
+          kind: config.renderer.kind,
+          vertices: config.renderer.vertices.map((vertex) => ({ ...vertex })),
+          offset: config.renderer.offset ? { ...config.renderer.offset } : undefined,
+        },
+      },
+    });
+
+    const id = this.createUnitId();
+
+    return {
+      id,
+      type,
+      position: { ...position },
+      hp,
+      maxHp,
+      armor: Math.max(config.armor, 0),
+      baseAttackDamage: Math.max(config.baseAttackDamage, 0),
+      baseAttackInterval: Math.max(config.baseAttackInterval, 0.01),
+      baseAttackDistance: Math.max(config.baseAttackDistance, 0),
+      moveSpeed: Math.max(config.moveSpeed, 0),
+      attackCooldown,
+      targetBrickId: null,
+      objectId,
+      renderer: config.renderer,
+    };
+  }
+
+  private updateUnit(unit: PlayerUnitState, deltaSeconds: number): void {
+    unit.attackCooldown = Math.max(unit.attackCooldown - deltaSeconds, 0);
+
+    const target = this.resolveTarget(unit);
+    if (!target) {
+      this.scene.updateObject(unit.objectId, {
+        position: { ...unit.position },
+      });
+      return;
+    }
+
+    const direction = {
+      x: target.position.x - unit.position.x,
+      y: target.position.y - unit.position.y,
+    };
+    const distance = Math.hypot(direction.x, direction.y);
+
+    if (distance > unit.baseAttackDistance) {
+      this.moveTowards(unit, direction, distance, deltaSeconds);
+      this.scene.updateObject(unit.objectId, {
+        position: { ...unit.position },
+        rotation: Math.atan2(direction.y, direction.x),
+      });
+      return;
+    }
+
+    if (unit.attackCooldown > 0) {
+      this.scene.updateObject(unit.objectId, {
+        position: { ...unit.position },
+        rotation: Math.atan2(direction.y, direction.x),
+      });
+      return;
+    }
+
+    this.performAttack(unit, target, direction, distance);
+  }
+
+  private resolveTarget(unit: PlayerUnitState): BrickRuntimeState | null {
+    if (unit.targetBrickId) {
+      const current = this.bricks.getBrickState(unit.targetBrickId);
+      if (current) {
+        return current;
+      }
+      unit.targetBrickId = null;
+    }
+
+    const nearest = this.bricks.findNearestBrick(unit.position);
+    unit.targetBrickId = nearest?.id ?? null;
+    return nearest ?? null;
+  }
+
+  private moveTowards(
+    unit: PlayerUnitState,
+    direction: SceneVector2,
+    distance: number,
+    deltaSeconds: number
+  ): void {
+    const availableDistance = unit.moveSpeed * deltaSeconds;
+    if (availableDistance <= 0 || distance <= 0) {
+      return;
+    }
+
+    const distanceToCover = Math.max(distance - unit.baseAttackDistance, 0);
+    const step = Math.min(distanceToCover, availableDistance);
+    if (step <= 0) {
+      return;
+    }
+
+    const factor = step / distance;
+    unit.position = this.clampToMap({
+      x: unit.position.x + direction.x * factor,
+      y: unit.position.y + direction.y * factor,
+    });
+  }
+
+  private performAttack(
+    unit: PlayerUnitState,
+    target: BrickRuntimeState,
+    direction: SceneVector2,
+    distance: number
+  ): void {
+    unit.attackCooldown = unit.baseAttackInterval;
+    const result = this.bricks.applyDamage(target.id, unit.baseAttackDamage);
+
+    if (result.destroyed) {
+      unit.targetBrickId = null;
+      this.scene.updateObject(unit.objectId, {
+        position: { ...unit.position },
+        rotation: Math.atan2(direction.y, direction.x),
+      });
+      return;
+    }
+
+    const surviving = result.brick ?? target;
+    const counterDamage = Math.max(surviving.baseDamage - unit.armor, 0);
+    if (counterDamage > 0) {
+      unit.hp = clampNumber(unit.hp - counterDamage, 0, unit.maxHp);
+    }
+
+    if (surviving.brickKnockBack > 0) {
+      this.applyKnockBack(unit, direction, distance, surviving.brickKnockBack);
+    }
+
+    if (unit.hp <= 0) {
+      this.removeUnit(unit);
+      return;
+    }
+
+    this.scene.updateObject(unit.objectId, {
+      position: { ...unit.position },
+      rotation: Math.atan2(direction.y, direction.x),
+    });
+  }
+
+  private applyKnockBack(
+    unit: PlayerUnitState,
+    direction: SceneVector2,
+    distance: number,
+    knockBack: number
+  ): void {
+    if (knockBack <= 0) {
+      return;
+    }
+
+    let scale = 1;
+    if (distance > 0) {
+      scale = knockBack / distance;
+    }
+
+    if (!Number.isFinite(scale) || scale <= 0) {
+      scale = 1;
+    }
+
+    const offset = {
+      x: -direction.x * scale,
+      y: -direction.y * scale,
+    };
+
+    if (offset.x === 0 && offset.y === 0) {
+      offset.y = -knockBack;
+    }
+
+    unit.position = this.clampToMap({
+      x: unit.position.x + offset.x,
+      y: unit.position.y + offset.y,
+    });
+  }
+
+  private removeUnit(unit: PlayerUnitState): void {
+    this.scene.removeObject(unit.objectId);
+    this.units.delete(unit.id);
+    this.unitOrder = this.unitOrder.filter((current) => current.id !== unit.id);
+  }
+
+  private clearUnits(): void {
+    this.unitOrder.forEach((unit) => {
+      this.scene.removeObject(unit.objectId);
+    });
+    this.unitOrder = [];
+    this.units.clear();
+  }
+
+  private clampToMap(position: SceneVector2): SceneVector2 {
+    const mapSize = this.scene.getMapSize();
+    return {
+      x: clampNumber(position.x, 0, mapSize.width),
+      y: clampNumber(position.y, 0, mapSize.height),
+    };
+  }
+
+  private createUnitId(): string {
+    this.idCounter += 1;
+    return `player-unit-${this.idCounter}`;
+  }
+}
+
+const clampNumber = (value: number | undefined, min: number, max: number): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return min;
+  }
+  if (min > max) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+};
+
+const sanitizeNumber = (value: number | undefined): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return undefined;
+};
+
+const sanitizeUnitType = (value: PlayerUnitType | undefined): PlayerUnitType => {
+  if (isPlayerUnitType(value)) {
+    return value;
+  }
+  return "bluePentagon";
+};

--- a/src/logic/services/MovementService.ts
+++ b/src/logic/services/MovementService.ts
@@ -1,0 +1,189 @@
+import { SceneVector2 } from "./SceneObjectManager";
+
+export interface MovementBodyOptions {
+  readonly position: SceneVector2;
+  readonly mass: number;
+  readonly maxSpeed: number;
+}
+
+export interface MovementBodyState {
+  readonly id: string;
+  readonly position: SceneVector2;
+  readonly velocity: SceneVector2;
+}
+
+interface InternalMovementBodyState {
+  id: string;
+  position: SceneVector2;
+  velocity: SceneVector2;
+  mass: number;
+  maxSpeed: number;
+  force: SceneVector2;
+  dampings: MovementDamping[];
+}
+
+interface MovementDamping {
+  initialVelocity: SceneVector2;
+  elapsed: number;
+  duration: number;
+}
+
+const ZERO_VECTOR: SceneVector2 = { x: 0, y: 0 };
+
+const clampPositive = (value: number, fallback: number): number => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+};
+
+const cloneVector = (vector: SceneVector2): SceneVector2 => ({ x: vector.x, y: vector.y });
+
+const scaleVector = (vector: SceneVector2, scalar: number): SceneVector2 => ({
+  x: vector.x * scalar,
+  y: vector.y * scalar,
+});
+
+const addVectors = (a: SceneVector2, b: SceneVector2): SceneVector2 => ({
+  x: a.x + b.x,
+  y: a.y + b.y,
+});
+
+const subtractVectors = (a: SceneVector2, b: SceneVector2): SceneVector2 => ({
+  x: a.x - b.x,
+  y: a.y - b.y,
+});
+
+export class MovementService {
+  private bodies = new Map<string, InternalMovementBodyState>();
+  private bodyOrder: InternalMovementBodyState[] = [];
+  private idCounter = 0;
+
+  public createBody(options: MovementBodyOptions): string {
+    const id = this.createBodyId();
+    const position = cloneVector(options.position);
+    const mass = clampPositive(options.mass, 1);
+    const maxSpeed = Math.max(options.maxSpeed, 0);
+
+    const body: InternalMovementBodyState = {
+      id,
+      position,
+      velocity: { ...ZERO_VECTOR },
+      mass,
+      maxSpeed,
+      force: { ...ZERO_VECTOR },
+      dampings: [],
+    };
+
+    this.bodies.set(id, body);
+    this.bodyOrder.push(body);
+
+    return id;
+  }
+
+  public removeBody(bodyId: string): void {
+    const body = this.bodies.get(bodyId);
+    if (!body) {
+      return;
+    }
+    this.bodies.delete(bodyId);
+    this.bodyOrder = this.bodyOrder.filter((current) => current.id !== bodyId);
+  }
+
+  public getBodyState(bodyId: string): MovementBodyState | null {
+    const body = this.bodies.get(bodyId);
+    if (!body) {
+      return null;
+    }
+    return {
+      id: body.id,
+      position: cloneVector(body.position),
+      velocity: cloneVector(body.velocity),
+    };
+  }
+
+  public setBodyPosition(bodyId: string, position: SceneVector2): void {
+    const body = this.bodies.get(bodyId);
+    if (!body) {
+      return;
+    }
+    body.position = cloneVector(position);
+  }
+
+  public setForce(bodyId: string, force: SceneVector2): void {
+    const body = this.bodies.get(bodyId);
+    if (!body) {
+      return;
+    }
+    body.force = cloneVector(force);
+  }
+
+  public applyImpulse(bodyId: string, velocity: SceneVector2, duration = 1): void {
+    const body = this.bodies.get(bodyId);
+    if (!body) {
+      return;
+    }
+
+    const safeDuration = clampPositive(duration, 0.001);
+    const impulseVelocity = cloneVector(velocity);
+
+    body.velocity = addVectors(body.velocity, impulseVelocity);
+    body.dampings.push({
+      initialVelocity: impulseVelocity,
+      elapsed: 0,
+      duration: safeDuration,
+    });
+  }
+
+  public update(deltaSeconds: number): void {
+    if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
+      this.resetForces();
+      return;
+    }
+
+    this.bodyOrder.forEach((body) => {
+      const acceleration = scaleVector(body.force, 1 / body.mass);
+      body.velocity = addVectors(body.velocity, scaleVector(acceleration, deltaSeconds));
+
+      body.dampings = body.dampings.filter((damping) => {
+        if (damping.duration <= 0) {
+          return false;
+        }
+        const remaining = Math.max(damping.duration - damping.elapsed, 0);
+        const step = Math.min(deltaSeconds, remaining);
+        if (step <= 0) {
+          damping.elapsed = damping.duration;
+          return false;
+        }
+        const previousRatio = damping.elapsed / damping.duration;
+        damping.elapsed += step;
+        const nextRatio = Math.min(damping.elapsed / damping.duration, 1);
+        const fraction = nextRatio - previousRatio;
+        const reduction = scaleVector(damping.initialVelocity, fraction);
+        body.velocity = subtractVectors(body.velocity, reduction);
+        return damping.elapsed < damping.duration - 1e-6;
+      });
+
+      const speed = Math.hypot(body.velocity.x, body.velocity.y);
+      if (body.maxSpeed > 0 && speed > body.maxSpeed) {
+        const factor = body.maxSpeed / speed;
+        body.velocity = scaleVector(body.velocity, factor);
+      }
+
+      body.position = addVectors(body.position, scaleVector(body.velocity, deltaSeconds));
+    });
+
+    this.resetForces();
+  }
+
+  private resetForces(): void {
+    this.bodyOrder.forEach((body) => {
+      body.force = { ...ZERO_VECTOR };
+    });
+  }
+
+  private createBodyId(): string {
+    this.idCounter += 1;
+    return `movement-body-${this.idCounter}`;
+  }
+}

--- a/src/ui/renderers/objects/PlayerUnitObjectRenderer.ts
+++ b/src/ui/renderers/objects/PlayerUnitObjectRenderer.ts
@@ -1,0 +1,110 @@
+import { ObjectRegistration, ObjectRenderer } from "./ObjectRenderer";
+import {
+  SceneObjectInstance,
+  SceneVector2,
+  SceneStroke,
+} from "../../../logic/services/SceneObjectManager";
+import {
+  createStaticPolygonPrimitive,
+  createStaticPolygonStrokePrimitive,
+} from "../primitives";
+
+interface PlayerUnitRendererPayload {
+  kind?: string;
+  vertices?: SceneVector2[];
+  offset?: SceneVector2;
+}
+
+interface PlayerUnitCustomData {
+  renderer?: PlayerUnitRendererPayload;
+}
+
+const DEFAULT_VERTICES: SceneVector2[] = [
+  { x: 0, y: -18 },
+  { x: 17, y: -6 },
+  { x: 11, y: 16 },
+  { x: -11, y: 16 },
+  { x: -17, y: -6 },
+];
+
+const isVector = (value: unknown): value is SceneVector2 =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as SceneVector2).x === "number" &&
+  typeof (value as SceneVector2).y === "number";
+
+const sanitizeVertices = (vertices: SceneVector2[] | undefined): SceneVector2[] => {
+  if (!Array.isArray(vertices)) {
+    return DEFAULT_VERTICES.map((vertex) => ({ ...vertex }));
+  }
+  const sanitized = vertices
+    .filter((vertex) => isVector(vertex))
+    .map((vertex) => ({ x: vertex.x, y: vertex.y }));
+  if (sanitized.length < 3) {
+    return DEFAULT_VERTICES.map((vertex) => ({ ...vertex }));
+  }
+  return sanitized;
+};
+
+const sanitizeOffset = (offset: SceneVector2 | undefined): SceneVector2 | undefined => {
+  if (!offset || !isVector(offset)) {
+    return undefined;
+  }
+  return { x: offset.x, y: offset.y };
+};
+
+const extractRendererData = (
+  instance: SceneObjectInstance
+): { vertices: SceneVector2[]; offset?: SceneVector2 } => {
+  const payload = instance.data.customData as PlayerUnitCustomData | undefined;
+  if (!payload || typeof payload !== "object") {
+    return { vertices: DEFAULT_VERTICES.map((vertex) => ({ ...vertex })) };
+  }
+  const renderer = payload.renderer;
+  if (!renderer || renderer.kind !== "polygon") {
+    return { vertices: DEFAULT_VERTICES.map((vertex) => ({ ...vertex })) };
+  }
+  return {
+    vertices: sanitizeVertices(renderer.vertices),
+    offset: sanitizeOffset(renderer.offset),
+  };
+};
+
+const hasStroke = (stroke: SceneStroke | undefined): stroke is SceneStroke =>
+  !!stroke && typeof stroke.width === "number" && stroke.width > 0;
+
+export class PlayerUnitObjectRenderer extends ObjectRenderer {
+  public register(instance: SceneObjectInstance): ObjectRegistration {
+    const { vertices, offset } = extractRendererData(instance);
+    const rotation = instance.data.rotation ?? 0;
+
+    const primitives = [];
+    if (hasStroke(instance.data.stroke)) {
+      const strokePrimitive = createStaticPolygonStrokePrimitive({
+        center: instance.data.position,
+        vertices,
+        stroke: instance.data.stroke,
+        rotation,
+        offset,
+      });
+      if (strokePrimitive) {
+        primitives.push(strokePrimitive);
+      }
+    }
+
+    primitives.push(
+      createStaticPolygonPrimitive({
+        center: instance.data.position,
+        vertices,
+        fill: instance.data.fill,
+        rotation,
+        offset,
+      })
+    );
+
+    return {
+      staticPrimitives: primitives,
+      dynamicPrimitives: [],
+    };
+  }
+}

--- a/src/ui/renderers/objects/PlayerUnitObjectRenderer.ts
+++ b/src/ui/renderers/objects/PlayerUnitObjectRenderer.ts
@@ -1,13 +1,11 @@
-import { ObjectRegistration, ObjectRenderer } from "./ObjectRenderer";
+import { DynamicPrimitive, ObjectRegistration, ObjectRenderer } from "./ObjectRenderer";
 import {
+  FILL_TYPES,
   SceneObjectInstance,
   SceneVector2,
   SceneStroke,
 } from "../../../logic/services/SceneObjectManager";
-import {
-  createStaticPolygonPrimitive,
-  createStaticPolygonStrokePrimitive,
-} from "../primitives";
+import { createDynamicPolygonPrimitive } from "../primitives";
 
 interface PlayerUnitRendererPayload {
   kind?: string;
@@ -76,35 +74,95 @@ const hasStroke = (stroke: SceneStroke | undefined): stroke is SceneStroke =>
 export class PlayerUnitObjectRenderer extends ObjectRenderer {
   public register(instance: SceneObjectInstance): ObjectRegistration {
     const { vertices, offset } = extractRendererData(instance);
-    const rotation = instance.data.rotation ?? 0;
 
-    const primitives = [];
+    const dynamicPrimitives: DynamicPrimitive[] = [];
+
     if (hasStroke(instance.data.stroke)) {
-      const strokePrimitive = createStaticPolygonStrokePrimitive({
-        center: instance.data.position,
-        vertices,
-        stroke: instance.data.stroke,
-        rotation,
+      const strokeVertices = expandVerticesForStroke(vertices, instance.data.stroke.width);
+      const strokePrimitive = createDynamicPolygonPrimitive(instance, {
+        vertices: strokeVertices,
+        fill: createStrokeFill(instance.data.stroke),
         offset,
       });
-      if (strokePrimitive) {
-        primitives.push(strokePrimitive);
-      }
+      dynamicPrimitives.push(strokePrimitive);
     }
 
-    primitives.push(
-      createStaticPolygonPrimitive({
-        center: instance.data.position,
+    dynamicPrimitives.push(
+      createDynamicPolygonPrimitive(instance, {
         vertices,
-        fill: instance.data.fill,
-        rotation,
         offset,
       })
     );
 
     return {
-      staticPrimitives: primitives,
-      dynamicPrimitives: [],
+      staticPrimitives: [],
+      dynamicPrimitives,
     };
   }
 }
+
+const createStrokeFill = (stroke: SceneStroke) => ({
+  fillType: FILL_TYPES.SOLID,
+  color: {
+    r: stroke.color.r,
+    g: stroke.color.g,
+    b: stroke.color.b,
+    a: typeof stroke.color.a === "number" ? stroke.color.a : 1,
+  },
+});
+
+const expandVerticesForStroke = (vertices: SceneVector2[], strokeWidth: number) => {
+  if (strokeWidth <= 0) {
+    return vertices.map((vertex) => ({ ...vertex }));
+  }
+
+  const center = computeCenter(vertices);
+  return vertices.map((vertex) => {
+    const direction = {
+      x: vertex.x - center.x,
+      y: vertex.y - center.y,
+    };
+    const length = Math.hypot(direction.x, direction.y);
+    if (length === 0) {
+      return {
+        x: vertex.x + strokeWidth,
+        y: vertex.y,
+      };
+    }
+    const scale = (length + strokeWidth) / Math.max(length, 1e-6);
+    return {
+      x: center.x + direction.x * scale,
+      y: center.y + direction.y * scale,
+    };
+  });
+};
+
+const computeCenter = (vertices: SceneVector2[]): SceneVector2 => {
+  if (vertices.length === 0) {
+    return { x: 0, y: 0 };
+  }
+
+  let minX = vertices[0]!.x;
+  let maxX = vertices[0]!.x;
+  let minY = vertices[0]!.y;
+  let maxY = vertices[0]!.y;
+
+  for (let i = 1; i < vertices.length; i += 1) {
+    const vertex = vertices[i]!;
+    if (vertex.x < minX) {
+      minX = vertex.x;
+    } else if (vertex.x > maxX) {
+      maxX = vertex.x;
+    }
+    if (vertex.y < minY) {
+      minY = vertex.y;
+    } else if (vertex.y > maxY) {
+      maxY = vertex.y;
+    }
+  }
+
+  return {
+    x: (minX + maxX) / 2,
+    y: (minY + maxY) / 2,
+  };
+};

--- a/src/ui/renderers/objects/index.ts
+++ b/src/ui/renderers/objects/index.ts
@@ -4,6 +4,7 @@ import { ObjectsRendererManager } from "./ObjectsRendererManager";
 import { ObjectRenderer } from "./ObjectRenderer";
 import { ExplosionObjectRenderer } from "./ExplosionObjectRenderer";
 import { PolygonObjectRenderer } from "./PolygonObjectRenderer";
+import { PlayerUnitObjectRenderer } from "./PlayerUnitObjectRenderer";
 
 export { ObjectsRendererManager } from "./ObjectsRendererManager";
 export type { SyncInstructions, DynamicBufferUpdate } from "./ObjectsRendererManager";
@@ -25,6 +26,7 @@ export const createObjectsRendererManager = (): ObjectsRendererManager => {
     ["bullet", new BulletObjectRenderer()],
     ["explosion", new ExplosionObjectRenderer()],
     ["polygon", new PolygonObjectRenderer()],
+    ["playerUnit", new PlayerUnitObjectRenderer()],
   ]);
   return new ObjectsRendererManager(renderers);
 };

--- a/src/ui/screens/MapSelect/MapSelectScreen.css
+++ b/src/ui/screens/MapSelect/MapSelectScreen.css
@@ -11,6 +11,56 @@
   font-size: 1.2rem;
 }
 
+.map-select-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 960px;
+}
+
+.map-select-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.2);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.map-select-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.map-select-card.is-selected {
+  border-color: #61dafb;
+  transform: translateY(-4px);
+}
+
+.map-select-details {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.map-select-details div {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.map-select-details dt {
+  font-weight: 600;
+}
+
+.map-select-details dd {
+  margin: 0;
+}
+
 .map-select-actions {
   display: flex;
   gap: 1rem;

--- a/src/ui/screens/MapSelect/MapSelectScreen.tsx
+++ b/src/ui/screens/MapSelect/MapSelectScreen.tsx
@@ -40,7 +40,7 @@ export const MapSelectScreen: React.FC<MapSelectScreenProps> = ({ onStart, onExi
     <div className="map-select-screen">
       <h1>Map Selection</h1>
       <p>Time played: {formatted}</p>
-      <p>Bricks on map: {brickCount}</p>
+      <p>Particles on map: {brickCount}</p>
       <div className="map-select-list">
         {maps.map((map) => {
           const isSelected = map.id === selectedMap;
@@ -58,7 +58,7 @@ export const MapSelectScreen: React.FC<MapSelectScreenProps> = ({ onStart, onExi
                   </dd>
                 </div>
                 <div>
-                  <dt>Bricks</dt>
+                  <dt>Particles</dt>
                   <dd>{map.brickCount}</dd>
                 </div>
                 <div>

--- a/src/ui/screens/MapSelect/MapSelectScreen.tsx
+++ b/src/ui/screens/MapSelect/MapSelectScreen.tsx
@@ -4,6 +4,12 @@ import { useAppLogic } from "../../contexts/AppLogicContext";
 import { useBridgeValue } from "../../shared/useBridgeValue";
 import { TIME_BRIDGE_KEY } from "../../../logic/modules/TestTimeModule";
 import { BRICK_COUNT_BRIDGE_KEY } from "../../../logic/modules/BricksModule";
+import {
+  MAP_LIST_BRIDGE_KEY,
+  MAP_SELECTED_BRIDGE_KEY,
+  MapListEntry,
+} from "../../../logic/modules/MapModule";
+import { MapId } from "../../../db/maps-db";
 import "./MapSelectScreen.css";
 
 interface MapSelectScreenProps {
@@ -21,19 +27,60 @@ const formatTime = (timeMs: number): string => {
 };
 
 export const MapSelectScreen: React.FC<MapSelectScreenProps> = ({ onStart, onExit }) => {
-  const { bridge } = useAppLogic();
+  const { app, bridge } = useAppLogic();
   const timePlayed = useBridgeValue<number>(bridge, TIME_BRIDGE_KEY, 0);
   const brickCount = useBridgeValue<number>(bridge, BRICK_COUNT_BRIDGE_KEY, 0);
+  const maps = useBridgeValue<MapListEntry[]>(bridge, MAP_LIST_BRIDGE_KEY, []);
+  const selectedMap = useBridgeValue<MapId | null>(bridge, MAP_SELECTED_BRIDGE_KEY, null);
 
   const formatted = useMemo(() => formatTime(timePlayed), [timePlayed]);
+  const canStart = maps.length === 0 ? false : selectedMap !== null;
 
   return (
     <div className="map-select-screen">
       <h1>Map Selection</h1>
       <p>Time played: {formatted}</p>
       <p>Bricks on map: {brickCount}</p>
+      <div className="map-select-list">
+        {maps.map((map) => {
+          const isSelected = map.id === selectedMap;
+          return (
+            <div
+              key={map.id}
+              className={`map-select-card${isSelected ? " is-selected" : ""}`}
+            >
+              <h2>{map.name}</h2>
+              <dl className="map-select-details">
+                <div>
+                  <dt>Size</dt>
+                  <dd>
+                    {map.size.width} × {map.size.height}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Bricks</dt>
+                  <dd>{map.brickCount}</dd>
+                </div>
+                <div>
+                  <dt>Types</dt>
+                  <dd>{map.brickTypes.join(", ")}</dd>
+                </div>
+              </dl>
+              <Button
+                onClick={() => {
+                  app.selectMap(map.id);
+                }}
+              >
+                {isSelected ? "Selected" : "Select"}
+              </Button>
+            </div>
+          );
+        })}
+      </div>
       <div className="map-select-actions">
-        <Button onClick={onStart}>Start</Button>
+        <Button onClick={onStart} disabled={!canStart}>
+          Start
+        </Button>
         <Button onClick={onExit}>Main Menu</Button>
       </div>
     </div>

--- a/src/ui/screens/Scene/SceneScreen.tsx
+++ b/src/ui/screens/Scene/SceneScreen.tsx
@@ -450,9 +450,10 @@ export const SceneScreen: React.FC<SceneScreenProps> = ({ onExit }) => {
 
       gl.viewport(0, 0, canvas.width, canvas.height);
       scene.setViewportScreenSize(canvas.width, canvas.height);
+      const currentMapSize = scene.getMapSize();
       scene.setMapSize({
-        width: Math.max(canvas.width, canvas.height, 1000),
-        height: Math.max(canvas.width, canvas.height, 1000),
+        width: Math.max(currentMapSize.width, canvas.width, canvas.height, 1000),
+        height: Math.max(currentMapSize.height, canvas.width, canvas.height, 1000),
       });
       const current = scene.getCamera();
       setScale(current.scale);

--- a/src/ui/screens/Scene/SceneScreen.tsx
+++ b/src/ui/screens/Scene/SceneScreen.tsx
@@ -2,7 +2,14 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useAppLogic } from "../../contexts/AppLogicContext";
 import { useBridgeValue } from "../../shared/useBridgeValue";
 import { TIME_BRIDGE_KEY } from "../../../logic/modules/TestTimeModule";
-import { BRICK_COUNT_BRIDGE_KEY } from "../../../logic/modules/BricksModule";
+import {
+  BRICK_COUNT_BRIDGE_KEY,
+  BRICK_TOTAL_HP_BRIDGE_KEY,
+} from "../../../logic/modules/BricksModule";
+import {
+  PLAYER_UNIT_COUNT_BRIDGE_KEY,
+  PLAYER_UNIT_TOTAL_HP_BRIDGE_KEY,
+} from "../../../logic/modules/PlayerUnitsModule";
 import {
   SceneCameraState,
   SceneObjectManager,
@@ -237,6 +244,9 @@ export const SceneScreen: React.FC<SceneScreenProps> = ({ onExit }) => {
   const { bridge, scene } = useAppLogic();
   const timePlayed = useBridgeValue<number>(bridge, TIME_BRIDGE_KEY, 0);
   const brickCount = useBridgeValue<number>(bridge, BRICK_COUNT_BRIDGE_KEY, 0);
+  const brickTotalHp = useBridgeValue<number>(bridge, BRICK_TOTAL_HP_BRIDGE_KEY, 0);
+  const unitCount = useBridgeValue<number>(bridge, PLAYER_UNIT_COUNT_BRIDGE_KEY, 0);
+  const unitTotalHp = useBridgeValue<number>(bridge, PLAYER_UNIT_TOTAL_HP_BRIDGE_KEY, 0);
   const formatted = useMemo(() => formatTime(timePlayed), [timePlayed]);
   const [scale, setScale] = useState(() => scene.getCamera().scale);
   const [cameraInfo, setCameraInfo] = useState(() => scene.getCamera());
@@ -501,7 +511,9 @@ export const SceneScreen: React.FC<SceneScreenProps> = ({ onExit }) => {
         <Button onClick={onExit}>Main Menu</Button>
         <div className="scene-status">
           <span>Time played: {formatted}</span>
-          <span>Bricks: {brickCount}</span>
+          <span>Particles: {brickCount}</span>
+          <span>Brick HP: {Math.round(brickTotalHp)}</span>
+          <span>Units: {unitCount} (HP {Math.round(unitTotalHp)})</span>
           <label className="scene-zoom">
             Zoom: {scale.toFixed(2)}x
             <input

--- a/tests/BricksModule.test.ts
+++ b/tests/BricksModule.test.ts
@@ -1,5 +1,9 @@
 import assert from "assert";
-import { BricksModule, BRICK_COUNT_BRIDGE_KEY } from "../src/logic/modules/BricksModule";
+import {
+  BricksModule,
+  BRICK_COUNT_BRIDGE_KEY,
+  BRICK_TOTAL_HP_BRIDGE_KEY,
+} from "../src/logic/modules/BricksModule";
 import { DataBridge } from "../src/logic/core/DataBridge";
 import {
   SceneObjectManager,
@@ -63,6 +67,7 @@ describe("BricksModule", () => {
     assert.strictEqual(instance.data.stroke?.width, config.stroke?.width);
 
     assert.strictEqual(bridge.getValue(BRICK_COUNT_BRIDGE_KEY), 1);
+    assert.strictEqual(bridge.getValue(BRICK_TOTAL_HP_BRIDGE_KEY), 5);
 
     const saved = module.save();
     assert(saved && typeof saved === "object", "save should return an object");
@@ -127,10 +132,16 @@ describe("BricksModule", () => {
     const stateAfterFirst = module.getBrickState(brick.id);
     assert(stateAfterFirst, "brick should survive first hit");
     assert.strictEqual(stateAfterFirst?.hp, brick.maxHp - Math.max(2 - brick.armor, 0));
+    assert.strictEqual(
+      bridge.getValue(BRICK_TOTAL_HP_BRIDGE_KEY),
+      stateAfterFirst?.hp,
+      "total HP should reflect damage"
+    );
 
     const lethalHit = module.applyDamage(brick.id, 100);
     assert.strictEqual(lethalHit.destroyed, true);
     assert.strictEqual(module.getBrickState(brick.id), null);
     assert.strictEqual(scene.getObjects().length, 0, "scene object should be removed");
+    assert.strictEqual(bridge.getValue(BRICK_TOTAL_HP_BRIDGE_KEY), 0);
   });
 });

--- a/tests/BricksModule.test.ts
+++ b/tests/BricksModule.test.ts
@@ -5,6 +5,7 @@ import {
   SceneObjectManager,
   FILL_TYPES,
   SceneLinearGradientFill,
+  SceneRadialGradientFill,
 } from "../src/logic/services/SceneObjectManager";
 import { BrickType, getBrickConfig } from "../src/db/bricks-db";
 import { describe, test } from "./testRunner";
@@ -34,16 +35,27 @@ describe("BricksModule", () => {
     const fill = instance.data.fill;
     const fillConfig = config.fill;
     if (fillConfig.type === "linear") {
-      assert.strictEqual(fill.fillType, FILL_TYPES.LINEAR_GRADIENT);
-      assert.strictEqual(fill.stops.length, fillConfig.stops.length);
-      fill.stops.forEach((stop, index) => {
+      const linearFill = fill as SceneLinearGradientFill;
+      assert.strictEqual(linearFill.fillType, FILL_TYPES.LINEAR_GRADIENT);
+      assert.strictEqual(linearFill.stops.length, fillConfig.stops.length);
+      linearFill.stops.forEach((stop, index) => {
+        const expected = fillConfig.stops[index];
+        assert(expected, "expected gradient stop");
+        assert.strictEqual(stop.offset, expected.offset);
+        assert.deepStrictEqual(stop.color, expected.color);
+      });
+    } else if (fillConfig.type === "radial") {
+      const radialFill = fill as SceneRadialGradientFill;
+      assert.strictEqual(radialFill.fillType, FILL_TYPES.RADIAL_GRADIENT);
+      assert.strictEqual(radialFill.stops.length, fillConfig.stops.length);
+      radialFill.stops.forEach((stop, index) => {
         const expected = fillConfig.stops[index];
         assert(expected, "expected gradient stop");
         assert.strictEqual(stop.offset, expected.offset);
         assert.deepStrictEqual(stop.color, expected.color);
       });
     } else {
-      assert.fail("expected linear gradient fill");
+      assert.fail(`unexpected fill type: ${fillConfig.type}`);
     }
 
     assert(instance.data.stroke, "stroke should be defined");

--- a/tests/MapModule.test.ts
+++ b/tests/MapModule.test.ts
@@ -17,7 +17,7 @@ describe("MapModule", () => {
     const scene = new SceneObjectManager();
     const bridge = new DataBridge();
     const bricks = new BricksModule({ scene, bridge });
-    const playerUnits = new PlayerUnitsModule({ scene, bricks });
+    const playerUnits = new PlayerUnitsModule({ scene, bricks, bridge });
     const maps = new MapModule({ scene, bridge, bricks, playerUnits });
 
     maps.initialize();

--- a/tests/MapModule.test.ts
+++ b/tests/MapModule.test.ts
@@ -4,6 +4,7 @@ import { SceneObjectManager } from "../src/logic/services/SceneObjectManager";
 import { DataBridge } from "../src/logic/core/DataBridge";
 import { BricksModule } from "../src/logic/modules/BricksModule";
 import { PlayerUnitsModule } from "../src/logic/modules/PlayerUnitsModule";
+import { MovementService } from "../src/logic/services/MovementService";
 import { MapModule, PLAYER_UNIT_SPAWN_SAFE_RADIUS } from "../src/logic/modules/MapModule";
 
 const distanceSq = (a: { x: number; y: number }, b: { x: number; y: number }): number => {
@@ -17,7 +18,8 @@ describe("MapModule", () => {
     const scene = new SceneObjectManager();
     const bridge = new DataBridge();
     const bricks = new BricksModule({ scene, bridge });
-    const playerUnits = new PlayerUnitsModule({ scene, bricks, bridge });
+    const movement = new MovementService();
+    const playerUnits = new PlayerUnitsModule({ scene, bricks, bridge, movement });
     const maps = new MapModule({ scene, bridge, bricks, playerUnits });
 
     maps.initialize();

--- a/tests/MapModule.test.ts
+++ b/tests/MapModule.test.ts
@@ -1,0 +1,38 @@
+import assert from "assert";
+import { describe, test } from "./testRunner";
+import { SceneObjectManager } from "../src/logic/services/SceneObjectManager";
+import { DataBridge } from "../src/logic/core/DataBridge";
+import { BricksModule } from "../src/logic/modules/BricksModule";
+import { PlayerUnitsModule } from "../src/logic/modules/PlayerUnitsModule";
+import { MapModule, PLAYER_UNIT_SPAWN_SAFE_RADIUS } from "../src/logic/modules/MapModule";
+
+const distanceSq = (a: { x: number; y: number }, b: { x: number; y: number }): number => {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return dx * dx + dy * dy;
+};
+
+describe("MapModule", () => {
+  test("bricks spawn outside of the player unit safe radius", () => {
+    const scene = new SceneObjectManager();
+    const bridge = new DataBridge();
+    const bricks = new BricksModule({ scene, bridge });
+    const playerUnits = new PlayerUnitsModule({ scene, bricks });
+    const maps = new MapModule({ scene, bridge, bricks, playerUnits });
+
+    maps.initialize();
+    maps.selectMap("initial");
+
+    const unitsSave = playerUnits.save() as { units?: { position?: { x: number; y: number } }[] };
+    assert(unitsSave.units && unitsSave.units[0]?.position, "unit should be spawned");
+    const unitPosition = unitsSave.units[0]!.position!;
+
+    const safetyRadiusSq = PLAYER_UNIT_SPAWN_SAFE_RADIUS * PLAYER_UNIT_SPAWN_SAFE_RADIUS;
+    bricks.getBrickStates().forEach((brick) => {
+      assert(
+        distanceSq(brick.position, unitPosition) >= safetyRadiusSq,
+        "brick should be spawned outside of the safety radius"
+      );
+    });
+  });
+});

--- a/tests/PlayerUnitsModule.test.ts
+++ b/tests/PlayerUnitsModule.test.ts
@@ -1,0 +1,81 @@
+import assert from "assert";
+import { describe, test } from "./testRunner";
+import { SceneObjectManager } from "../src/logic/services/SceneObjectManager";
+import { BricksModule } from "../src/logic/modules/BricksModule";
+import { DataBridge } from "../src/logic/core/DataBridge";
+import { PlayerUnitsModule } from "../src/logic/modules/PlayerUnitsModule";
+
+const tickSeconds = (module: PlayerUnitsModule, seconds: number) => {
+  module.tick(seconds * 1000);
+};
+
+describe("PlayerUnitsModule", () => {
+  test("unit destroys weak brick when in range", () => {
+    const scene = new SceneObjectManager();
+    const bridge = new DataBridge();
+    const bricks = new BricksModule({ scene, bridge });
+    const units = new PlayerUnitsModule({ scene, bricks });
+
+    bricks.setBricks([
+      {
+        position: { x: 4, y: 0 },
+        rotation: 0,
+        type: "smallSquareGray",
+      },
+    ]);
+
+    units.setUnits([
+      {
+        type: "bluePentagon",
+        position: { x: 0, y: 0 },
+      },
+    ]);
+
+    tickSeconds(units, 1);
+
+    assert.strictEqual(bricks.getBrickStates().length, 0, "brick should be destroyed");
+    const save = units.save() as { units?: { hp?: number }[] };
+    assert(save.units && save.units[0], "unit should be saved");
+    assert.strictEqual(save.units[0]?.hp, 40);
+  });
+
+  test("unit moves towards brick and gets knocked back on counter damage", () => {
+    const scene = new SceneObjectManager();
+    const bridge = new DataBridge();
+    const bricks = new BricksModule({ scene, bridge });
+    const units = new PlayerUnitsModule({ scene, bricks });
+
+    bricks.setBricks([
+      {
+        position: { x: 100, y: 0 },
+        rotation: 0,
+        type: "blueRadial",
+      },
+    ]);
+
+    units.setUnits([
+      {
+        type: "bluePentagon",
+        position: { x: 0, y: 0 },
+      },
+    ]);
+
+    tickSeconds(units, 1);
+    tickSeconds(units, 1);
+    tickSeconds(units, 1);
+
+    const save = units.save() as {
+      units?: { position?: { x: number; y: number }; hp?: number }[];
+    };
+    assert(save.units && save.units[0], "unit should be saved");
+    const savedUnit = save.units[0]!;
+    assert(savedUnit.position, "position should be saved");
+    assert(Math.abs(savedUnit.position!.x - 75) < 0.0001, "unit should be knocked back to x≈75");
+    assert.strictEqual(savedUnit.position!.y, 0);
+    assert.strictEqual(savedUnit.hp, 33, "unit should take counter damage");
+
+    const [brick] = bricks.getBrickStates();
+    assert(brick, "brick should survive");
+    assert.strictEqual(brick.hp, brick.maxHp);
+  });
+});

--- a/tests/run.ts
+++ b/tests/run.ts
@@ -5,5 +5,6 @@ import "./fill.test";
 import "./BulletModule.test";
 import "./ExplosionModule.test";
 import "./BricksModule.test";
+import "./PlayerUnitsModule.test";
 
 void run();

--- a/tests/run.ts
+++ b/tests/run.ts
@@ -6,5 +6,6 @@ import "./BulletModule.test";
 import "./ExplosionModule.test";
 import "./BricksModule.test";
 import "./PlayerUnitsModule.test";
+import "./MapModule.test";
 
 void run();


### PR DESCRIPTION
## Summary
- add a map database with an initial layout of 2,000 small grey bricks
- introduce a map module that initializes the scene and bricks from selected map configs
- update the map select screen, scene sizing, and related tests to support choosing maps

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e158171e2c8320ad2e1292aeed4bc4