### PR TITLE
Add brick explosion effects and document logic API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,8 @@
 
 This document summarizes the core building blocks that power the eater's prototype
 framework. Every system is designed for reusability so modules can combine without
-forming tight coupling between UI and logic.
+forming tight coupling between UI and logic. For an in-depth look at module APIs
+and data contracts, see the [Logic API Reference](./api-reference.md).
 
 ## Core runtime
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -87,10 +87,11 @@ Manages destructible map bricks. Responsibilities:
   zero.
 
 Each brick stores knock-back parameters, base damage, and physical size derived
-from `bricks-db.ts`. Destructible configs can now define
-`hitExplosionType` / `destroyExplosionType`. The module spawns those effects via
-`ExplosionModule` using the brick's position and collision radius, so all visual
-logic is centralized in the explosion system.
+from `bricks-db.ts`. Destructible configs now define
+`damageExplosion` / `destructionExplosion`, providing explosion type references
+and radius tuning. The module spawns those effects via `ExplosionModule` using
+the brick's position, so all visual logic is centralized in the explosion
+system.
 
 ### `MapModule`
 Loads map definitions, wires brick groups, and resets dependent modules when the
@@ -133,15 +134,15 @@ Destructible metadata includes:
 - `baseDamage` — melee damage inflicted when units collide with the brick.
 - `brickKnockBackDistance` / `brickKnockBackSpeed` — knock-back tuning.
 - `physicalSize` — collision radius for targeting.
-- `hitExplosionType` / `destroyExplosionType` — identifiers for explosion
-  effects to spawn on damage and destruction. These values are consumed by
-  `BricksModule` and resolved by `ExplosionModule`.
+- `damageExplosion` / `destructionExplosion` — references to explosion effects
+  with optional radius overrides. These values are consumed by `BricksModule`
+  and resolved by `ExplosionModule`.
 
 ## Interaction flow summary
 
 1. A unit attacks a brick through `PlayerUnitsModule`.
 2. `BricksModule.applyDamage` reduces health and (if configured) calls
-   `ExplosionModule.spawnExplosionByType` with the hit or destroy effect.
+   `ExplosionModule.spawnExplosionByType` with the damage or destruction effect.
 3. `ExplosionModule` creates a wave scene object and optional particle emitter
    that the renderer animates automatically.
 4. `BricksModule` updates bridge statistics so UI counters stay in sync.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,150 @@
