### PR TITLE
Implement skill tree database, module, and Map Select UI

### DIFF
--- a/src/db/skills-db.ts
+++ b/src/db/skills-db.ts
@@ -1,0 +1,143 @@
+import { ResourceAmount } from "./resources-db";
+
+export interface SkillNodePosition {
+  readonly x: number;
+  readonly y: number;
+}
+
+export type SkillCostFunction = (level: number) => ResourceAmount;
+
+export interface SkillConfig {
+  readonly id: SkillId;
+  readonly name: string;
+  readonly description: string;
+  readonly nodePosition: SkillNodePosition;
+  readonly maxLevel: number;
+  readonly effects: Record<string, unknown>;
+  readonly nodesRequired: Partial<Record<SkillId, number>>;
+  readonly cost: SkillCostFunction;
+}
+
+export const SKILL_IDS = [
+  "stone_lore",
+  "quarry_overseers",
+  "granite_bonding",
+  "bastion_foundations",
+  "sand_scribing",
+  "glass_latticework",
+  "emberglass_reactors",
+] as const;
+
+export type SkillId = (typeof SKILL_IDS)[number];
+
+const createStoneCost = (base: number, growth: number) =>
+  (level: number): ResourceAmount => ({
+    stone: Math.ceil(base * Math.pow(growth, Math.max(level, 1))),
+  });
+
+const createSandCost = (base: number, growth: number) =>
+  (level: number): ResourceAmount => ({
+    sand: Math.ceil(base * Math.pow(growth, Math.max(level, 1))),
+  });
+
+const createMixedCost = (
+  stoneBase: number,
+  stoneGrowth: number,
+  sandBase: number,
+  sandGrowth: number
+) =>
+  (level: number): ResourceAmount => ({
+    stone: Math.ceil(stoneBase * Math.pow(stoneGrowth, Math.max(level, 1))),
+    sand: Math.ceil(sandBase * Math.pow(sandGrowth, Math.max(level, 1))),
+  });
+
+const SKILL_DB: Record<SkillId, SkillConfig> = {
+  stone_lore: {
+    id: "stone_lore",
+    name: "Stone Lore",
+    description:
+      "Foundational studies in sorting shattered bricks, enabling steadier stone yields.",
+    nodePosition: { x: 0, y: 0 },
+    maxLevel: 3,
+    effects: {},
+    nodesRequired: {},
+    cost: createStoneCost(6, 1.35),
+  },
+  quarry_overseers: {
+    id: "quarry_overseers",
+    name: "Quarry Overseers",
+    description:
+      "Assign dedicated haulers who keep rubble moving and expose richer stone veins.",
+    nodePosition: { x: -1, y: 1 },
+    maxLevel: 4,
+    effects: {},
+    nodesRequired: { stone_lore: 1 },
+    cost: createStoneCost(10, 1.4),
+  },
+  granite_bonding: {
+    id: "granite_bonding",
+    name: "Granite Bonding",
+    description:
+      "Fuse heavy chunks together, forming denser stockpiles that resist crumble losses.",
+    nodePosition: { x: -2, y: 2 },
+    maxLevel: 3,
+    effects: {},
+    nodesRequired: { quarry_overseers: 2 },
+    cost: createStoneCost(16, 1.5),
+  },
+  bastion_foundations: {
+    id: "bastion_foundations",
+    name: "Bastion Foundations",
+    description:
+      "Lay channelled footings so every slab stacks true, preparing for future defenses.",
+    nodePosition: { x: -1, y: 3 },
+    maxLevel: 2,
+    effects: {},
+    nodesRequired: { granite_bonding: 1 },
+    cost: createMixedCost(18, 1.5, 6, 1.25),
+  },
+  sand_scribing: {
+    id: "sand_scribing",
+    name: "Sand Scribing",
+    description:
+      "Refine sieving rituals that separate glimmering sand from dull dust motes.",
+    nodePosition: { x: 1, y: 1 },
+    maxLevel: 4,
+    effects: {},
+    nodesRequired: { stone_lore: 1 },
+    cost: createSandCost(8, 1.35),
+  },
+  glass_latticework: {
+    id: "glass_latticework",
+    name: "Glass Latticework",
+    description:
+      "Weave molten filaments into frameworks that stabilize fragile sand constructs.",
+    nodePosition: { x: 2, y: 2 },
+    maxLevel: 3,
+    effects: {},
+    nodesRequired: { sand_scribing: 2 },
+    cost: createSandCost(14, 1.45),
+  },
+  emberglass_reactors: {
+    id: "emberglass_reactors",
+    name: "Emberglass Reactors",
+    description:
+      "Channel heat through mirrored chambers, transmuting sand surges into lasting stores.",
+    nodePosition: { x: 1, y: 3 },
+    maxLevel: 2,
+    effects: {},
+    nodesRequired: { glass_latticework: 1 },
+    cost: createMixedCost(20, 1.55, 12, 1.4),
+  },
+};
+
+export const getSkillConfig = (id: SkillId): SkillConfig => {
+  const config = SKILL_DB[id];
+  if (!config) {
+    throw new Error(`Unknown skill id: ${id}`);
+  }
+  return config;
+};
+
+export const getAllSkillConfigs = (): SkillConfig[] =>
+  SKILL_IDS.map((id) => SKILL_DB[id]);

