### PR TITLE
Add resource tracking and map select sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,9 @@ function App(): JSX.Element {
               app.returnToMainMenu();
               setScreen("save-select");
             }}
+            onLeaveToMapSelect={() => {
+              setScreen("map-select");
+            }}
           />
         )}
       </div>

--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -6,6 +6,7 @@ import {
 } from "../logic/services/SceneObjectManager";
 
 import { DestructubleData } from "../logic/interfaces/destructuble";
+import { ResourceAmount } from "./resources-db";
 
 export type BrickType = "classic" | "smallSquareGray" | "smallSquareYellow" | "blueRadial";
 
@@ -43,6 +44,7 @@ export interface BrickConfig {
   fill: BrickFillConfig;
   stroke?: BrickStrokeConfig;
   destructubleData?: DestructubleData;
+  rewards?: ResourceAmount;
 }
 
 const CLASSIC_GRADIENT: readonly SceneGradientStop[] = [
@@ -122,6 +124,9 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
         radiusMultiplier: 0.95,
       },
     },
+    rewards: {
+      stone: 1,
+    },
   },
   smallSquareYellow: {
     size: { width: 24, height: 24 },
@@ -148,6 +153,9 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
         type: "grayBrickDestroy",
         radiusMultiplier: 0.95,
       },
+    },
+    rewards: {
+      sand: 1,
     },
   },
   blueRadial: {

--- a/src/db/player-units-db.ts
+++ b/src/db/player-units-db.ts
@@ -67,7 +67,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
       },
       offset: { x: 0, y: 0 },
     },
-    maxHp: 10,
+    maxHp: 40,
     armor: 1,
     baseAttackDamage: 2,
     baseAttackInterval: 1,

--- a/src/db/resources-db.ts
+++ b/src/db/resources-db.ts
@@ -1,0 +1,78 @@
+export type ResourceId = "stone" | "sand";
+
+export interface ResourceConfig {
+  readonly id: ResourceId;
+  readonly name: string;
+  readonly description?: string;
+}
+
+export type ResourceAmount = Partial<Record<ResourceId, number>>;
+export type ResourceStockpile = Record<ResourceId, number>;
+
+const RESOURCE_DB: Record<ResourceId, ResourceConfig> = {
+  stone: {
+    id: "stone",
+    name: "Stone",
+    description: "Solid fragments gathered from shattered bricks.",
+  },
+  sand: {
+    id: "sand",
+    name: "Sand",
+    description: "Fine grains useful for future construction.",
+  },
+};
+
+export const RESOURCE_IDS = Object.keys(RESOURCE_DB) as ResourceId[];
+
+export const getResourceConfig = (id: ResourceId): ResourceConfig => {
+  const config = RESOURCE_DB[id];
+  if (!config) {
+    throw new Error(`Unknown resource id: ${id}`);
+  }
+  return config;
+};
+
+const sanitizeResourceValue = (value: unknown): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(Math.floor(value), 0);
+};
+
+export const createEmptyResourceStockpile = (): ResourceStockpile => {
+  const stockpile = {} as ResourceStockpile;
+  RESOURCE_IDS.forEach((id) => {
+    stockpile[id] = 0;
+  });
+  return stockpile;
+};
+
+export const normalizeResourceAmount = (
+  amount: ResourceAmount | ResourceStockpile | null | undefined
+): ResourceStockpile => {
+  const normalized = createEmptyResourceStockpile();
+  if (!amount) {
+    return normalized;
+  }
+  RESOURCE_IDS.forEach((id) => {
+    normalized[id] = sanitizeResourceValue((amount as Record<ResourceId, number | undefined>)[id]);
+  });
+  return normalized;
+};
+
+export const cloneResourceStockpile = (source: ResourceStockpile): ResourceStockpile => {
+  const clone = createEmptyResourceStockpile();
+  RESOURCE_IDS.forEach((id) => {
+    clone[id] = sanitizeResourceValue(source[id]);
+  });
+  return clone;
+};
+
+export const hasAnyResources = (
+  amount: ResourceAmount | ResourceStockpile | null | undefined
+): boolean => {
+  if (!amount) {
+    return false;
+  }
+  return RESOURCE_IDS.some((id) => sanitizeResourceValue((amount as Record<ResourceId, number | undefined>)[id]) > 0);
+};

