### PR TITLE
Improve scene toolbar center styling

### DIFF
--- a/src/ui/screens/Scene/ResourceDiamondMeter.css
+++ b/src/ui/screens/Scene/ResourceDiamondMeter.css
@@ -1,0 +1,28 @@
+.resource-diamond-meter {
+  position: relative;
+  width: 118px;
+  height: 118px;
+  display: grid;
+  place-items: center;
+  color: var(--resource-label-color, #f8fafc);
+}
+
+.resource-diamond-meter__svg {
+  width: 100%;
+  height: 100%;
+  filter: drop-shadow(0 12px 26px var(--resource-gem-glow, rgba(56, 189, 248, 0.35)));
+  transition: transform 240ms ease, filter 240ms ease;
+}
+
+.resource-diamond-meter__value {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-shadow: 0 1px 2px rgba(15, 23, 42, 0.45);
+  pointer-events: none;
+  transition: transform 200ms ease, opacity 200ms ease;
+}

--- a/src/ui/screens/Scene/ResourceDiamondMeter.tsx
+++ b/src/ui/screens/Scene/ResourceDiamondMeter.tsx
@@ -1,0 +1,125 @@
+import { CSSProperties, useId } from "react";
+import "./ResourceDiamondMeter.css";
+
+interface GradientStop {
+  offset: number;
+  color: string;
+  opacity?: number;
+}
+
+export interface ResourceDiamondMeterProps {
+  id: string;
+  className?: string;
+  current: number;
+  max: number;
+  gradientStops: readonly GradientStop[];
+  outlineColor: string;
+  glowColor: string;
+  showText?: boolean;
+  formatValue?: (current: number, max: number, percent: number) => React.ReactNode;
+}
+
+const DIAMOND_SIZE = 120;
+const DIAMOND_PATH = "M60 4L116 60L60 116L4 60Z";
+const INNER_RIDGE_PATH = "M60 12L108 60L60 108L12 60Z";
+
+export const ResourceDiamondMeter: React.FC<ResourceDiamondMeterProps> = ({
+  id,
+  className,
+  current,
+  max,
+  gradientStops,
+  outlineColor,
+  glowColor,
+  showText = true,
+  formatValue,
+}) => {
+  const safeMax = sanitizeMax(max);
+  const safeCurrent = clampValue(current, 0, safeMax);
+  const percent = safeMax > 0 ? clampValue((safeCurrent / safeMax) * 100, 0, 100) : 0;
+  const label = formatValue
+    ? formatValue(safeCurrent, safeMax, percent)
+    : `${safeCurrent.toFixed(1)} / ${safeMax.toFixed(1)}`;
+
+  const rawId = useId().replace(/:/g, "");
+  const idBase = `${id}-${rawId}`;
+  const clipPathId = `${idBase}-clip`;
+  const baseGradientId = `${idBase}-base-gradient`;
+  const fillGradientId = `${idBase}-fill-gradient`;
+  const highlightGradientId = `${idBase}-highlight-gradient`;
+
+  const fillHeight = (percent / 100) * DIAMOND_SIZE;
+  const classes = ["resource-diamond-meter", className].filter(Boolean).join(" ");
+
+  const meterStyle = {
+    "--resource-gem-glow": glowColor,
+  } as CSSProperties;
+
+  return (
+    <div className={classes} style={meterStyle}>
+      <svg
+        className="resource-diamond-meter__svg"
+        viewBox={`0 0 ${DIAMOND_SIZE} ${DIAMOND_SIZE}`}
+        aria-hidden="true"
+        focusable="false"
+      >
+        <defs>
+          <clipPath id={clipPathId}>
+            <path d={DIAMOND_PATH} />
+          </clipPath>
+          <linearGradient id={baseGradientId} x1="0.5" y1="0" x2="0.5" y2="1">
+            <stop offset="0%" stopColor="rgba(226, 232, 240, 0.18)" />
+            <stop offset="55%" stopColor="rgba(148, 163, 184, 0.12)" />
+            <stop offset="100%" stopColor="rgba(15, 23, 42, 0.78)" />
+          </linearGradient>
+          <linearGradient id={fillGradientId} x1="0.5" y1="1" x2="0.5" y2="0">
+            {gradientStops.map((stop, index) => (
+              <stop
+                key={`${stop.offset}-${index}`}
+                offset={`${Math.min(Math.max(stop.offset, 0), 1) * 100}%`}
+                stopColor={stop.color}
+                stopOpacity={stop.opacity ?? 1}
+              />
+            ))}
+          </linearGradient>
+          <linearGradient id={highlightGradientId} x1="0.15" y1="0.1" x2="0.85" y2="0.85">
+            <stop offset="0%" stopColor="rgba(255, 255, 255, 0.6)" />
+            <stop offset="35%" stopColor="rgba(255, 255, 255, 0.25)" />
+            <stop offset="100%" stopColor="rgba(255, 255, 255, 0)" />
+          </linearGradient>
+        </defs>
+        <g clipPath={`url(#${clipPathId})`}>
+          <rect width={DIAMOND_SIZE} height={DIAMOND_SIZE} fill={`url(#${baseGradientId})`} />
+          <rect
+            x="0"
+            y={Math.max(DIAMOND_SIZE - fillHeight, 0)}
+            width={DIAMOND_SIZE}
+            height={Math.max(fillHeight, 0)}
+            fill={`url(#${fillGradientId})`}
+          />
+          <rect width={DIAMOND_SIZE} height={DIAMOND_SIZE} fill={`url(#${highlightGradientId})`} />
+        </g>
+        <path d={DIAMOND_PATH} fill="none" stroke={outlineColor} strokeWidth="2" opacity="0.9" />
+        <path d={INNER_RIDGE_PATH} fill="none" stroke="rgba(255, 255, 255, 0.35)" strokeWidth="1.5" opacity="0.7" />
+      </svg>
+      {showText ? <div className="resource-diamond-meter__value">{label}</div> : null}
+    </div>
+  );
+};
+
+const sanitizeMax = (value: number): number => {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  return 1;
+};
+
+const clampValue = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (min > max) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+};