+# Logic API Reference
+
+This document describes the runtime classes that power the eater's prototype. It
+focuses on constructor dependencies, important methods, and the data contracts
+that modules exchange through the services layer.
+
+## Core architecture
+
+### `Application`
+Coordinates wiring between services and game modules. The constructor builds the
+shared services (`SaveManager`, `GameLoop`, `SceneObjectManager`,
+`MovementService`) and modules (`TestTimeModule`, `ExplosionModule`,
+`BricksModule`, `PlayerUnitsModule`, `MapModule`, `BulletModule`). Key methods:
+
+- `initialize()` — calls `initialize` on every registered module.
+- `reset()` — clears the scene graph and forwards `reset` to modules.
+- `selectSlot(slot)` — changes save slot, reloads data, restarts the game loop.
+- `returnToMainMenu()` — saves the current slot, clears it, stops the loop.
+- `selectMap(mapId)` — forwards the selection to `MapModule`.
+- `getBridge()`, `getSceneObjects()`, `getGameLoop()`, `getSaveManager()` —
+  expose the shared services for UI and tests.
+
+Modules are registered through a private helper that wires them into the save
+manager and the game loop at the same time.
+
+### `ServiceContainer`
+A lightweight registry that stores singleton instances by string key. It offers
+`register(key, instance)` and `get<T>(key)` to retrieve the service. The
+container prevents accidental duplicates and centralizes dependency lookup,
+allowing modules to remain decoupled.
+
+### `DataBridge`
+A type-agnostic publish/subscribe bus. Modules push derived data through
+`setValue(key, value)`, React components subscribe with `subscribe(key, cb)` and
+consume values through `getValue(key)`. The bridge decouples UI reactivity from
+module internals.
+
+### `GameLoop`
+Owns the ticking scheduler. Modules register via `registerModule(module)` and
+receive `tick(deltaMs)` callbacks when the loop is running. The loop can be
+started and stopped, and it automatically skips updates when `deltaMs` is zero
+or negative.
+
+### `SaveManager`
+Persists per-module save payloads to `localStorage`. Modules register themselves
+so the manager can call `save()` and `load(data)` for each slot. The manager
+supports manual saves, slot switching, and timed autosaves.
+
+### `SceneObjectManager`
+Maintains the world map and renderable objects. Important capabilities:
+
+- `addObject(type, config)` — inserts a new renderable and returns its id.
+- `updateObject(id, patch)` — mutates existing objects in place.
+- `removeObject(id)` — deletes renderables when they expire or are destroyed.
+- `clear()` — wipes the scene (used when resetting modules).
+- `getMapSize()` — returns `{width, height}` for clamping positions.
+
+Scene objects are pure data records consumed by the WebGL renderer, which keeps
+logic isolated from presentation.
+
+## Modules
+
+### Module lifecycle
+Every module implements the `GameModule` interface:
+
+- `id` — unique identifier used in save payloads.
+- `initialize()` — called once when the application boots.
+- `reset()` — clears state when switching saves or returning to menu.
+- `load(data)` / `save()` — serialization hooks for the `SaveManager`.
+- `tick(deltaMs)` — optional update hook, called by the `GameLoop`.
+
+### `TestTimeModule`
+A sample module that increments an in-game timer on each tick, persists the
+elapsed time, and pushes a formatted string via the bridge key
+`time/elapsedLabel`.
+
+### `BricksModule`
+Manages destructible map bricks. Responsibilities:
+
+- `setBricks(bricks)` / `load(data)` — sanitize brick definitions and build
+  immutable runtime state.
+- `getBrickStates()` / `getBrickState(id)` — expose defensive copies for other
+  systems (e.g., unit AI).
+- `findNearestBrick(position)` — spatial query helper for targeting.
+- `applyDamage(brickId, rawDamage)` — subtracts armor, applies damage, spawns
+  explosion effects, updates bridge stats, and removes bricks when health reaches
+  zero.
+
+Each brick stores knock-back parameters, base damage, and physical size derived
+from `bricks-db.ts`. Destructible configs can now define
+`hitExplosionType` / `destroyExplosionType`. The module spawns those effects via
+`ExplosionModule` using the brick's position and collision radius, so all visual
+logic is centralized in the explosion system.
+
+### `MapModule`
+Loads map definitions, wires brick groups, and resets dependent modules when the
+player selects a new map. It ensures the scene graph reflects the currently
+active map configuration.
+
+### `PlayerUnitsModule`
+Controls friendly units. Core features include movement towards target bricks,
+attack resolution (`applyDamage` on `BricksModule`), knock-back handling, and
+bridge updates for unit stats. It depends on `MovementService` for pathing.
+
+### `ExplosionModule`
+Creates persistent explosion effects that animate their radius, opacity, and
+particle emitters over time. Public API:
+
+- `spawnExplosion({ position, initialRadius })` — convenience wrapper that uses
+  the default "plasmoid" config.
+- `spawnExplosionByType(type, { position, initialRadius? })` — loads the config
+  from `explosions-db.ts`, spawns a wave renderable, and configures optional
+  particle emitters.
+
+The module tracks active explosions, updates them each tick, and removes them
+when their lifetimes expire.
+
+### `BulletModule`
+Handles projectile spawning and updates. Bullets move across the map, expire
+after their configured lifetime or when they leave bounds, and trigger
+explosions via `ExplosionModule` (using the type defined in `bullets-db.ts`).
+
+### `Map` and `Player` databases
+- `maps-db.ts` defines map layouts and groups of bricks to spawn.
+- `player-units-db.ts` stores unit archetypes with stats such as damage, attack
+  delay, and speed. `PlayerUnitsModule` reads these configs when creating units.
+
+### Brick configuration database
+`bricks-db.ts` describes the visual and gameplay properties of each brick type.
+Destructible metadata includes:
+
+- `maxHp`, `hp`, and `armor` — durability parameters.
+- `baseDamage` — melee damage inflicted when units collide with the brick.
+- `brickKnockBackDistance` / `brickKnockBackSpeed` — knock-back tuning.
+- `physicalSize` — collision radius for targeting.
+- `hitExplosionType` / `destroyExplosionType` — identifiers for explosion
+  effects to spawn on damage and destruction. These values are consumed by
+  `BricksModule` and resolved by `ExplosionModule`.
+
+## Interaction flow summary
+
+1. A unit attacks a brick through `PlayerUnitsModule`.
+2. `BricksModule.applyDamage` reduces health and (if configured) calls
+   `ExplosionModule.spawnExplosionByType` with the hit or destroy effect.
+3. `ExplosionModule` creates a wave scene object and optional particle emitter
+   that the renderer animates automatically.
+4. `BricksModule` updates bridge statistics so UI counters stay in sync.
+
+This pipeline ensures all visual effects are centralized while logic modules only
+own gameplay state and intent.

