### PR TITLE
Stabilize skill tree layout bounds

### DIFF
--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/SkillTree/SkillTreeView.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/SkillTree/SkillTreeView.tsx
@@ -144,12 +144,11 @@ const isNodeVisible = (node: SkillNodeBridgePayload): boolean => {
   return node.requirements.some((req) => req.currentLevel > 0);
 };
 
-const computeLayout = (nodes: SkillNodeBridgePayload[]): SkillTreeLayout => {
-  // Filter to only visible nodes for layout calculations
-  const visibleNodes = nodes.filter(isNodeVisible);
-  const visibleNodeIds = new Set(visibleNodes.map((n) => n.id));
-
-  if (visibleNodes.length === 0) {
+const computeLayout = (
+  nodes: SkillNodeBridgePayload[],
+  visibleNodes: SkillNodeBridgePayload[]
+): SkillTreeLayout => {
+  if (nodes.length === 0) {
     return {
       width: 0,
       height: 0,
@@ -158,7 +157,7 @@ const computeLayout = (nodes: SkillNodeBridgePayload[]): SkillTreeLayout => {
     };
   }
 
-  const first = visibleNodes[0];
+  const first = nodes[0];
   if (!first) {
     return {
       width: 0,
@@ -173,7 +172,7 @@ const computeLayout = (nodes: SkillNodeBridgePayload[]): SkillTreeLayout => {
   let minY = first.position.y;
   let maxY = first.position.y;
 
-  visibleNodes.forEach((node) => {
+  nodes.forEach((node) => {
     minX = Math.min(minX, node.position.x);
     maxX = Math.max(maxX, node.position.x);
     minY = Math.min(minY, node.position.y);
@@ -193,6 +192,7 @@ const computeLayout = (nodes: SkillNodeBridgePayload[]): SkillTreeLayout => {
     });
   });
 
+  const visibleNodeIds = new Set(visibleNodes.map((n) => n.id));
   const edges: SkillTreeEdge[] = [];
   visibleNodes.forEach((node) => {
     const to = positions.get(node.id);
@@ -318,7 +318,10 @@ export const SkillTreeView: React.FC = () => {
     });
   }, [visibleNodes]);
 
-  const layout = useMemo(() => computeLayout(nodes), [nodes]);
+  const layout = useMemo(
+    () => computeLayout(nodes, visibleNodes),
+    [nodes, visibleNodes]
+  );
   const hoveredId = pointerHoveredId ?? focusHoveredId;
   // Update ref directly instead of useEffect
   hoveredIdRef.current = hoveredId;


### PR DESCRIPTION
### Motivation
- Prevent the skill tree canvas and node positions from jumping when nodes are shown or hidden by computing stable global bounds instead of using only visible nodes.

### Description
- Changed `computeLayout` signature to `computeLayout(nodes, visibleNodes)` and compute `minX/maxX/minY/maxY` from the full `nodes` list so `width`/`height` and `offsetX/offsetY` are stable.
- Build `layout.positions` using the fixed global offsets but populate the map only with `visibleNodes` so hidden nodes are not rendered.
- Keep edges and visible-node position calculations based on `visibleNodes` while using the global bounds for canvas sizing.
- Wired the `useMemo` that produces `layout` to call `computeLayout(nodes, visibleNodes)` so memoization depends on both sets.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b66bc1d488320802112eaae78f144)