--- a/src/ui/screens/Scene/SceneSummoningPanel.css
+++ b/src/ui/screens/Scene/SceneSummoningPanel.css
@@ -37,7 +37,6 @@
   gap: 0.5rem;
   width: 100%;
   --resource-glow-color: rgba(96, 165, 250, 0.4);
-  --resource-outline-color: rgba(96, 165, 250, 0.45);
   --resource-text-flash-color: rgba(96, 165, 250, 0.8);
 }
 
@@ -49,88 +48,50 @@
   color: #cbd5f5;
 }
 
-.scene-summoning-panel__resource-bar {
-  --progress-bar-track-color: rgba(148, 163, 184, 0.25);
-  --progress-bar-label-color: #f8fafc;
+.scene-summoning-panel__resource-meter {
+  --resource-label-color: #f8fafc;
+  width: 118px;
+  height: 118px;
 }
 
-.scene-summoning-panel__resource-bar--sanity {
-  --progress-bar-fill-color: linear-gradient(0deg, #400e69, #96218a);
+.scene-summoning-panel__resource .resource-diamond-meter__svg {
+  border-radius: 12px;
 }
 
-.scene-summoning-panel__resource-bar--mana {
-  --progress-bar-fill-color: linear-gradient(0deg, #3b82f6, #22d3ee);
-}
-
-.scene-summoning-panel__resource .progress-bar--vertical .progress-bar__track {
-  width: 110px;
-  height: 110px;
-  border: 1px solid var(--resource-outline-color);
-  border-radius: 999px;
-  background: radial-gradient(120% 120% at 50% 20%, rgba(248, 250, 252, 0.08), rgba(15, 23, 42, 0.55));
-  box-shadow: 0 0 0 0 var(--resource-glow-color);
-  transition: box-shadow 240ms ease, transform 240ms ease, border-color 240ms ease;
-}
-
-
-.scene-summoning-panel__resource .progress-bar--vertical .progress-bar__track::after {
-  content: "";
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, #ffffff55, transparent 60%);
-  box-shadow: inset -10px -10px 20px rgba(0,0,0,0.3),
-              0 0 20px rgba(0,0,0,0.1);
-}
-
-.scene-summoning-panel__resource .progress-bar--vertical .progress-bar__track .progress-bar__fill {
-  border-radius: 0;
-}
-
-.scene-summoning-panel__resource .progress-bar__label {
-  transition: transform 200ms ease, opacity 200ms ease;
+.scene-summoning-panel__resource .resource-diamond-meter__value {
   will-change: transform;
 }
 
 .scene-summoning-panel__resource--mana {
   --resource-glow-color: rgba(56, 189, 248, 0.35);
-  --resource-outline-color: rgba(56, 189, 248, 0.35);
   --resource-text-flash-color: rgba(96, 165, 250, 0.85);
 }
 
 .scene-summoning-panel__resource--sanity {
   --resource-glow-color: rgba(168, 85, 247, 0.35);
-  --resource-outline-color: rgba(168, 85, 247, 0.35);
   --resource-text-flash-color: rgba(236, 72, 153, 0.8);
 }
 
-.scene-summoning-panel__resource--consuming .progress-bar--vertical .progress-bar__track {
-  animation: scene-summoning-panel__resource-flash 360ms ease-out;
+.scene-summoning-panel__resource--consuming .resource-diamond-meter__svg {
+  animation: scene-summoning-panel__resource-gem-flash 360ms ease-out;
 }
 
-.scene-summoning-panel__resource--consuming .progress-bar__fill {
-  filter: brightness(1.1) saturate(1.1);
-}
-
-.scene-summoning-panel__resource--consuming .progress-bar__label {
+.scene-summoning-panel__resource--consuming .resource-diamond-meter__value {
   animation: scene-summoning-panel__resource-count-drop 360ms ease-out;
   opacity: 0.92;
 }
 
-@keyframes scene-summoning-panel__resource-flash {
+@keyframes scene-summoning-panel__resource-gem-flash {
   0% {
-    box-shadow: 0 0 0 0 var(--resource-glow-color);
+    filter: drop-shadow(0 12px 26px var(--resource-gem-glow, rgba(56, 189, 248, 0.35)));
     transform: scale(1);
   }
   45% {
-    box-shadow: 0 0 28px 6px var(--resource-glow-color);
+    filter: drop-shadow(0 18px 38px var(--resource-glow-color));
     transform: scale(1.05);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+    filter: drop-shadow(0 12px 26px var(--resource-gem-glow, rgba(56, 189, 248, 0.35)));
     transform: scale(1);
   }
 }

--- a/src/ui/screens/Scene/SceneSummoningPanel.tsx
+++ b/src/ui/screens/Scene/SceneSummoningPanel.tsx
@@ -5,7 +5,7 @@ import {
   NecromancerSpawnOption,
 } from "../../../logic/modules/NecromancerModule";
 import { createEmptyResourceAmount } from "../../../types/resources";
-import { ProgressBar } from "../../shared/ProgressBar";
+import { ResourceDiamondMeter } from "./ResourceDiamondMeter";
 import { ResourceCostDisplay } from "../../shared/ResourceCostDisplay";
 import "./SceneSummoningPanel.css";
 
@@ -15,8 +15,11 @@ interface SceneSummoningPanelProps {
   onSummon: (type: PlayerUnitType) => void;
 }
 
-const formatResourceValue = (current: number, max: number): string =>
-  `${current.toFixed(1)} / ${max.toFixed(1)}`;
+const formatResourceValue = (
+  current: number,
+  max: number,
+  _percent?: number
+): string => `${current.toFixed(1)} / ${max.toFixed(1)}`;
 
 
 export const SceneSummoningPanel = forwardRef<HTMLDivElement, SceneSummoningPanelProps>(
@@ -50,12 +53,19 @@ export const SceneSummoningPanel = forwardRef<HTMLDivElement, SceneSummoningPane
         <div className="scene-summoning-panel__section scene-summoning-panel__section--left">
           <div className={sanityResourceClassName}>
             <div className="scene-summoning-panel__resource-label">Sanity</div>
-            <ProgressBar
-              className="scene-summoning-panel__resource-bar scene-summoning-panel__resource-bar--sanity"
+            <ResourceDiamondMeter
+              id="sanity"
+              className="scene-summoning-panel__resource-meter scene-summoning-panel__resource-meter--sanity"
               current={resources.sanity.current}
               max={resources.sanity.max}
-              formatValue={(current, max) => formatResourceValue(current, max)}
-              orientation="vertical"
+              gradientStops={[
+                { offset: 0, color: "#581c87" },
+                { offset: 0.55, color: "#8b21a8" },
+                { offset: 1, color: "#c084fc" },
+              ]}
+              outlineColor="rgba(236, 72, 153, 0.5)"
+              glowColor="rgba(168, 85, 247, 0.35)"
+              formatValue={formatResourceValue}
             />
           </div>
         </div>
@@ -92,12 +102,19 @@ export const SceneSummoningPanel = forwardRef<HTMLDivElement, SceneSummoningPane
         <div className="scene-summoning-panel__section scene-summoning-panel__section--right">
           <div className={manaResourceClassName}>
             <div className="scene-summoning-panel__resource-label">Mana</div>
-            <ProgressBar
-              className="scene-summoning-panel__resource-bar scene-summoning-panel__resource-bar--mana"
+            <ResourceDiamondMeter
+              id="mana"
+              className="scene-summoning-panel__resource-meter scene-summoning-panel__resource-meter--mana"
               current={resources.mana.current}
               max={resources.mana.max}
-              formatValue={(current, max) => formatResourceValue(current, max)}
-              orientation="vertical"
+              gradientStops={[
+                { offset: 0, color: "#1e3a8a" },
+                { offset: 0.45, color: "#2563eb" },
+                { offset: 1, color: "#22d3ee" },
+              ]}
+              outlineColor="rgba(59, 130, 246, 0.6)"
+              glowColor="rgba(56, 189, 248, 0.35)"
+              formatValue={formatResourceValue}
             />
           </div>
         </div>

--- a/src/ui/screens/Scene/SceneToolbar.css
+++ b/src/ui/screens/Scene/SceneToolbar.css
@@ -23,38 +23,16 @@
   flex-direction: column;
   align-items: center;
   gap: 0.75rem;
-  background: rgba(13, 17, 23, 0.85);
-  margin: 0 20%;
   position: relative;
-  padding: 1rem 2rem;
-  border-top: 1px solid rgba(97, 218, 251, 0.15);
-  border-bottom: 1px solid rgba(97, 218, 251, 0.15);
-  box-shadow: 
-    0 -8px 16px rgba(0, 1, 1, 0.95),
-    0 8px 16px rgba(0, 1, 1, 0.95);
-}
-
-.scene-toolbar__section--center::before,
-.scene-toolbar__section--center::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 0;
-  height: 0;
-  border-style: solid;
-}
-
-.scene-toolbar__section--center::before {
-  left: -50px;
-  border-width: 50px 50px 50px 0;
-  border-color: transparent rgba(13, 17, 23, 0.85) transparent transparent;
-}
-
-.scene-toolbar__section--center::after {
-  right: -50px;
-  border-width: 50px 0 50px 50px;
-  border-color: transparent transparent transparent rgba(13, 17, 23, 0.85);
+  margin: 0 20%;
+  padding: 1rem 2.75rem;
+  background: linear-gradient(180deg, rgba(22, 28, 38, 0.9) 0%, rgba(9, 12, 18, 0.78) 100%);
+  clip-path: polygon(0 50%, 36px 0, calc(100% - 36px) 0, 100% 50%, calc(100% - 36px) 100%, 36px 100%);
+  filter: drop-shadow(0 0 20px rgba(81, 202, 255, 0.45));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.35),
+    0 0 0 1px rgba(73, 169, 218, 0.25);
 }
 
 .scene-toolbar__section--right {
@@ -123,12 +101,13 @@
   .scene-toolbar__section--center {
     order: 3;
     margin: 0;
-    padding: 1rem;
-  }
-
-  .scene-toolbar__section--center::before,
-  .scene-toolbar__section--center::after {
-    display: none;
+    padding: 1rem 1.5rem;
+    clip-path: none;
+    filter: drop-shadow(0 0 14px rgba(81, 202, 255, 0.35));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(73, 169, 218, 0.25);
   }
 
   .scene-toolbar__section--right {

--- a/src/ui/screens/Scene/SceneToolbar.css
+++ b/src/ui/screens/Scene/SceneToolbar.css
@@ -28,11 +28,11 @@
   padding: 1rem 2.75rem;
   background: linear-gradient(180deg, rgba(22, 28, 38, 0.9) 0%, rgba(9, 12, 18, 0.78) 100%);
   clip-path: polygon(0 50%, 36px 0, calc(100% - 36px) 0, 100% 50%, calc(100% - 36px) 100%, 36px 100%);
-  filter: drop-shadow(0 0 20px rgba(81, 202, 255, 0.45));
   box-shadow:
+    0 16px 36px rgba(60, 160, 210, 0.45),
+    0 0 0 1px rgba(73, 169, 218, 0.35),
     inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.35),
-    0 0 0 1px rgba(73, 169, 218, 0.25);
+    inset 0 -1px 0 rgba(0, 0, 0, 0.35);
 }
 
 .scene-toolbar__section--right {
@@ -103,11 +103,11 @@
     margin: 0;
     padding: 1rem 1.5rem;
     clip-path: none;
-    filter: drop-shadow(0 0 14px rgba(81, 202, 255, 0.35));
     box-shadow:
+      0 12px 28px rgba(60, 160, 210, 0.35),
+      0 0 0 1px rgba(73, 169, 218, 0.35),
       inset 0 1px 0 rgba(255, 255, 255, 0.08),
-      inset 0 -1px 0 rgba(0, 0, 0, 0.35),
-      0 0 0 1px rgba(73, 169, 218, 0.25);
+      inset 0 -1px 0 rgba(0, 0, 0, 0.35);
   }
 
   .scene-toolbar__section--right {

--- a/src/ui/screens/Scene/SceneToolbar.css
+++ b/src/ui/screens/Scene/SceneToolbar.css
@@ -19,6 +19,7 @@
 }
 
 .scene-toolbar__section--center {
+  --scene-toolbar-center-wing: 60px;
   flex: 1;
   flex-direction: column;
   align-items: center;
@@ -30,25 +31,19 @@
   z-index: 0;
 }
 
-.scene-toolbar__section--center::before {
-  content: "";
+.scene-toolbar__center-silhouette {
   position: absolute;
   inset: 0;
-  border-radius: 12px;
-  background:
-    linear-gradient(180deg, rgba(22, 28, 38, 0.9) 0%, rgba(9, 12, 18, 0.78) 100%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
-  background-blend-mode: normal, soft-light;
-  clip-path: polygon(0 50%, 36px 0, calc(100% - 36px) 0, 100% 50%, calc(100% - 36px) 100%, 36px 100%);
-  box-shadow:
-    0 0 0 1px rgba(73, 169, 218, 0.35),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.45);
-  filter:
-    drop-shadow(0 22px 40px rgba(62, 162, 214, 0.45))
-    drop-shadow(0 2px 10px rgba(73, 169, 218, 0.4));
+  left: calc(-1 * var(--scene-toolbar-center-wing));
+  width: calc(100% + var(--scene-toolbar-center-wing) * 2);
+  height: 100%;
   pointer-events: none;
   z-index: -1;
+  overflow: visible;
+}
+
+.scene-toolbar__center-silhouette path {
+  transition: opacity 120ms ease;
 }
 
 .scene-toolbar__section--right {
@@ -118,14 +113,7 @@
     order: 3;
     margin: 0;
     padding: 1rem 1.5rem;
-  }
-
-  .scene-toolbar__section--center::before {
-    border-radius: 16px;
-    clip-path: none;
-    filter:
-      drop-shadow(0 18px 32px rgba(62, 162, 214, 0.38))
-      drop-shadow(0 2px 8px rgba(73, 169, 218, 0.35));
+    --scene-toolbar-center-wing: 36px;
   }
 
   .scene-toolbar__section--right {

--- a/src/ui/screens/Scene/SceneToolbar.css
+++ b/src/ui/screens/Scene/SceneToolbar.css
@@ -26,13 +26,29 @@
   position: relative;
   margin: 0 20%;
   padding: 1rem 2.75rem;
-  background: linear-gradient(180deg, rgba(22, 28, 38, 0.9) 0%, rgba(9, 12, 18, 0.78) 100%);
+  isolation: isolate;
+  z-index: 0;
+}
+
+.scene-toolbar__section--center::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  background:
+    linear-gradient(180deg, rgba(22, 28, 38, 0.9) 0%, rgba(9, 12, 18, 0.78) 100%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
+  background-blend-mode: normal, soft-light;
   clip-path: polygon(0 50%, 36px 0, calc(100% - 36px) 0, 100% 50%, calc(100% - 36px) 100%, 36px 100%);
   box-shadow:
-    0 16px 36px rgba(60, 160, 210, 0.45),
     0 0 0 1px rgba(73, 169, 218, 0.35),
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.35);
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.45);
+  filter:
+    drop-shadow(0 22px 40px rgba(62, 162, 214, 0.45))
+    drop-shadow(0 2px 10px rgba(73, 169, 218, 0.4));
+  pointer-events: none;
+  z-index: -1;
 }
 
 .scene-toolbar__section--right {
@@ -102,12 +118,14 @@
     order: 3;
     margin: 0;
     padding: 1rem 1.5rem;
+  }
+
+  .scene-toolbar__section--center::before {
+    border-radius: 16px;
     clip-path: none;
-    box-shadow:
-      0 12px 28px rgba(60, 160, 210, 0.35),
-      0 0 0 1px rgba(73, 169, 218, 0.35),
-      inset 0 1px 0 rgba(255, 255, 255, 0.08),
-      inset 0 -1px 0 rgba(0, 0, 0, 0.35);
+    filter:
+      drop-shadow(0 18px 32px rgba(62, 162, 214, 0.38))
+      drop-shadow(0 2px 8px rgba(73, 169, 218, 0.35));
   }
 
   .scene-toolbar__section--right {

--- a/src/ui/screens/Scene/SceneToolbar.tsx
+++ b/src/ui/screens/Scene/SceneToolbar.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import { Button } from "../../shared/Button";
 import { ProgressBar } from "../../shared/ProgressBar";
 import "./SceneToolbar.css";
@@ -27,6 +28,8 @@ const clamp = (value: number, min: number, max: number): number => {
   return value;
 };
 
+const sanitizeId = (value: string): string => value.replace(/[^a-zA-Z0-9_-]/g, "_");
+
 export const SceneToolbar: React.FC<SceneToolbarProps> = ({
   onExit,
   brickTotalHp,
@@ -39,6 +42,11 @@ export const SceneToolbar: React.FC<SceneToolbarProps> = ({
   cameraPosition,
 }) => {
   const clampedInitialHp = brickInitialHp > 0 ? brickInitialHp : brickTotalHp;
+  const shapePrefix = sanitizeId(`${useId()}-scene-toolbar`);
+  const fillGradientId = `${shapePrefix}-fill`;
+  const sheenGradientId = `${shapePrefix}-sheen`;
+  const outlineGradientId = `${shapePrefix}-outline`;
+  const glowFilterId = `${shapePrefix}-glow`;
 
   return (
     <div className="scene-toolbar">
@@ -46,6 +54,77 @@ export const SceneToolbar: React.FC<SceneToolbarProps> = ({
         <Button onClick={onExit}>Main Menu</Button>
       </div>
       <div className="scene-toolbar__section scene-toolbar__section--center">
+        <svg
+          className="scene-toolbar__center-silhouette"
+          viewBox="0 0 400 120"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <defs>
+            <linearGradient id={fillGradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="rgba(22, 28, 38, 0.9)" />
+              <stop offset="100%" stopColor="rgba(9, 12, 18, 0.78)" />
+            </linearGradient>
+            <linearGradient id={sheenGradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="rgba(255, 255, 255, 0.28)" />
+              <stop offset="45%" stopColor="rgba(255, 255, 255, 0.08)" />
+              <stop offset="100%" stopColor="rgba(255, 255, 255, 0)" />
+            </linearGradient>
+            <linearGradient id={outlineGradientId} x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stopColor="rgba(123, 198, 240, 0.35)" />
+              <stop offset="50%" stopColor="rgba(73, 169, 218, 0.25)" />
+              <stop offset="100%" stopColor="rgba(123, 198, 240, 0.35)" />
+            </linearGradient>
+            <filter
+              id={glowFilterId}
+              x="-25%"
+              y="-55%"
+              width="150%"
+              height="230%"
+              colorInterpolationFilters="sRGB"
+            >
+              <feDropShadow
+                dx="0"
+                dy="24"
+                stdDeviation="20"
+                floodColor="#3ea2d6"
+                floodOpacity="0.32"
+              />
+              <feDropShadow
+                dx="0"
+                dy="6"
+                stdDeviation="12"
+                floodColor="#49a9da"
+                floodOpacity="0.38"
+              />
+            </filter>
+          </defs>
+          <path
+            d="M0 60 L40 0 H360 L400 60 L360 120 H40 Z"
+            fill={`url(#${fillGradientId})`}
+            filter={`url(#${glowFilterId})`}
+            vectorEffect="non-scaling-stroke"
+          />
+          <path
+            d="M40 0 H360 L380 60 L20 60 Z"
+            fill={`url(#${sheenGradientId})`}
+            vectorEffect="non-scaling-stroke"
+          />
+          <path
+            d="M0 60 L40 0 H360 L400 60 L360 120 H40 Z"
+            fill="none"
+            stroke={`url(#${outlineGradientId})`}
+            strokeWidth="3"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
+          <path
+            d="M20 60 L40 120 H360 L380 60 Z"
+            fill="rgba(0, 0, 0, 0.25)"
+            opacity="0.35"
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
         <div className="scene-toolbar__hp">
           <div className="scene-toolbar__hp-label">Brick Integrity</div>
           <ProgressBar

--- a/tests/BricksModule.test.ts
+++ b/tests/BricksModule.test.ts
@@ -14,15 +14,24 @@ import {
 import { BrickType, getBrickConfig } from "../src/db/bricks-db";
 import { ExplosionModule } from "../src/logic/modules/ExplosionModule";
 import { describe, test } from "./testRunner";
+import { BonusesModule } from "../src/logic/modules/BonusesModule";
 
-const createBricksModule = (scene: SceneObjectManager, bridge: DataBridge) => {
+const createBricksModule = (
+  scene: SceneObjectManager,
+  bridge: DataBridge
+) => {
   const explosions = new ExplosionModule({ scene });
   const resources = {
     grantResources: () => {
       // no-op for tests
     },
+    notifyBrickDestroyed: () => {
+      // no-op for tests
+    },
   };
-  return new BricksModule({ scene, bridge, explosions, resources });
+  const bonuses = new BonusesModule();
+  bonuses.initialize();
+  return new BricksModule({ scene, bridge, explosions, resources, bonuses });
 };
 
 describe("BricksModule", () => {

--- a/tests/MapModule.test.ts
+++ b/tests/MapModule.test.ts
@@ -8,6 +8,7 @@ import { MovementService } from "../src/logic/services/MovementService";
 import { MapModule, PLAYER_UNIT_SPAWN_SAFE_RADIUS } from "../src/logic/modules/MapModule";
 import { ExplosionModule } from "../src/logic/modules/ExplosionModule";
 import { NecromancerModule } from "../src/logic/modules/NecromancerModule";
+import { BonusesModule } from "../src/logic/modules/BonusesModule";
 
 const distanceSq = (a: { x: number; y: number }, b: { x: number; y: number }): number => {
   const dx = a.x - b.x;
@@ -20,6 +21,8 @@ describe("MapModule", () => {
     const scene = new SceneObjectManager();
     const bridge = new DataBridge();
     const explosions = new ExplosionModule({ scene });
+    const bonuses = new BonusesModule();
+    bonuses.initialize();
     const resources = {
       startRun: () => {
         // no-op for tests
@@ -27,14 +30,18 @@ describe("MapModule", () => {
       grantResources: () => {
         // no-op for tests
       },
+      notifyBrickDestroyed: () => {
+        // no-op for tests
+      },
     };
-    const bricks = new BricksModule({ scene, bridge, explosions, resources });
+    const bricks = new BricksModule({ scene, bridge, explosions, resources, bonuses });
     const movement = new MovementService();
-    const playerUnits = new PlayerUnitsModule({ scene, bricks, bridge, movement });
+    const playerUnits = new PlayerUnitsModule({ scene, bricks, bridge, movement, bonuses });
     const necromancer = new NecromancerModule({
       bridge,
       playerUnits,
       scene,
+      bonuses,
     });
     const maps = new MapModule({
       scene,

--- a/tests/PlayerUnitsModule.test.ts
+++ b/tests/PlayerUnitsModule.test.ts
@@ -9,15 +9,23 @@ import {
 } from "../src/logic/modules/PlayerUnitsModule";
 import { MovementService } from "../src/logic/services/MovementService";
 import { ExplosionModule } from "../src/logic/modules/ExplosionModule";
+import { BonusesModule } from "../src/logic/modules/BonusesModule";
 
-const createBricksModule = (scene: SceneObjectManager, bridge: DataBridge) => {
+const createBricksModule = (
+  scene: SceneObjectManager,
+  bridge: DataBridge,
+  bonuses: BonusesModule
+) => {
   const explosions = new ExplosionModule({ scene });
   const resources = {
     grantResources: () => {
       // no-op for tests
     },
+    notifyBrickDestroyed: () => {
+      // no-op for tests
+    },
   };
-  return new BricksModule({ scene, bridge, explosions, resources });
+  return new BricksModule({ scene, bridge, explosions, resources, bonuses });
 };
 
 const tickSeconds = (module: PlayerUnitsModule, seconds: number) => {
@@ -29,8 +37,10 @@ describe("PlayerUnitsModule", () => {
     const scene = new SceneObjectManager();
     const bridge = new DataBridge();
     const movement = new MovementService();
-    const bricks = createBricksModule(scene, bridge);
-    const units = new PlayerUnitsModule({ scene, bricks, bridge, movement });
+    const bonuses = new BonusesModule();
+    bonuses.initialize();
+    const bricks = createBricksModule(scene, bridge, bonuses);
+    const units = new PlayerUnitsModule({ scene, bricks, bridge, movement, bonuses });
 
     bricks.setBricks([
       {
@@ -71,8 +81,10 @@ describe("PlayerUnitsModule", () => {
     const scene = new SceneObjectManager();
     const bridge = new DataBridge();
     const movement = new MovementService();
-    const bricks = createBricksModule(scene, bridge);
-    const units = new PlayerUnitsModule({ scene, bricks, bridge, movement });
+    const bonuses = new BonusesModule();
+    bonuses.initialize();
+    const bricks = createBricksModule(scene, bridge, bonuses);
+    const units = new PlayerUnitsModule({ scene, bricks, bridge, movement, bonuses });
 
     bricks.setBricks([
       {


### PR DESCRIPTION
## Summary
- restyle the scene toolbar center panel with a seamless triangular silhouette and gradient fill
- add a subtle outline and blue drop shadow for the floating effect
- retain responsive adjustments for smaller screens without the angled edges

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68e5741f59608320ade12e27c62fbf26