--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -77,8 +77,8 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       maxHp: 25,
       armor: 2,
       baseDamage: 3,
-      brickKnockBackDistance: 20,
-      brickKnockBackSpeed: 40,
+      brickKnockBackDistance: 40,
+      brickKnockBackSpeed: 80,
       physicalSize: 28,
       damageExplosion: {
         type: "plasmoid",
@@ -95,7 +95,7 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
     fill: {
       type: "radial",
       center: { x: 0, y: 0 },
-      radius: 28,
+      radius: 12,
       stops: SMALL_SQUARE_GRAY_GRADIENT,
     },
     stroke: { color: { r: 0.3, g: 0.3, b: 0.35, a: 1 }, width: 1.5 },
@@ -103,8 +103,8 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       maxHp: 5,
       armor: 0,
       baseDamage: 2,
-      brickKnockBackDistance: 20,
-      brickKnockBackSpeed: 40,
+      brickKnockBackDistance: 40,
+      brickKnockBackSpeed: 80,
       physicalSize: 16,
       damageExplosion: {
         type: "grayBrickHit",

--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -5,7 +5,7 @@ import {
   SceneVector2,
 } from "../logic/services/SceneObjectManager";
 
-import {DestructubleData} from '../logic/interfaces/destructuble';
+import { DestructubleData } from "../logic/interfaces/destructuble";
 
 export type BrickType = "classic" | "smallSquareGray" | "blueRadial";
 
@@ -80,7 +80,9 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       brickKnockBackDistance: 20,
       brickKnockBackSpeed: 40,
       physicalSize: 28,
-    }
+      hitExplosionType: "plasmoid",
+      destroyExplosionType: "plasmoid",
+    },
   },
   smallSquareGray: {
     size: { width: 24, height: 24 },
@@ -98,7 +100,9 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       brickKnockBackDistance: 20,
       brickKnockBackSpeed: 40,
       physicalSize: 16,
-    }
+      hitExplosionType: "plasmoid",
+      destroyExplosionType: "plasmoid",
+    },
   },
   blueRadial: {
     size: { width: 48, height: 48 },
@@ -116,7 +120,9 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       brickKnockBackDistance: 20,
       brickKnockBackSpeed: 40,
       physicalSize: 24,
-    }
+      hitExplosionType: "magnetic",
+      destroyExplosionType: "magnetic",
+    },
   },
 };
 

