### PR TITLE
Handle edge scrolling when cursor overlaps the summoning panel

### DIFF
--- a/src/ui/screens/Scene/SceneSummoningPanel.tsx
+++ b/src/ui/screens/Scene/SceneSummoningPanel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { forwardRef } from "react";
 import { PlayerUnitType } from "../../../db/player-units-db";
 import {
   NecromancerResourcesPayload,
@@ -18,75 +18,75 @@ interface SceneSummoningPanelProps {
 const formatResourceValue = (current: number, max: number): string =>
   `${current.toFixed(1)} / ${max.toFixed(1)}`;
 
-export const SceneSummoningPanel: React.FC<SceneSummoningPanelProps> = ({
-  resources,
-  spawnOptions,
-  onSummon,
-}) => {
-  const available = {
-    mana: resources.mana.current,
-    sanity: resources.sanity.current,
-  };
+export const SceneSummoningPanel = forwardRef<HTMLDivElement, SceneSummoningPanelProps>(
+  ({ resources, spawnOptions, onSummon }, ref) => {
+    const available = {
+      mana: resources.mana.current,
+      sanity: resources.sanity.current,
+    };
 
-  return (
-    <div className="scene-summoning-panel">
-      <div className="scene-summoning-panel__section scene-summoning-panel__section--left">
-        <div className="scene-summoning-panel__resource">
-          <div className="scene-summoning-panel__resource-label">Sanity</div>
-          <ProgressBar
-            className="scene-summoning-panel__resource-bar scene-summoning-panel__resource-bar--sanity"
-            current={resources.sanity.current}
-            max={resources.sanity.max}
-            formatValue={(current, max) => formatResourceValue(current, max)}
-            orientation={'vertical'}
-          />
+    return (
+      <div ref={ref} className="scene-summoning-panel">
+        <div className="scene-summoning-panel__section scene-summoning-panel__section--left">
+          <div className="scene-summoning-panel__resource">
+            <div className="scene-summoning-panel__resource-label">Sanity</div>
+            <ProgressBar
+              className="scene-summoning-panel__resource-bar scene-summoning-panel__resource-bar--sanity"
+              current={resources.sanity.current}
+              max={resources.sanity.max}
+              formatValue={(current, max) => formatResourceValue(current, max)}
+              orientation="vertical"
+            />
+          </div>
+        </div>
+        <div className="scene-summoning-panel__section scene-summoning-panel__section--center">
+          <div className="scene-summoning-panel__unit-list">
+            {spawnOptions.map((option) => {
+              const missing = computeMissing(option.cost, available);
+              const canAfford = missing.mana <= 0 && missing.sanity <= 0;
+              const itemClassName = [
+                "scene-summoning-panel__unit",
+                !canAfford ? "scene-summoning-panel__unit--disabled" : null,
+              ]
+                .filter(Boolean)
+                .join(" ");
+              return (
+                <button
+                  key={option.type}
+                  type="button"
+                  className={itemClassName}
+                  onClick={() => {
+                    if (canAfford) {
+                      onSummon(option.type);
+                    }
+                  }}
+                  disabled={!canAfford}
+                >
+                  <div className="scene-summoning-panel__unit-name">{option.name}</div>
+                  <ResourceCostDisplay cost={option.cost} missing={missing} />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <div className="scene-summoning-panel__section scene-summoning-panel__section--right">
+          <div className="scene-summoning-panel__resource">
+            <div className="scene-summoning-panel__resource-label">Mana</div>
+            <ProgressBar
+              className="scene-summoning-panel__resource-bar scene-summoning-panel__resource-bar--mana"
+              current={resources.mana.current}
+              max={resources.mana.max}
+              formatValue={(current, max) => formatResourceValue(current, max)}
+              orientation="vertical"
+            />
+          </div>
         </div>
       </div>
-      <div className="scene-summoning-panel__section scene-summoning-panel__section--center">
-        <div className="scene-summoning-panel__unit-list">
-          {spawnOptions.map((option) => {
-            const missing = computeMissing(option.cost, available);
-            const canAfford = missing.mana <= 0 && missing.sanity <= 0;
-            const itemClassName = [
-              "scene-summoning-panel__unit",
-              !canAfford ? "scene-summoning-panel__unit--disabled" : null,
-            ]
-              .filter(Boolean)
-              .join(" ");
-            return (
-              <button
-                key={option.type}
-                type="button"
-                className={itemClassName}
-                onClick={() => {
-                  if (canAfford) {
-                    onSummon(option.type);
-                  }
-                }}
-                disabled={!canAfford}
-              >
-                <div className="scene-summoning-panel__unit-name">{option.name}</div>
-                <ResourceCostDisplay cost={option.cost} missing={missing} />
-              </button>
-            );
-          })}
-        </div>
-      </div>
-      <div className="scene-summoning-panel__section scene-summoning-panel__section--right">
-        <div className="scene-summoning-panel__resource">
-          <div className="scene-summoning-panel__resource-label">Mana</div>
-          <ProgressBar
-            className="scene-summoning-panel__resource-bar scene-summoning-panel__resource-bar--mana"
-            current={resources.mana.current}
-            max={resources.mana.max}
-            formatValue={(current, max) => formatResourceValue(current, max)}
-            orientation="vertical"
-          />
-        </div>
-      </div>
-    </div>
-  );
-};
+    );
+  }
+);
+
+SceneSummoningPanel.displayName = "SceneSummoningPanel";
 
 const computeMissing = (
   cost: NecromancerSpawnOption["cost"],


### PR DESCRIPTION
## Summary
- track pointer movement at the window level so camera edge scrolling still works when the summoning panel overlaps the canvas
- measure the summoning panel height and extend the scroll hotspot to cover it
- forward the summoning panel ref so the scene can observe its dimensions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2b3866c4883209b4e65bf462b442a