--- a/src/logic/modules/MapModule.ts
+++ b/src/logic/modules/MapModule.ts
@@ -18,6 +18,10 @@ import {
 import { SceneVector2 } from "../services/SceneObjectManager";
 import { buildBricksFromBlueprints } from "../services/BrickLayoutService";
 
+interface ResourceRunController {
+  startRun(): void;
+}
+
 export const MAP_LIST_BRIDGE_KEY = "maps/list";
 export const MAP_SELECTED_BRIDGE_KEY = "maps/selected";
 
@@ -27,6 +31,7 @@ interface MapModuleOptions {
   bricks: BricksModule;
   playerUnits: PlayerUnitsModule;
   necromancer: NecromancerModule;
+  resources: ResourceRunController;
 }
 
 interface MapSaveData {
@@ -80,6 +85,13 @@ export class MapModule implements GameModule {
     this.applyMap(mapId, { generateBricks: true, generateUnits: true });
   }
 
+  public restartSelectedMap(): void {
+    if (!this.selectedMapId) {
+      return;
+    }
+    this.applyMap(this.selectedMapId, { generateBricks: true, generateUnits: true });
+  }
+
   private ensureSelection(options: { generateBricks: boolean; generateUnits: boolean }): void {
     const mapId = this.selectedMapId ?? DEFAULT_MAP_ID;
     this.selectedMapId = mapId;
@@ -105,6 +117,8 @@ export class MapModule implements GameModule {
     this.options.necromancer.configureForMap({
       spawnPoints: spawnUnits.map((unit) => unit.position),
     });
+
+    this.options.resources.startRun();
 
     this.pushSelectedMap();
   }

--- a/src/logic/modules/NecromancerModule.ts
+++ b/src/logic/modules/NecromancerModule.ts
@@ -178,6 +178,15 @@ export class NecromancerModule implements GameModule {
     return true;
   }
 
+  public hasSanityForAnySpawn(): boolean {
+    const currentSanity = this.sanity.current;
+    return PLAYER_UNIT_TYPES.some((type) => {
+      const config = getPlayerUnitConfig(type);
+      const cost = normalizeResourceCost(config.cost);
+      return currentSanity >= cost.sanity;
+    });
+  }
+
   private pushSpawnOptions(): void {
     const options: NecromancerSpawnOption[] = PLAYER_UNIT_TYPES.map((type) => {
       const config = getPlayerUnitConfig(type);

--- a/src/logic/modules/PlayerUnitsModule.ts
+++ b/src/logic/modules/PlayerUnitsModule.ts
@@ -36,6 +36,7 @@ interface PlayerUnitsModuleOptions {
   bricks: BricksModule;
   bridge: DataBridge;
   movement: MovementService;
+  onAllUnitsDefeated?: () => void;
 }
 
 interface PlayerUnitSaveData {
@@ -74,6 +75,7 @@ export class PlayerUnitsModule implements GameModule {
   private readonly bricks: BricksModule;
   private readonly bridge: DataBridge;
   private readonly movement: MovementService;
+  private readonly onAllUnitsDefeated?: () => void;
 
   private units = new Map<string, PlayerUnitState>();
   private unitOrder: PlayerUnitState[] = [];
@@ -84,6 +86,7 @@ export class PlayerUnitsModule implements GameModule {
     this.bricks = options.bricks;
     this.bridge = options.bridge;
     this.movement = options.movement;
+    this.onAllUnitsDefeated = options.onAllUnitsDefeated;
   }
 
   public initialize(): void {
@@ -641,6 +644,9 @@ export class PlayerUnitsModule implements GameModule {
     this.units.delete(unit.id);
     this.unitOrder = this.unitOrder.filter((current) => current.id !== unit.id);
     this.pushStats();
+    if (this.unitOrder.length === 0) {
+      this.onAllUnitsDefeated?.();
+    }
   }
 
   private clearUnits(): void {

--- a/src/logic/modules/ResourcesModule.ts
+++ b/src/logic/modules/ResourcesModule.ts
@@ -1,0 +1,208 @@
+import { DataBridge } from "../core/DataBridge";
+import { GameModule } from "../core/types";
+import {
+  RESOURCE_IDS,
+  ResourceAmount,
+  ResourceId,
+  ResourceStockpile,
+  createEmptyResourceStockpile,
+  getResourceConfig,
+  normalizeResourceAmount,
+  cloneResourceStockpile,
+} from "../../db/resources-db";
+
+export const RESOURCE_TOTALS_BRIDGE_KEY = "resources/totals";
+export const RESOURCE_RUN_SUMMARY_BRIDGE_KEY = "resources/runSummary";
+
+export interface ResourceAmountPayload {
+  id: ResourceId;
+  name: string;
+  amount: number;
+}
+
+export interface ResourceRunSummaryItem extends ResourceAmountPayload {
+  gained: number;
+}
+
+export interface ResourceRunSummaryPayload {
+  completed: boolean;
+  resources: ResourceRunSummaryItem[];
+}
+
+export const DEFAULT_RESOURCE_RUN_SUMMARY: ResourceRunSummaryPayload = Object.freeze({
+  completed: false,
+  resources: [],
+});
+
+interface ResourcesModuleOptions {
+  bridge: DataBridge;
+}
+
+interface ResourcesSaveData {
+  totals: ResourceAmount;
+}
+
+export class ResourcesModule implements GameModule {
+  public readonly id = "resources";
+
+  private readonly bridge: DataBridge;
+  private totals: ResourceStockpile = createEmptyResourceStockpile();
+  private runGains: ResourceStockpile = createEmptyResourceStockpile();
+  private runActive = false;
+  private summaryCompleted = false;
+
+  constructor(options: ResourcesModuleOptions) {
+    this.bridge = options.bridge;
+  }
+
+  public initialize(): void {
+    this.pushTotals();
+    this.pushRunSummary();
+  }
+
+  public reset(): void {
+    this.totals = createEmptyResourceStockpile();
+    this.runGains = createEmptyResourceStockpile();
+    this.runActive = false;
+    this.summaryCompleted = false;
+    this.pushTotals();
+    this.pushRunSummary();
+  }
+
+  public load(data: unknown | undefined): void {
+    const parsed = this.parseSaveData(data);
+    if (parsed) {
+      this.totals = parsed;
+    }
+    this.pushTotals();
+    this.pushRunSummary();
+  }
+
+  public save(): unknown {
+    return {
+      totals: { ...this.totals },
+    } satisfies ResourcesSaveData;
+  }
+
+  public tick(_deltaMs: number): void {
+    // No periodic work required for resource bookkeeping.
+  }
+
+  public startRun(): void {
+    this.runGains = createEmptyResourceStockpile();
+    this.runActive = true;
+    this.summaryCompleted = false;
+    this.pushRunSummary();
+  }
+
+  public finishRun(): void {
+    if (!this.runActive) {
+      return;
+    }
+    this.runActive = false;
+    this.summaryCompleted = true;
+    this.pushRunSummary();
+  }
+
+  public grantResources(amount: ResourceAmount | ResourceStockpile): void {
+    const normalized = normalizeResourceAmount(amount);
+    let changed = false;
+    RESOURCE_IDS.forEach((id) => {
+      const value = normalized[id];
+      if (value > 0) {
+        this.totals[id] += value;
+        this.runGains[id] += value;
+        changed = true;
+      }
+    });
+
+    if (changed) {
+      this.pushTotals();
+      if (this.summaryCompleted || !this.runActive) {
+        this.pushRunSummary();
+      }
+    }
+  }
+
+  public canAfford(amount: ResourceAmount | ResourceStockpile): boolean {
+    const normalized = normalizeResourceAmount(amount);
+    return RESOURCE_IDS.every((id) => this.totals[id] >= normalized[id]);
+  }
+
+  public spendResources(amount: ResourceAmount | ResourceStockpile): boolean {
+    const normalized = normalizeResourceAmount(amount);
+    if (!this.canAfford(normalized)) {
+      return false;
+    }
+
+    RESOURCE_IDS.forEach((id) => {
+      this.totals[id] -= normalized[id];
+    });
+
+    this.pushTotals();
+    if (this.summaryCompleted) {
+      this.pushRunSummary();
+    }
+    return true;
+  }
+
+  public getTotals(): ResourceStockpile {
+    return cloneResourceStockpile(this.totals);
+  }
+
+  public getRunGains(): ResourceStockpile {
+    return cloneResourceStockpile(this.runGains);
+  }
+
+  public isRunSummaryAvailable(): boolean {
+    return this.summaryCompleted;
+  }
+
+  private pushTotals(): void {
+    this.bridge.setValue(RESOURCE_TOTALS_BRIDGE_KEY, this.createTotalsPayload());
+  }
+
+  private pushRunSummary(): void {
+    const payload: ResourceRunSummaryPayload = {
+      completed: this.summaryCompleted,
+      resources: this.createRunSummaryItems(),
+    };
+    this.bridge.setValue(RESOURCE_RUN_SUMMARY_BRIDGE_KEY, payload);
+  }
+
+  private createTotalsPayload(): ResourceAmountPayload[] {
+    return RESOURCE_IDS.map((id) => {
+      const config = getResourceConfig(id);
+      return {
+        id,
+        name: config.name,
+        amount: this.totals[id] ?? 0,
+      };
+    });
+  }
+
+  private createRunSummaryItems(): ResourceRunSummaryItem[] {
+    return RESOURCE_IDS.map((id) => {
+      const config = getResourceConfig(id);
+      return {
+        id,
+        name: config.name,
+        amount: this.totals[id] ?? 0,
+        gained: this.runGains[id] ?? 0,
+      };
+    });
+  }
+
+  private parseSaveData(data: unknown): ResourceStockpile | null {
+    if (
+      typeof data !== "object" ||
+      data === null ||
+      !("totals" in data)
+    ) {
+      return null;
+    }
+
+    const totals = (data as ResourcesSaveData).totals;
+    return normalizeResourceAmount(totals);
+  }
+}

--- a/src/ui/screens/MapSelect/MapSelectScreen.css
+++ b/src/ui/screens/MapSelect/MapSelectScreen.css
@@ -1,22 +1,99 @@
 .map-select-screen {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  padding: 2rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 2.5rem;
+  padding: 2.5rem 3rem;
+  min-height: 100vh;
+  box-sizing: border-box;
+  background: radial-gradient(circle at top left, rgba(22, 32, 52, 0.85), rgba(10, 16, 28, 0.95));
+  color: inherit;
 }
 
-.map-select-screen p {
-  font-size: 1.2rem;
+.map-select-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.map-select-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.map-select-header h1 {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: 0.04em;
+}
+
+.map-select-tabs {
+  display: inline-flex;
+  background: rgba(14, 21, 35, 0.8);
+  padding: 0.35rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(97, 218, 251, 0.25);
+  gap: 0.35rem;
+}
+
+.map-select-tab {
+  border: none;
+  background: transparent;
+  color: rgba(240, 248, 255, 0.7);
+  padding: 0.45rem 1.1rem;
+  border-radius: 9999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.map-select-tab:hover {
+  color: #ffffff;
+}
+
+.map-select-tab.is-active {
+  background: linear-gradient(135deg, rgba(97, 218, 251, 0.25), rgba(97, 218, 251, 0.45));
+  color: #ffffff;
+}
+
+.map-select-panel {
+  background: rgba(10, 16, 28, 0.75);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(97, 218, 251, 0.15);
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.map-select-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.map-select-stats__label {
+  display: block;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.map-select-stats__value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #ffffff;
 }
 
 .map-select-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1.5rem;
-  width: 100%;
-  max-width: 960px;
 }
 
 .map-select-card {
@@ -24,20 +101,20 @@
   flex-direction: column;
   gap: 0.75rem;
   padding: 1.5rem;
-  border-radius: 0.75rem;
-  border: 2px solid rgba(255, 255, 255, 0.1);
-  background: rgba(255, 255, 255, 0.05);
-  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.2);
+  border-radius: 1rem;
+  border: 1px solid rgba(97, 218, 251, 0.15);
+  background: rgba(15, 24, 41, 0.9);
+  box-shadow: 0 1.25rem 2.5rem rgba(0, 0, 0, 0.25);
   transition: border-color 0.2s ease, transform 0.2s ease;
 }
 
 .map-select-card h2 {
   margin: 0;
-  font-size: 1.4rem;
+  font-size: 1.35rem;
 }
 
 .map-select-card.is-selected {
-  border-color: #61dafb;
+  border-color: rgba(97, 218, 251, 0.9);
   transform: translateY(-4px);
 }
 
@@ -50,18 +127,106 @@
 .map-select-details div {
   display: flex;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .map-select-details dt {
   font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .map-select-details dd {
   margin: 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.map-select-empty {
+  grid-column: 1 / -1;
+  padding: 2rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  border: 1px dashed rgba(97, 218, 251, 0.35);
+  border-radius: 1rem;
 }
 
 .map-select-actions {
   display: flex;
+  justify-content: flex-end;
   gap: 1rem;
+}
+
+.map-select-sidebar {
+  background: rgba(10, 16, 28, 0.65);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(97, 218, 251, 0.2);
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.map-select-sidebar__title {
+  margin: 0;
+  font-size: 1.4rem;
+  letter-spacing: 0.05em;
+}
+
+.map-select-resources {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.map-select-resources__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 24, 41, 0.85);
+  border: 1px solid rgba(97, 218, 251, 0.15);
+}
+
+.map-select-resources__name {
+  font-weight: 600;
+}
+
+.map-select-resources__value {
+  font-weight: 700;
+}
+
+.map-select-resources__empty {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.map-select-skill-placeholder {
+  text-align: center;
+  padding: 3rem 1rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(97, 218, 251, 0.3);
+  background: rgba(12, 18, 30, 0.65);
+  color: rgba(255, 255, 255, 0.75);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.map-select-skill-placeholder h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+@media (max-width: 1024px) {
+  .map-select-screen {
+    grid-template-columns: 1fr;
+  }
+
+  .map-select-sidebar {
+    order: -1;
+  }
 }

--- a/src/ui/screens/MapSelect/MapSelectScreen.tsx
+++ b/src/ui/screens/MapSelect/MapSelectScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "../../shared/Button";
 import { useAppLogic } from "../../contexts/AppLogicContext";
 import { useBridgeValue } from "../../shared/useBridgeValue";
@@ -10,12 +10,18 @@ import {
   MapListEntry,
 } from "../../../logic/modules/MapModule";
 import { MapId } from "../../../db/maps-db";
+import {
+  RESOURCE_TOTALS_BRIDGE_KEY,
+  ResourceAmountPayload,
+} from "../../../logic/modules/ResourcesModule";
 import "./MapSelectScreen.css";
 
 interface MapSelectScreenProps {
   onStart: () => void;
   onExit: () => void;
 }
+
+type MapSelectTab = "maps" | "skills";
 
 const formatTime = (timeMs: number): string => {
   const totalSeconds = Math.floor(timeMs / 1000);
@@ -26,63 +32,141 @@ const formatTime = (timeMs: number): string => {
   return `${minutes}:${seconds}`;
 };
 
+const SkillTreePlaceholder: React.FC = () => (
+  <div className="map-select-skill-placeholder">
+    <h2>Skill Tree</h2>
+    <p>Research in progress. Unlocks and upgrades will appear here in a future update.</p>
+  </div>
+);
+
 export const MapSelectScreen: React.FC<MapSelectScreenProps> = ({ onStart, onExit }) => {
   const { app, bridge } = useAppLogic();
+  const [activeTab, setActiveTab] = useState<MapSelectTab>("maps");
   const timePlayed = useBridgeValue<number>(bridge, TIME_BRIDGE_KEY, 0);
   const brickCount = useBridgeValue<number>(bridge, BRICK_COUNT_BRIDGE_KEY, 0);
   const maps = useBridgeValue<MapListEntry[]>(bridge, MAP_LIST_BRIDGE_KEY, []);
   const selectedMap = useBridgeValue<MapId | null>(bridge, MAP_SELECTED_BRIDGE_KEY, null);
+  const resources = useBridgeValue<ResourceAmountPayload[]>(
+    bridge,
+    RESOURCE_TOTALS_BRIDGE_KEY,
+    []
+  );
 
   const formatted = useMemo(() => formatTime(timePlayed), [timePlayed]);
-  const canStart = maps.length === 0 ? false : selectedMap !== null;
+  const canStart = maps.length > 0 && selectedMap !== null;
 
   return (
     <div className="map-select-screen">
-      <h1>Map Selection</h1>
-      <p>Time played: {formatted}</p>
-      <p>Particles on map: {brickCount}</p>
-      <div className="map-select-list">
-        {maps.map((map) => {
-          const isSelected = map.id === selectedMap;
-          return (
-            <div
-              key={map.id}
-              className={`map-select-card${isSelected ? " is-selected" : ""}`}
+      <div className="map-select-main">
+        <header className="map-select-header">
+          <h1>Command Center</h1>
+          <div className="map-select-tabs">
+            <button
+              type="button"
+              className={`map-select-tab${activeTab === "maps" ? " is-active" : ""}`}
+              onClick={() => setActiveTab("maps")}
             >
-              <h2>{map.name}</h2>
-              <dl className="map-select-details">
+              Map Selector
+            </button>
+            <button
+              type="button"
+              className={`map-select-tab${activeTab === "skills" ? " is-active" : ""}`}
+              onClick={() => setActiveTab("skills")}
+            >
+              Skill Tree
+            </button>
+          </div>
+        </header>
+
+        <div className="map-select-panel">
+          {activeTab === "maps" ? (
+            <>
+              <div className="map-select-stats">
                 <div>
-                  <dt>Size</dt>
-                  <dd>
-                    {map.size.width} × {map.size.height}
-                  </dd>
+                  <span className="map-select-stats__label">Time played</span>
+                  <span className="map-select-stats__value">{formatted}</span>
                 </div>
                 <div>
-                  <dt>Particles</dt>
-                  <dd>{map.brickCount}</dd>
+                  <span className="map-select-stats__label">Particles on map</span>
+                  <span className="map-select-stats__value">{brickCount}</span>
                 </div>
-                <div>
-                  <dt>Types</dt>
-                  <dd>{map.brickTypes.join(", ")}</dd>
-                </div>
-              </dl>
-              <Button
-                onClick={() => {
-                  app.selectMap(map.id);
-                }}
-              >
-                {isSelected ? "Selected" : "Select"}
-              </Button>
-            </div>
-          );
-        })}
+              </div>
+              <div className="map-select-list">
+                {maps.map((map) => {
+                  const isSelected = map.id === selectedMap;
+                  return (
+                    <div
+                      key={map.id}
+                      className={`map-select-card${isSelected ? " is-selected" : ""}`}
+                    >
+                      <h2>{map.name}</h2>
+                      <dl className="map-select-details">
+                        <div>
+                          <dt>Size</dt>
+                          <dd>
+                            {map.size.width} × {map.size.height}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt>Particles</dt>
+                          <dd>{map.brickCount}</dd>
+                        </div>
+                        <div>
+                          <dt>Types</dt>
+                          <dd>{map.brickTypes.join(", ")}</dd>
+                        </div>
+                      </dl>
+                      <Button
+                        onClick={() => {
+                          app.selectMap(map.id);
+                        }}
+                      >
+                        {isSelected ? "Selected" : "Select"}
+                      </Button>
+                    </div>
+                  );
+                })}
+                {maps.length === 0 && (
+                  <div className="map-select-empty">No maps available yet.</div>
+                )}
+              </div>
+              <div className="map-select-actions">
+                <Button
+                  onClick={() => {
+                    if (!canStart) {
+                      return;
+                    }
+                    app.restartCurrentMap();
+                    onStart();
+                  }}
+                  disabled={!canStart}
+                >
+                  Start
+                </Button>
+                <Button onClick={onExit}>Main Menu</Button>
+              </div>
+            </>
+          ) : (
+            <SkillTreePlaceholder />
+          )}
+        </div>
       </div>
-      <div className="map-select-actions">
-        <Button onClick={onStart} disabled={!canStart}>
-          Start
-        </Button>
-        <Button onClick={onExit}>Main Menu</Button>
-      </div>
+
+      <aside className="map-select-sidebar">
+        <h2 className="map-select-sidebar__title">Resources</h2>
+        {resources.length > 0 ? (
+          <ul className="map-select-resources">
+            {resources.map((resource) => (
+              <li key={resource.id} className="map-select-resources__item">
+                <span className="map-select-resources__name">{resource.name}</span>
+                <span className="map-select-resources__value">{resource.amount}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="map-select-resources__empty">No resources collected yet.</p>
+        )}
+      </aside>
     </div>
   );
 };

--- a/src/ui/screens/Scene/SceneRunSummaryModal.css
+++ b/src/ui/screens/Scene/SceneRunSummaryModal.css
@@ -1,0 +1,95 @@
+.scene-run-summary {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+  pointer-events: none;
+}
+
+.scene-run-summary__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(6, 12, 24, 0.75);
+  backdrop-filter: blur(6px);
+  pointer-events: auto;
+}
+
+.scene-run-summary__dialog {
+  position: relative;
+  max-width: 420px;
+  width: calc(100% - 3rem);
+  padding: 2rem;
+  border-radius: 1rem;
+  background: linear-gradient(180deg, rgba(22, 35, 58, 0.95), rgba(12, 20, 36, 0.95));
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(97, 218, 251, 0.35);
+  pointer-events: auto;
+  color: #f6fbff;
+}
+
+.scene-run-summary__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+  text-align: center;
+}
+
+.scene-run-summary__subtitle {
+  margin: 0 0 1.25rem;
+  text-align: center;
+  color: rgba(246, 251, 255, 0.75);
+}
+
+.scene-run-summary__list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.scene-run-summary__list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(9, 17, 32, 0.75);
+  border: 1px solid rgba(97, 218, 251, 0.15);
+}
+
+.scene-run-summary__resource-name {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.scene-run-summary__resource-amount {
+  font-weight: 700;
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.scene-run-summary__resource-delta {
+  font-size: 0.95rem;
+  color: #61dafb;
+}
+
+.scene-run-summary__empty {
+  margin: 0 0 1.5rem;
+  text-align: center;
+  color: rgba(246, 251, 255, 0.7);
+}
+
+.scene-run-summary__actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.scene-run-summary__actions .button {
+  min-width: 120px;
+}

--- a/src/ui/screens/Scene/SceneRunSummaryModal.tsx
+++ b/src/ui/screens/Scene/SceneRunSummaryModal.tsx
@@ -1,0 +1,53 @@
+import { ResourceRunSummaryItem } from "../../../logic/modules/ResourcesModule";
+import { Button } from "../../shared/Button";
+import "./SceneRunSummaryModal.css";
+
+interface SceneRunSummaryModalProps {
+  resources: ResourceRunSummaryItem[];
+  onLeave: () => void;
+  onRestart: () => void;
+}
+
+const formatDelta = (value: number): string => {
+  if (value <= 0) {
+    return `(+0)`;
+  }
+  return `(+${value})`;
+};
+
+export const SceneRunSummaryModal: React.FC<SceneRunSummaryModalProps> = ({
+  resources,
+  onLeave,
+  onRestart,
+}) => {
+  const hasResources = resources.length > 0;
+
+  return (
+    <div className="scene-run-summary">
+      <div className="scene-run-summary__backdrop" />
+      <div className="scene-run-summary__dialog">
+        <h2 className="scene-run-summary__title">Run Complete</h2>
+        <p className="scene-run-summary__subtitle">Resources recovered from the ruins:</p>
+        {hasResources ? (
+          <ul className="scene-run-summary__list">
+            {resources.map((resource) => (
+              <li key={resource.id} className="scene-run-summary__list-item">
+                <span className="scene-run-summary__resource-name">{resource.name}</span>
+                <span className="scene-run-summary__resource-amount">
+                  {resource.amount}
+                  <span className="scene-run-summary__resource-delta">{formatDelta(resource.gained)}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="scene-run-summary__empty">No resources gathered this time.</p>
+        )}
+        <div className="scene-run-summary__actions">
+          <Button onClick={onLeave}>Leave</Button>
+          <Button onClick={onRestart}>Restart</Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/tests/BricksModule.test.ts
+++ b/tests/BricksModule.test.ts
@@ -17,7 +17,12 @@ import { describe, test } from "./testRunner";
 
 const createBricksModule = (scene: SceneObjectManager, bridge: DataBridge) => {
   const explosions = new ExplosionModule({ scene });
-  return new BricksModule({ scene, bridge, explosions });
+  const resources = {
+    grantResources: () => {
+      // no-op for tests
+    },
+  };
+  return new BricksModule({ scene, bridge, explosions, resources });
 };
 
 describe("BricksModule", () => {

--- a/tests/MapModule.test.ts
+++ b/tests/MapModule.test.ts
@@ -20,7 +20,15 @@ describe("MapModule", () => {
     const scene = new SceneObjectManager();
     const bridge = new DataBridge();
     const explosions = new ExplosionModule({ scene });
-    const bricks = new BricksModule({ scene, bridge, explosions });
+    const resources = {
+      startRun: () => {
+        // no-op for tests
+      },
+      grantResources: () => {
+        // no-op for tests
+      },
+    };
+    const bricks = new BricksModule({ scene, bridge, explosions, resources });
     const movement = new MovementService();
     const playerUnits = new PlayerUnitsModule({ scene, bricks, bridge, movement });
     const necromancer = new NecromancerModule({
@@ -28,7 +36,14 @@ describe("MapModule", () => {
       playerUnits,
       scene,
     });
-    const maps = new MapModule({ scene, bridge, bricks, playerUnits, necromancer });
+    const maps = new MapModule({
+      scene,
+      bridge,
+      bricks,
+      playerUnits,
+      necromancer,
+      resources,
+    });
 
     necromancer.initialize();
     maps.initialize();

--- a/tests/PlayerUnitsModule.test.ts
+++ b/tests/PlayerUnitsModule.test.ts
@@ -12,7 +12,12 @@ import { ExplosionModule } from "../src/logic/modules/ExplosionModule";
 
 const createBricksModule = (scene: SceneObjectManager, bridge: DataBridge) => {
   const explosions = new ExplosionModule({ scene });
-  return new BricksModule({ scene, bridge, explosions });
+  const resources = {
+    grantResources: () => {
+      // no-op for tests
+    },
+  };
+  return new BricksModule({ scene, bridge, explosions, resources });
 };
 
 const tickSeconds = (module: PlayerUnitsModule, seconds: number) => {


### PR DESCRIPTION
## Summary
- introduce a resource database and rewards for bricks, then track totals with a new ResourcesModule that integrates into the application flow
- trigger a post-run summary when no units remain and sanity is insufficient, showing a SceneRunSummaryModal that awards and displays collected resources
- redesign the map select screen with map/skill tabs, a persistent resource sidebar, and restart the selected map when starting a run

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2c81501408320a8a0903d3719bfb5