--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -80,8 +80,14 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       brickKnockBackDistance: 20,
       brickKnockBackSpeed: 40,
       physicalSize: 28,
-      hitExplosionType: "plasmoid",
-      destroyExplosionType: "plasmoid",
+      damageExplosion: {
+        type: "plasmoid",
+        radiusMultiplier: 0.9,
+      },
+      destructionExplosion: {
+        type: "plasmoid",
+        radiusMultiplier: 1.05,
+      },
     },
   },
   smallSquareGray: {
@@ -100,8 +106,15 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       brickKnockBackDistance: 20,
       brickKnockBackSpeed: 40,
       physicalSize: 16,
-      hitExplosionType: "plasmoid",
-      destroyExplosionType: "plasmoid",
+      damageExplosion: {
+        type: "grayBrickHit",
+        radiusMultiplier: 0.7,
+        radiusOffset: -2,
+      },
+      destructionExplosion: {
+        type: "grayBrickDestroy",
+        radiusMultiplier: 0.95,
+      },
     },
   },
   blueRadial: {
@@ -120,8 +133,14 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       brickKnockBackDistance: 20,
       brickKnockBackSpeed: 40,
       physicalSize: 24,
-      hitExplosionType: "magnetic",
-      destroyExplosionType: "magnetic",
+      damageExplosion: {
+        type: "magnetic",
+        radiusMultiplier: 0.85,
+      },
+      destructionExplosion: {
+        type: "magnetic",
+        radiusMultiplier: 1.25,
+      },
     },
   },
 };

--- a/src/db/explosions-db.ts
+++ b/src/db/explosions-db.ts
@@ -6,7 +6,11 @@ import {
   SceneVector2,
 } from "../logic/services/SceneObjectManager";
 