--- a/src/logic/core/Application.ts
+++ b/src/logic/core/Application.ts
@@ -14,6 +14,7 @@ import { PlayerUnitsModule } from "../modules/PlayerUnitsModule";
 import { MovementService } from "../services/MovementService";
 import { NecromancerModule } from "../modules/NecromancerModule";
 import { ResourcesModule } from "../modules/ResourcesModule";
+import { SkillTreeModule } from "../modules/SkillTreeModule";
 
 export class Application {
   private serviceContainer = new ServiceContainer();
@@ -22,6 +23,7 @@ export class Application {
   private mapModule: MapModule;
   private necromancerModule: NecromancerModule;
   private resourcesModule: ResourcesModule;
+  private skillTreeModule: SkillTreeModule;
 
   constructor() {
     const saveManager = new SaveManager();
@@ -39,6 +41,12 @@ export class Application {
       bridge: this.dataBridge,
     });
     this.resourcesModule = resourcesModule;
+
+    const skillTreeModule = new SkillTreeModule({
+      bridge: this.dataBridge,
+      resources: resourcesModule,
+    });
+    this.skillTreeModule = skillTreeModule;
 
     const timeModule = new TestTimeModule({
       bridge: this.dataBridge,
@@ -83,6 +91,7 @@ export class Application {
     });
 
     this.registerModule(resourcesModule);
+    this.registerModule(skillTreeModule);
     this.registerModule(timeModule);
     this.registerModule(bricksModule);
     this.registerModule(playerUnitsModule);
@@ -139,6 +148,10 @@ export class Application {
 
   public getNecromancer(): NecromancerModule {
     return this.necromancerModule;
+  }
+
+  public getSkillTree(): SkillTreeModule {
+    return this.skillTreeModule;
   }
 
   public restartCurrentMap(): void {

--- a/src/logic/modules/SkillTreeModule.ts
+++ b/src/logic/modules/SkillTreeModule.ts
@@ -1,0 +1,212 @@
+import { DataBridge } from "../core/DataBridge";
+import { GameModule } from "../core/types";
+import {
+  SKILL_IDS,
+  SkillConfig,
+  SkillId,
+  SkillNodePosition,
+  getSkillConfig,
+} from "../../db/skills-db";
+import {
+  RESOURCE_IDS,
+  ResourceStockpile,
+  createEmptyResourceStockpile,
+  normalizeResourceAmount,
+} from "../../db/resources-db";
+import { ResourcesModule } from "./ResourcesModule";
+
+export const SKILL_TREE_STATE_BRIDGE_KEY = "skills/tree";
+
+export interface SkillNodeRequirementPayload {
+  id: SkillId;
+  requiredLevel: number;
+  currentLevel: number;
+}
+
+export interface SkillNodeBridgePayload {
+  id: SkillId;
+  name: string;
+  description: string;
+  level: number;
+  maxLevel: number;
+  position: SkillNodePosition;
+  requirements: SkillNodeRequirementPayload[];
+  unlocked: boolean;
+  maxed: boolean;
+  nextCost: ResourceStockpile | null;
+}
+
+export interface SkillTreeBridgePayload {
+  nodes: SkillNodeBridgePayload[];
+}
+
+export const DEFAULT_SKILL_TREE_STATE: SkillTreeBridgePayload = Object.freeze({
+  nodes: [],
+});
+
+interface SkillTreeModuleOptions {
+  bridge: DataBridge;
+  resources: ResourcesModule;
+}
+
+interface SkillTreeSaveData {
+  levels: Partial<Record<SkillId, number>>;
+}
+
+type SkillLevelMap = Record<SkillId, number>;
+
+const createDefaultLevels = (): SkillLevelMap => {
+  const levels = {} as SkillLevelMap;
+  SKILL_IDS.forEach((id) => {
+    levels[id] = 0;
+  });
+  return levels;
+};
+
+const clampLevel = (value: number, config: SkillConfig): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  const sanitized = Math.floor(Math.max(value, 0));
+  return Math.min(sanitized, config.maxLevel);
+};
+
+export class SkillTreeModule implements GameModule {
+  public readonly id = "skillTree";
+
+  private readonly bridge: DataBridge;
+  private readonly resources: ResourcesModule;
+  private levels: SkillLevelMap = createDefaultLevels();
+
+  constructor(options: SkillTreeModuleOptions) {
+    this.bridge = options.bridge;
+    this.resources = options.resources;
+  }
+
+  public initialize(): void {
+    this.pushState();
+  }
+
+  public reset(): void {
+    this.levels = createDefaultLevels();
+    this.pushState();
+  }
+
+  public load(data: unknown | undefined): void {
+    const parsed = this.parseSaveData(data);
+    if (parsed) {
+      this.levels = parsed;
+    }
+    this.pushState();
+  }
+
+  public save(): unknown {
+    return {
+      levels: { ...this.levels },
+    } satisfies SkillTreeSaveData;
+  }
+
+  public tick(_deltaMs: number): void {
+    // Skill upgrades do not require periodic updates yet.
+  }
+
+  public tryPurchaseSkill(id: SkillId): boolean {
+    const config = getSkillConfig(id);
+    const currentLevel = this.levels[id] ?? 0;
+
+    if (currentLevel >= config.maxLevel) {
+      return false;
+    }
+    if (!this.areRequirementsMet(config)) {
+      return false;
+    }
+
+    const targetLevel = currentLevel + 1;
+    const cost = normalizeResourceAmount(config.cost(targetLevel));
+    if (!this.resources.spendResources(cost)) {
+      return false;
+    }
+
+    this.levels[id] = targetLevel;
+    this.pushState();
+    return true;
+  }
+
+  public getLevel(id: SkillId): number {
+    return this.levels[id] ?? 0;
+  }
+
+  private areRequirementsMet(config: SkillConfig): boolean {
+    return Object.entries(config.nodesRequired).every(([requiredId, level]) => {
+      const id = requiredId as SkillId;
+      return (this.levels[id] ?? 0) >= (level ?? 0);
+    });
+  }
+
+  private pushState(): void {
+    const payload: SkillTreeBridgePayload = {
+      nodes: SKILL_IDS.map((id) => this.createNodePayload(id)),
+    };
+    this.bridge.setValue(SKILL_TREE_STATE_BRIDGE_KEY, payload);
+  }
+
+  private createNodePayload(id: SkillId): SkillNodeBridgePayload {
+    const config = getSkillConfig(id);
+    const level = this.levels[id] ?? 0;
+    const unlocked = this.areRequirementsMet(config);
+    const nextLevel = level + 1;
+    const nextCost =
+      unlocked && nextLevel <= config.maxLevel
+        ? this.cloneCost(normalizeResourceAmount(config.cost(nextLevel)))
+        : null;
+
+    return {
+      id,
+      name: config.name,
+      description: config.description,
+      level,
+      maxLevel: config.maxLevel,
+      position: config.nodePosition,
+      requirements: this.createRequirementPayloads(config),
+      unlocked,
+      maxed: level >= config.maxLevel,
+      nextCost,
+    };
+  }
+
+  private createRequirementPayloads(config: SkillConfig): SkillNodeRequirementPayload[] {
+    return Object.entries(config.nodesRequired).map(([requiredId, requiredLevel]) => {
+      const id = requiredId as SkillId;
+      return {
+        id,
+        requiredLevel: requiredLevel ?? 0,
+        currentLevel: this.levels[id] ?? 0,
+      };
+    });
+  }
+
+  private cloneCost(source: ResourceStockpile): ResourceStockpile {
+    const clone = createEmptyResourceStockpile();
+    RESOURCE_IDS.forEach((id) => {
+      clone[id] = source[id];
+    });
+    return clone;
+  }
+
+  private parseSaveData(data: unknown): SkillLevelMap | null {
+    if (!data || typeof data !== "object" || !("levels" in data)) {
+      return null;
+    }
+
+    const { levels } = data as SkillTreeSaveData;
+    const next = createDefaultLevels();
+    SKILL_IDS.forEach((id) => {
+      const config = getSkillConfig(id);
+      const raw = levels?.[id];
+      if (typeof raw === "number") {
+        next[id] = clampLevel(raw, config);
+      }
+    });
+    return next;
+  }
+}

--- a/src/types/resources.ts
+++ b/src/types/resources.ts
@@ -3,6 +3,7 @@ export type ResourceType = "mana" | "sanity";
 export interface ResourceAmountMap {
   mana: number;
   sanity: number;
+  [key: string]: number;
 }
 
 export type ResourceCost = Partial<ResourceAmountMap>;

--- a/src/ui/screens/MapSelect/MapSelectScreen.tsx
+++ b/src/ui/screens/MapSelect/MapSelectScreen.tsx
@@ -14,6 +14,7 @@ import {
   RESOURCE_TOTALS_BRIDGE_KEY,
   ResourceAmountPayload,
 } from "../../../logic/modules/ResourcesModule";
+import { SkillTreeView } from "./SkillTree/SkillTreeView";
 import "./MapSelectScreen.css";
 
 interface MapSelectScreenProps {
@@ -31,13 +32,6 @@ const formatTime = (timeMs: number): string => {
   const seconds = (totalSeconds % 60).toString().padStart(2, "0");
   return `${minutes}:${seconds}`;
 };
-
-const SkillTreePlaceholder: React.FC = () => (
-  <div className="map-select-skill-placeholder">
-    <h2>Skill Tree</h2>
-    <p>Research in progress. Unlocks and upgrades will appear here in a future update.</p>
-  </div>
-);
 
 export const MapSelectScreen: React.FC<MapSelectScreenProps> = ({ onStart, onExit }) => {
   const { app, bridge } = useAppLogic();
@@ -147,7 +141,7 @@ export const MapSelectScreen: React.FC<MapSelectScreenProps> = ({ onStart, onExi
               </div>
             </>
           ) : (
-            <SkillTreePlaceholder />
+            <SkillTreeView />
           )}
         </div>
       </div>

--- a/src/ui/screens/MapSelect/SkillTree/SkillTreeView.css
+++ b/src/ui/screens/MapSelect/SkillTree/SkillTreeView.css
@@ -1,0 +1,246 @@
+.skill-tree {
+  display: flex;
+  gap: 2rem;
+  align-items: stretch;
+}
+
+.skill-tree__viewport {
+  flex: 1;
+  position: relative;
+  padding: 1rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.85), rgba(8, 13, 25, 0.92));
+  box-shadow: inset 0 0 32px rgba(0, 0, 0, 0.35);
+  overflow: auto;
+}
+
+.skill-tree__canvas {
+  position: relative;
+  min-height: 320px;
+  min-width: 360px;
+}
+
+.skill-tree__links {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.skill-tree__link {
+  stroke-width: 4;
+  stroke-linecap: round;
+  opacity: 0.85;
+}
+
+.skill-tree__link--fulfilled {
+  stroke: rgba(203, 213, 225, 0.85);
+}
+
+.skill-tree__link--locked {
+  stroke: rgba(250, 204, 21, 0.85);
+  stroke-dasharray: 14 10;
+}
+
+.skill-tree-node {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 78px;
+  height: 78px;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.35);
+  background: radial-gradient(circle at 35% 30%, rgba(148, 163, 184, 0.25), rgba(15, 23, 42, 0.9));
+  color: #e2e8f0;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.skill-tree-node--inactive {
+  cursor: default;
+  opacity: 0.9;
+}
+
+.skill-tree-node__level {
+  position: absolute;
+  top: -1.8rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+}
+
+.skill-tree-node__icon {
+  font-size: 1.35rem;
+}
+
+.skill-tree-node--locked {
+  border-color: rgba(250, 204, 21, 0.65);
+  background: radial-gradient(circle at 30% 30%, rgba(254, 240, 138, 0.22), rgba(59, 7, 24, 0.6));
+  color: rgba(252, 211, 77, 0.85);
+}
+
+.skill-tree-node--unlocked {
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.skill-tree-node--available {
+  box-shadow: 0 0 0 0 rgba(96, 165, 250, 0.35);
+}
+
+.skill-tree-node--available:not(:disabled):hover {
+  transform: translate(-50%, -50%) scale(1.05);
+  box-shadow: 0 0 18px rgba(96, 165, 250, 0.45);
+  border-color: rgba(96, 165, 250, 0.75);
+}
+
+.skill-tree-node--affordable:not(:disabled) {
+  border-color: rgba(34, 197, 94, 0.75);
+  box-shadow: 0 0 22px rgba(34, 197, 94, 0.25);
+}
+
+.skill-tree-node--affordable:not(:disabled):hover {
+  box-shadow: 0 0 26px rgba(34, 197, 94, 0.45);
+}
+
+.skill-tree-node--maxed {
+  border-color: rgba(147, 197, 253, 0.85);
+  background: radial-gradient(circle at 40% 30%, rgba(191, 219, 254, 0.35), rgba(30, 41, 59, 0.9));
+}
+
+.skill-tree-node--active {
+  box-shadow: 0 0 28px rgba(129, 140, 248, 0.45);
+  border-color: rgba(129, 140, 248, 0.85);
+}
+
+.skill-tree__empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.skill-tree__details {
+  width: 320px;
+  flex-shrink: 0;
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.35);
+}
+
+.skill-tree__details-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.skill-tree__details-header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+  letter-spacing: 0.06em;
+}
+
+.skill-tree__details-level {
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.skill-tree__details-description {
+  margin: 0;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.skill-tree__details-section h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 255, 0.95);
+}
+
+.skill-tree__requirements {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skill-tree__requirement {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(234, 179, 8, 0.35);
+  background: rgba(74, 20, 20, 0.35);
+  color: rgba(252, 211, 77, 0.9);
+  font-size: 0.85rem;
+}
+
+.skill-tree__requirement--met {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.skill-tree__requirement-name {
+  font-weight: 600;
+}
+
+.skill-tree__requirement-level {
+  font-family: "IBM Plex Mono", monospace;
+  letter-spacing: 0.1em;
+}
+
+.skill-tree__requirements-empty,
+.skill-tree__maxed,
+.skill-tree__details-empty {
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.skill-tree__details-cost {
+  display: inline-flex;
+  gap: 0.75rem;
+}
+
+.skill-tree__hint {
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(94, 234, 212, 0.9);
+}
+
+@media (max-width: 1200px) {
+  .skill-tree {
+    flex-direction: column;
+  }
+
+  .skill-tree__details {
+    width: 100%;
+  }
+}

--- a/src/ui/screens/MapSelect/SkillTree/SkillTreeView.tsx
+++ b/src/ui/screens/MapSelect/SkillTree/SkillTreeView.tsx
@@ -1,0 +1,353 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAppLogic } from "../../../contexts/AppLogicContext";
+import { useBridgeValue } from "../../../shared/useBridgeValue";
+import {
+  DEFAULT_SKILL_TREE_STATE,
+  SKILL_TREE_STATE_BRIDGE_KEY,
+  SkillNodeBridgePayload,
+  SkillTreeBridgePayload,
+} from "../../../../logic/modules/SkillTreeModule";
+import {
+  RESOURCE_TOTALS_BRIDGE_KEY,
+  ResourceAmountPayload,
+} from "../../../../logic/modules/ResourcesModule";
+import {
+  RESOURCE_IDS,
+  ResourceId,
+  ResourceStockpile,
+  createEmptyResourceStockpile,
+  getResourceConfig,
+} from "../../../../db/resources-db";
+import { SkillId, getSkillConfig } from "../../../../db/skills-db";
+import { ResourceCostDisplay } from "../../../shared/ResourceCostDisplay";
+import "./SkillTreeView.css";
+
+const CELL_SIZE_X = 180;
+const CELL_SIZE_Y = 170;
+const TREE_MARGIN = 120;
+
+interface SkillTreeEdge {
+  id: string;
+  from: { x: number; y: number };
+  to: { x: number; y: number };
+  fulfilled: boolean;
+}
+
+interface SkillTreeLayout {
+  width: number;
+  height: number;
+  positions: Map<SkillId, { x: number; y: number }>;
+  edges: SkillTreeEdge[];
+}
+
+const SKILL_TREE_RESOURCES = RESOURCE_IDS.map((id) => {
+  const config = getResourceConfig(id);
+  return { id: config.id, label: config.name };
+});
+
+const computeLayout = (nodes: SkillNodeBridgePayload[]): SkillTreeLayout => {
+  if (nodes.length === 0) {
+    return {
+      width: 0,
+      height: 0,
+      positions: new Map(),
+      edges: [],
+    };
+  }
+
+  const first = nodes[0];
+  if (!first) {
+    return {
+      width: 0,
+      height: 0,
+      positions: new Map(),
+      edges: [],
+    };
+  }
+
+  let minX = first.position.x;
+  let maxX = first.position.x;
+  let minY = first.position.y;
+  let maxY = first.position.y;
+
+  nodes.forEach((node) => {
+    minX = Math.min(minX, node.position.x);
+    maxX = Math.max(maxX, node.position.x);
+    minY = Math.min(minY, node.position.y);
+    maxY = Math.max(maxY, node.position.y);
+  });
+
+  const width = (maxX - minX) * CELL_SIZE_X + TREE_MARGIN * 2;
+  const height = (maxY - minY) * CELL_SIZE_Y + TREE_MARGIN * 2;
+  const offsetX = TREE_MARGIN - minX * CELL_SIZE_X;
+  const offsetY = TREE_MARGIN - minY * CELL_SIZE_Y;
+
+  const positions = new Map<SkillId, { x: number; y: number }>();
+  nodes.forEach((node) => {
+    positions.set(node.id, {
+      x: offsetX + node.position.x * CELL_SIZE_X,
+      y: offsetY + node.position.y * CELL_SIZE_Y,
+    });
+  });
+
+  const edges: SkillTreeEdge[] = [];
+  nodes.forEach((node) => {
+    const to = positions.get(node.id);
+    if (!to) {
+      return;
+    }
+    node.requirements.forEach((requirement) => {
+      const from = positions.get(requirement.id);
+      if (!from) {
+        return;
+      }
+      edges.push({
+        id: `${requirement.id}->${node.id}`,
+        from,
+        to,
+        fulfilled: requirement.currentLevel >= requirement.requiredLevel,
+      });
+    });
+  });
+
+  return {
+    width,
+    height,
+    positions,
+    edges,
+  };
+};
+
+const toTotalsMap = (totals: ResourceAmountPayload[]): Record<ResourceId, number> => {
+  const map = createEmptyResourceStockpile();
+  totals.forEach((resource) => {
+    const id = resource.id as ResourceId;
+    map[id] = resource.amount;
+  });
+  return map;
+};
+
+const computeMissing = (
+  cost: ResourceStockpile | null,
+  totals: Record<ResourceId, number>
+): Record<ResourceId, number> => {
+  const missing = createEmptyResourceStockpile();
+  if (!cost) {
+    return missing;
+  }
+  RESOURCE_IDS.forEach((id) => {
+    const required = cost[id] ?? 0;
+    const available = totals[id] ?? 0;
+    missing[id] = Math.max(required - available, 0);
+  });
+  return missing;
+};
+
+const canAffordCost = (
+  cost: ResourceStockpile | null,
+  totals: Record<ResourceId, number>
+): boolean => {
+  if (!cost) {
+    return false;
+  }
+  return RESOURCE_IDS.every((id) => (totals[id] ?? 0) >= (cost[id] ?? 0));
+};
+
+export const SkillTreeView: React.FC = () => {
+  const { app, bridge } = useAppLogic();
+  const skillTree = useBridgeValue<SkillTreeBridgePayload>(
+    bridge,
+    SKILL_TREE_STATE_BRIDGE_KEY,
+    DEFAULT_SKILL_TREE_STATE
+  );
+  const totals = useBridgeValue<ResourceAmountPayload[]>(
+    bridge,
+    RESOURCE_TOTALS_BRIDGE_KEY,
+    []
+  );
+  const [hoveredId, setHoveredId] = useState<SkillId | null>(null);
+  const skillTreeModule = useMemo(() => app.getSkillTree(), [app]);
+
+  const nodes = skillTree.nodes;
+
+  useEffect(() => {
+    if (hoveredId && !nodes.some((node) => node.id === hoveredId)) {
+      setHoveredId(null);
+    }
+  }, [hoveredId, nodes]);
+
+  const totalsMap = useMemo(() => toTotalsMap(totals), [totals]);
+  const layout = useMemo(() => computeLayout(nodes), [nodes]);
+
+  const fallbackId: SkillId | null = nodes[0]?.id ?? null;
+  const activeId = hoveredId ?? fallbackId;
+  const activeNode = nodes.find((node) => node.id === activeId) ?? null;
+
+  const activeMissing = useMemo(
+    () => computeMissing(activeNode?.nextCost ?? null, totalsMap),
+    [activeNode, totalsMap]
+  );
+  const activeAffordable = useMemo(
+    () => canAffordCost(activeNode?.nextCost ?? null, totalsMap),
+    [activeNode, totalsMap]
+  );
+
+  const handleNodeClick = useCallback(
+    (id: SkillId) => {
+      skillTreeModule.tryPurchaseSkill(id);
+    },
+    [skillTreeModule]
+  );
+
+  return (
+    <div className="skill-tree">
+      <div className="skill-tree__viewport">
+        <div
+          className="skill-tree__canvas"
+          style={{
+            width: `${Math.max(layout.width, 360)}px`,
+            height: `${Math.max(layout.height, 320)}px`,
+          }}
+        >
+          <svg
+            className="skill-tree__links"
+            viewBox={`0 0 ${Math.max(layout.width, 1)} ${Math.max(layout.height, 1)}`}
+            preserveAspectRatio="xMidYMid meet"
+          >
+            {layout.edges.map((edge) => (
+              <line
+                key={edge.id}
+                x1={edge.from.x}
+                y1={edge.from.y}
+                x2={edge.to.x}
+                y2={edge.to.y}
+                className={edge.fulfilled ? "skill-tree__link skill-tree__link--fulfilled" : "skill-tree__link skill-tree__link--locked"}
+              />
+            ))}
+          </svg>
+          {nodes.map((node) => {
+            const position = layout.positions.get(node.id);
+            if (!position) {
+              return null;
+            }
+            const affordable = canAffordCost(node.nextCost, totalsMap);
+            const locked = !node.unlocked;
+            const inactive = locked || node.maxed || !affordable;
+            const nodeClasses = [
+              "skill-tree-node",
+              node.maxed ? "skill-tree-node--maxed" : null,
+              node.unlocked ? "skill-tree-node--unlocked" : "skill-tree-node--locked",
+              !node.maxed && node.unlocked ? "skill-tree-node--available" : null,
+              !node.maxed && node.unlocked && affordable
+                ? "skill-tree-node--affordable"
+                : null,
+              inactive ? "skill-tree-node--inactive" : null,
+              activeId === node.id ? "skill-tree-node--active" : null,
+            ]
+              .filter(Boolean)
+              .join(" ");
+
+            return (
+              <button
+                key={node.id}
+                type="button"
+                className={nodeClasses}
+                style={{ left: `${position.x}px`, top: `${position.y}px` }}
+                onMouseEnter={() => setHoveredId(node.id)}
+                onMouseLeave={() => setHoveredId((current) => (current === node.id ? null : current))}
+                onFocus={() => setHoveredId(node.id)}
+                onBlur={() => setHoveredId((current) => (current === node.id ? null : current))}
+                onClick={() => {
+                  if (!inactive) {
+                    handleNodeClick(node.id);
+                  }
+                }}
+                aria-disabled={inactive}
+                aria-label={`${node.name} level ${node.level} of ${node.maxLevel}`}
+              >
+                <div className="skill-tree-node__level">
+                  {node.level} / {node.maxLevel}
+                </div>
+                <div className="skill-tree-node__icon">
+                  {node.name
+                    .split(" ")
+                    .map((part) => part[0])
+                    .join("")
+                    .slice(0, 2)}
+                </div>
+              </button>
+            );
+          })}
+          {nodes.length === 0 && (
+            <div className="skill-tree__empty">No skills available yet.</div>
+          )}
+        </div>
+      </div>
+      <aside className="skill-tree__details">
+        {activeNode ? (
+          <>
+            <div className="skill-tree__details-header">
+              <h2>{activeNode.name}</h2>
+              <span className="skill-tree__details-level">
+                Level {activeNode.level} / {activeNode.maxLevel}
+              </span>
+            </div>
+            <p className="skill-tree__details-description">{activeNode.description}</p>
+            <div className="skill-tree__details-section">
+              <h3>Requirements</h3>
+              {activeNode.requirements.length > 0 ? (
+                <ul className="skill-tree__requirements">
+                  {activeNode.requirements.map((requirement) => {
+                    const config = getSkillConfig(requirement.id);
+                    const met = requirement.currentLevel >= requirement.requiredLevel;
+                    return (
+                      <li
+                        key={requirement.id}
+                        className={met ? "skill-tree__requirement skill-tree__requirement--met" : "skill-tree__requirement"}
+                      >
+                        <span className="skill-tree__requirement-name">{config.name}</span>
+                        <span className="skill-tree__requirement-level">
+                          {requirement.currentLevel} / {requirement.requiredLevel}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <div className="skill-tree__requirements-empty">No prerequisites.</div>
+              )}
+            </div>
+            <div className="skill-tree__details-section">
+              <h3>Next Level Cost</h3>
+              {activeNode.maxed ? (
+                <div className="skill-tree__maxed">Max level reached.</div>
+              ) : activeNode.nextCost ? (
+                <ResourceCostDisplay
+                  className="skill-tree__details-cost"
+                  cost={activeNode.nextCost}
+                  missing={activeMissing}
+                  resources={SKILL_TREE_RESOURCES}
+                />
+              ) : (
+                <div className="skill-tree__requirements-empty">Meet prerequisites to reveal cost.</div>
+              )}
+            </div>
+            {!activeNode.maxed && (
+              <div className="skill-tree__hint">
+                {activeNode.unlocked
+                  ? activeAffordable
+                    ? "Click a highlighted node to upgrade it."
+                    : "Gather more stone and sand to upgrade."
+                  : "Unlock prerequisites to make this upgrade available."}
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="skill-tree__details-empty">
+            Hover over a skill node to inspect its details.
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+};

--- a/src/ui/shared/ResourceCostDisplay.css
+++ b/src/ui/shared/ResourceCostDisplay.css
@@ -23,6 +23,14 @@
   color: #facc15;
 }
 
+.resource-cost__item--stone {
+  color: #cbd5f5;
+}
+
+.resource-cost__item--sand {
+  color: #fbbf24;
+}
+
 .resource-cost__item--missing {
   color: #f87171;
 }


### PR DESCRIPTION
## Summary
- add a skills database that lays out two-branch upgrade paths with cost formulas and prerequisites
- implement a SkillTreeModule that persists skill levels, enforces requirements, and syncs state through the data bridge
- integrate a Map Select skill tree view with interactive nodes, hover details, and generalized resource cost rendering that supports stone and sand

## Testing
- npm test *(fails: existing PlayerUnitsModule tests report mismatched expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e3781097c08320b5c4bc803e07218b