-export type ExplosionType = "plasmoid" | "magnetic";
+export type ExplosionType =
+  | "plasmoid"
+  | "magnetic"
+  | "grayBrickHit"
+  | "grayBrickDestroy";
 
 export interface ExplosionWaveConfig {
   radiusExtension: number;
@@ -70,6 +74,18 @@ const MAGNETIC_WAVE_GRADIENT_STOPS: readonly SceneGradientStop[] = [
   { offset: 1, color: { r: 0.25, g: 0.05, b: 0.7, a: 0 } },
 ] as const;
 
+const GRAY_BRICK_HIT_WAVE_GRADIENT_STOPS: readonly SceneGradientStop[] = [
+  { offset: 0, color: { r: 0.92, g: 0.92, b: 0.94, a: 0.45 } },
+  { offset: 0.4, color: { r: 0.75, g: 0.77, b: 0.8, a: 0.25 } },
+  { offset: 1, color: { r: 0.55, g: 0.58, b: 0.6, a: 0 } },
+] as const;
+
+const GRAY_BRICK_DESTROY_WAVE_GRADIENT_STOPS: readonly SceneGradientStop[] = [
+  { offset: 0, color: { r: 0.95, g: 0.95, b: 0.97, a: 0.6 } },
+  { offset: 0.35, color: { r: 0.78, g: 0.8, b: 0.84, a: 0.35 } },
+  { offset: 1, color: { r: 0.45, g: 0.48, b: 0.52, a: 0 } },
+] as const;
+
 const DEFAULT_EMITTER_FILL: SceneFill = {
   fillType: FILL_TYPES.SOLID,
   color: { r: 1, g: 0.85, b: 0.55, a: 1 },
@@ -83,6 +99,17 @@ const MAGNETIC_EMITTER_FILL: SceneFill = {
     { offset: 0, color: { r: 1, g: 1, b: 1, a: 0.95 } },
     { offset: 0.4, color: { r: 0.7, g: 0.6, b: 1, a: 0.6 } },
     { offset: 1, color: { r: 0.4, g: 0.2, b: 0.9, a: 0 } },
+  ],
+};
+
+const GRAY_BRICK_EMITTER_FILL: SceneFill = {
+  fillType: FILL_TYPES.RADIAL_GRADIENT,
+  start: { x: 0, y: 0 },
+  end: 5,
+  stops: [
+    { offset: 0, color: { r: 0.9, g: 0.9, b: 0.92, a: 0.85 } },
+    { offset: 0.45, color: { r: 0.72, g: 0.74, b: 0.78, a: 0.4 } },
+    { offset: 1, color: { r: 0.45, g: 0.48, b: 0.52, a: 0 } },
   ],
 };
 
@@ -100,6 +127,38 @@ const DEFAULT_EMITTER: ExplosionEmitterConfig = {
   arc: Math.PI * 2,
   direction: 0,
   fill: DEFAULT_EMITTER_FILL,
+};
+
+const GRAY_BRICK_DAMAGE_EMITTER: ExplosionEmitterConfig = {
+  emissionDurationMs: 240,
+  particlesPerSecond: 130,
+  baseSpeed: 0.08,
+  speedVariation: 0.03,
+  particleLifetimeMs: 650,
+  fadeStartMs: 280,
+  sizeRange: { min: 0.6, max: 1.4 },
+  spawnRadius: { min: 0, max: 5 },
+  spawnRadiusMultiplier: 1.2,
+  color: { r: 0.82, g: 0.84, b: 0.88, a: 1 },
+  arc: Math.PI * 2,
+  direction: 0,
+  fill: GRAY_BRICK_EMITTER_FILL,
+};
+
+const GRAY_BRICK_DESTRUCTION_EMITTER: ExplosionEmitterConfig = {
+  emissionDurationMs: 520,
+  particlesPerSecond: 280,
+  baseSpeed: 0.12,
+  speedVariation: 0.06,
+  particleLifetimeMs: 1_000,
+  fadeStartMs: 480,
+  sizeRange: { min: 0.8, max: 1.9 },
+  spawnRadius: { min: 0, max: 8 },
+  spawnRadiusMultiplier: 1.5,
+  color: { r: 0.85, g: 0.87, b: 0.92, a: 1 },
+  arc: Math.PI * 2,
+  direction: 0,
+  fill: GRAY_BRICK_EMITTER_FILL,
 };
 
 const EXPLOSION_DB: Record<ExplosionType, ExplosionConfig> = {
@@ -130,6 +189,28 @@ const EXPLOSION_DB: Record<ExplosionType, ExplosionConfig> = {
       arc: Math.PI / 2,
       direction: Math.PI,
     },
+  },
+  grayBrickHit: {
+    lifetimeMs: 1_000,
+    defaultInitialRadius: 6,
+    wave: {
+      radiusExtension: 40,
+      startAlpha: 0.4,
+      endAlpha: 0,
+      gradientStops: GRAY_BRICK_HIT_WAVE_GRADIENT_STOPS,
+    },
+    emitter: GRAY_BRICK_DAMAGE_EMITTER,
+  },
+  grayBrickDestroy: {
+    lifetimeMs: 1_600,
+    defaultInitialRadius: 10,
+    wave: {
+      radiusExtension: 90,
+      startAlpha: 0.55,
+      endAlpha: 0,
+      gradientStops: GRAY_BRICK_DESTROY_WAVE_GRADIENT_STOPS,
+    },
+    emitter: GRAY_BRICK_DESTRUCTION_EMITTER,
   },
 };
 

--- a/src/logic/core/Application.ts
+++ b/src/logic/core/Application.ts
@@ -35,9 +35,14 @@ export class Application {
       bridge: this.dataBridge,
     });
 
+    const explosionModule = new ExplosionModule({
+      scene: sceneObjects,
+    });
+
     const bricksModule = new BricksModule({
       scene: sceneObjects,
       bridge: this.dataBridge,
+      explosions: explosionModule,
     });
     const playerUnitsModule = new PlayerUnitsModule({
       scene: sceneObjects,
@@ -50,10 +55,6 @@ export class Application {
       bridge: this.dataBridge,
       bricks: bricksModule,
       playerUnits: playerUnitsModule,
-    });
-
-    const explosionModule = new ExplosionModule({
-      scene: sceneObjects,
     });
 
     const bulletModule = new BulletModule({

--- a/src/logic/interfaces/destructuble.ts
+++ b/src/logic/interfaces/destructuble.ts
@@ -1,5 +1,22 @@
 import type { ExplosionType } from "../../db/explosions-db";
 
+export interface DestructubleExplosionConfig {
+    type: ExplosionType;
+    /**
+     * Overrides the radius passed to the explosion module. When provided it takes
+     * precedence over the multiplier and offset values.
+     */
+    initialRadius?: number;
+    /**
+     * Scales the base radius of the brick before applying the offset. Defaults to 1.
+     */
+    radiusMultiplier?: number;
+    /**
+     * Adds a constant value to the computed initial radius.
+     */
+    radiusOffset?: number;
+}
+
 export interface DestructubleData {
     hp?: number;
     maxHp: number;
@@ -8,6 +25,6 @@ export interface DestructubleData {
     brickKnockBackDistance?: number;
     brickKnockBackSpeed?: number;
     physicalSize?: number;
-    hitExplosionType?: ExplosionType;
-    destroyExplosionType?: ExplosionType;
+    damageExplosion?: DestructubleExplosionConfig;
+    destructionExplosion?: DestructubleExplosionConfig;
 }

--- a/src/logic/interfaces/destructuble.ts
+++ b/src/logic/interfaces/destructuble.ts
@@ -1,3 +1,5 @@
+import type { ExplosionType } from "../../db/explosions-db";
+
 export interface DestructubleData {
     hp?: number;
     maxHp: number;
@@ -6,4 +8,6 @@ export interface DestructubleData {
     brickKnockBackDistance?: number;
     brickKnockBackSpeed?: number;
     physicalSize?: number;
+    hitExplosionType?: ExplosionType;
+    destroyExplosionType?: ExplosionType;
 }

--- a/tests/BricksModule.test.ts
+++ b/tests/BricksModule.test.ts
@@ -156,4 +156,53 @@ describe("BricksModule", () => {
     assert.strictEqual(explosionObjects.length, 1, "destroy explosion should be spawned");
     assert.strictEqual(bridge.getValue(BRICK_TOTAL_HP_BRIDGE_KEY), 0);
   });
+
+  test("small gray bricks use configured explosion presets", () => {
+    const scene = new SceneObjectManager();
+    const bridge = new DataBridge();
+    const module = createBricksModule(scene, bridge);
+
+    module.setBricks([
+      {
+        position: { x: 10, y: 10 },
+        rotation: 0,
+        type: "smallSquareGray",
+      },
+    ]);
+
+    const [brick] = module.getBrickStates();
+    assert(brick, "expected brick state");
+
+    module.applyDamage(brick.id, 3);
+
+    let explosions = scene.getObjects().filter((object) => object.type === "explosion");
+    assert.strictEqual(explosions.length, 1, "damage should spawn one explosion");
+    const damageExplosion = explosions[0]!;
+    assert.strictEqual(Math.round((damageExplosion.data.size?.width ?? 0) * 10) / 10, 18.4);
+    const damageEmitter = (damageExplosion.data.customData as { emitter?: { color?: unknown } })
+      ?.emitter;
+    assert(damageEmitter, "damage explosion should configure an emitter");
+    assert.deepStrictEqual(damageEmitter?.color, {
+      r: 0.82,
+      g: 0.84,
+      b: 0.88,
+      a: 1,
+    });
+
+    module.applyDamage(brick.id, 100);
+
+    explosions = scene.getObjects().filter((object) => object.type === "explosion");
+    assert.strictEqual(explosions.length, 2, "destroy should spawn another explosion");
+    const destroyExplosion = explosions[explosions.length - 1]!;
+    assert.strictEqual(Math.round((destroyExplosion.data.size?.width ?? 0) * 10) / 10, 30.4);
+    const destroyEmitter = (destroyExplosion.data.customData as { emitter?: { color?: unknown } })
+      ?.emitter;
+    assert(destroyEmitter, "destroy explosion should configure an emitter");
+    assert.deepStrictEqual(destroyEmitter?.color, {
+      r: 0.85,
+      g: 0.87,
+      b: 0.92,
+      a: 1,
+    });
+  });
 });

--- a/tests/MapModule.test.ts
+++ b/tests/MapModule.test.ts
@@ -6,6 +6,7 @@ import { BricksModule } from "../src/logic/modules/BricksModule";
 import { PlayerUnitsModule } from "../src/logic/modules/PlayerUnitsModule";
 import { MovementService } from "../src/logic/services/MovementService";
 import { MapModule, PLAYER_UNIT_SPAWN_SAFE_RADIUS } from "../src/logic/modules/MapModule";
+import { ExplosionModule } from "../src/logic/modules/ExplosionModule";
 
 const distanceSq = (a: { x: number; y: number }, b: { x: number; y: number }): number => {
   const dx = a.x - b.x;
@@ -17,7 +18,8 @@ describe("MapModule", () => {
   test("bricks spawn outside of the player unit safe radius", () => {
     const scene = new SceneObjectManager();
     const bridge = new DataBridge();
-    const bricks = new BricksModule({ scene, bridge });
+    const explosions = new ExplosionModule({ scene });
+    const bricks = new BricksModule({ scene, bridge, explosions });
     const movement = new MovementService();
     const playerUnits = new PlayerUnitsModule({ scene, bricks, bridge, movement });
     const maps = new MapModule({ scene, bridge, bricks, playerUnits });

--- a/tests/PlayerUnitsModule.test.ts
+++ b/tests/PlayerUnitsModule.test.ts
@@ -8,6 +8,12 @@ import {
   PLAYER_UNIT_TOTAL_HP_BRIDGE_KEY,
 } from "../src/logic/modules/PlayerUnitsModule";
 import { MovementService } from "../src/logic/services/MovementService";
+import { ExplosionModule } from "../src/logic/modules/ExplosionModule";
+
+const createBricksModule = (scene: SceneObjectManager, bridge: DataBridge) => {
+  const explosions = new ExplosionModule({ scene });
+  return new BricksModule({ scene, bridge, explosions });
+};
 
 const tickSeconds = (module: PlayerUnitsModule, seconds: number) => {
   module.tick(seconds * 1000);
@@ -18,7 +24,7 @@ describe("PlayerUnitsModule", () => {
     const scene = new SceneObjectManager();
     const bridge = new DataBridge();
     const movement = new MovementService();
-    const bricks = new BricksModule({ scene, bridge });
+    const bricks = createBricksModule(scene, bridge);
     const units = new PlayerUnitsModule({ scene, bricks, bridge, movement });
 
     bricks.setBricks([
@@ -60,7 +66,7 @@ describe("PlayerUnitsModule", () => {
     const scene = new SceneObjectManager();
     const bridge = new DataBridge();
     const movement = new MovementService();
-    const bricks = new BricksModule({ scene, bridge });
+    const bricks = createBricksModule(scene, bridge);
     const units = new PlayerUnitsModule({ scene, bricks, bridge, movement });
 
     bricks.setBricks([


### PR DESCRIPTION
## Summary
- enrich brick destructible configs with hit/destroy explosion types and surface them through the bricks module
- route brick damage through the shared ExplosionModule and adjust tests for the new dependency
- add an in-depth logic API reference in docs and link it from the overview

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e18a4101d0832097be4d0e25e2701a