### PR TITLE
Add map-wide radioactivity effect

### DIFF
--- a/src/core/logic/ui/BridgeSchema.ts
+++ b/src/core/logic/ui/BridgeSchema.ts
@@ -8,7 +8,11 @@ import type { UnitDesignId } from "@logic/modules/camp/unit-design/unit-design.t
 import type { PlayerUnitType } from "@db/player-units-db";
 import type { PlayerUnitBlueprintStats } from "@shared/types/player-units";
 import type { ResourceAmountPayload, ResourceRunSummaryPayload } from "@logic/modules/shared/resources/resources.types";
-import type { MapListEntry, MapAutoRestartState } from "@logic/modules/active-map/map/map.types";
+import type {
+  MapListEntry,
+  MapAutoRestartState,
+  MapEffectsBridgeState,
+} from "@logic/modules/active-map/map/map.types";
 import type { BuildingsWorkshopBridgeState } from "@logic/modules/camp/buildings/buildings.types";
 import type { CraftingBridgeState } from "@logic/modules/camp/crafting/crafting.types";
 import type { UnitDesignerBridgeState } from "@logic/modules/camp/unit-design/unit-design.types";
@@ -54,6 +58,7 @@ export interface BridgeSchema {
   "maps/selectViewTransform": ViewTransform | null;
   "maps/controlHintsCollapsed": boolean;
   "maps/inspectedTarget": TargetSnapshot<"brick" | "enemy", BrickRuntimeState | EnemyRuntimeState> | null;
+  "maps/effects": MapEffectsBridgeState;
 
   // Player Units
   "playerUnits/count": number;

--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -307,7 +307,7 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
         radiusOffset: -2,
       },
       destructionExplosion: {
-        type: "grayBrickDestroy",
+        type: "grayBrickDestroyV2",
         radiusMultiplier: 0.95,
       },
     },

--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -694,9 +694,9 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
     },
     stroke: { color: { r: 0.3, g: 0.5, b: 0.2, a: 1 }, width: 2.4 },
     destructubleData: {
-      maxHp: 36750,
-      armor: 12445,
-      baseDamage: 3355,
+      maxHp: 16750,
+      armor: 2445,
+      baseDamage: 1355,
       knockBackDistance: 190,
       knockBackSpeed: 280,
       brickKnockBackAmplitude: 4,
@@ -711,7 +711,7 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
       },
     },
     rewards: {
-      uranium: 0.5,
+      uranium: 0.1,
     },
   },
   smallMagma: {

--- a/src/db/explosions-db.ts
+++ b/src/db/explosions-db.ts
@@ -17,6 +17,7 @@ export type ExplosionType =
   | "fireball"
   | "grayBrickHit"
   | "grayBrickDestroy"
+  | "grayBrickDestroyV2"
   | "yellowBrickHit"
   | "yellowBrickDestroy"
   | "organicBrickHit"
@@ -479,6 +480,28 @@ const GRAY_BRICK_DESTRUCTION_EMITTER: ParticleEmitterConfig = {
   sizeGrowthRate: 1.35,
 };
 
+
+const GRAY_BRICK_DESTRUCTION_EMITTER_V2: ParticleEmitterConfig = {
+  emissionDurationMs: 220,
+  particlesPerSecond: 420,
+  baseSpeed: 0.1,
+  speedVariation: 0.01,
+  particleLifetimeMs: 750,
+  fadeStartMs: 480,
+  sizeRange: { min: 1, max: 3 },
+  spawnRadius: { min: 0, max: 8 },
+  spawnRadiusMultiplier: 1.5,
+  color: { r: 0.85, g: 0.87, b: 0.92, a: 1 },
+  arc: Math.PI * 2,
+  direction: 0,
+  fill: {
+    fillType: FILL_TYPES.SOLID,
+    color: { r: 0.85, g: 0.87, b: 0.92, a: 1 },
+  },
+  shape: "triangle",
+  sizeGrowthRate: 1.0,
+};
+
 const CRITICAL_HIT_EMITTER: ParticleEmitterConfig = {
   emissionDurationMs: 240,
   particlesPerSecond: 220,
@@ -704,6 +727,18 @@ const EXPLOSION_DB: Record<ExplosionType, ExplosionConfig> = {
       gradientStops: GRAY_BRICK_DESTROY_WAVE_GRADIENT_STOPS,
     }),
     emitter: GRAY_BRICK_DESTRUCTION_EMITTER,
+  },
+  grayBrickDestroyV2: {
+    lifetimeMs: 1_200,
+    defaultInitialRadius: 10,
+    waves: createSimpleWave({
+      defaultInitialRadius: 10,
+      radiusExtension: 60,
+      startAlpha: 0.6,
+      endAlpha: 0.0,
+      gradientStops: GRAY_BRICK_DESTROY_WAVE_GRADIENT_STOPS,
+    }),
+    emitter: GRAY_BRICK_DESTRUCTION_EMITTER_V2,
   },
   yellowBrickHit: {
     lifetimeMs: 1_000,

--- a/src/db/map-effects-db.ts
+++ b/src/db/map-effects-db.ts
@@ -11,6 +11,11 @@ export interface MapEffectVisualConfig {
   readonly maxNoiseColor: number;
   readonly noiseScale: number;
   readonly noiseDensity?: number;
+  readonly filamentColorContrast: number;
+  readonly filamentAlphaContrast: number;
+  readonly filamentWidth: number;
+  readonly filamentDensity: number;
+  readonly filamentEdgeBlur: number;
 }
 
 export interface MapEffectConfig {
@@ -29,7 +34,7 @@ const MAP_EFFECTS_DB: Record<MapEffectId, MapEffectConfig> = {
     name: "Radioactivity",
     maxLevel: 1,
     growthPerSecond: 0.01,
-    hpDrainPercentPerSecond: 0.5,
+    hpDrainPercentPerSecond: 25,
     targets: ["playerUnits"],
     visuals: {
       tintColor: { r: 0.1, g: 0.9, b: 0.45, a: 1 },
@@ -38,6 +43,11 @@ const MAP_EFFECTS_DB: Record<MapEffectId, MapEffectConfig> = {
       maxNoiseColor: 0.25,
       noiseScale: 1.4,
       noiseDensity: 0.8,
+      filamentColorContrast: 0.18,
+      filamentAlphaContrast: 0.25,
+      filamentWidth: 0.35,
+      filamentDensity: 0.65,
+      filamentEdgeBlur: 0.4,
     },
   },
 };

--- a/src/db/map-effects-db.ts
+++ b/src/db/map-effects-db.ts
@@ -2,6 +2,17 @@ export type MapEffectId = "radioactivity";
 
 export type MapEffectTarget = "playerUnits" | "enemies";
 
+import type { SceneColor } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+
+export interface MapEffectVisualConfig {
+  readonly tintColor: SceneColor;
+  readonly maxTintAlpha: number;
+  readonly maxNoiseAlpha: number;
+  readonly maxNoiseColor: number;
+  readonly noiseScale: number;
+  readonly noiseDensity?: number;
+}
+
 export interface MapEffectConfig {
   readonly id: MapEffectId;
   readonly name: string;
@@ -9,6 +20,7 @@ export interface MapEffectConfig {
   readonly growthPerSecond: number;
   readonly hpDrainPercentPerSecond: number;
   readonly targets: readonly MapEffectTarget[];
+  readonly visuals?: MapEffectVisualConfig;
 }
 
 const MAP_EFFECTS_DB: Record<MapEffectId, MapEffectConfig> = {
@@ -19,6 +31,14 @@ const MAP_EFFECTS_DB: Record<MapEffectId, MapEffectConfig> = {
     growthPerSecond: 0.01,
     hpDrainPercentPerSecond: 0.5,
     targets: ["playerUnits"],
+    visuals: {
+      tintColor: { r: 0.1, g: 0.9, b: 0.45, a: 1 },
+      maxTintAlpha: 0.12,
+      maxNoiseAlpha: 0.2,
+      maxNoiseColor: 0.25,
+      noiseScale: 1.4,
+      noiseDensity: 0.8,
+    },
   },
 };
 

--- a/src/db/map-effects-db.ts
+++ b/src/db/map-effects-db.ts
@@ -1,0 +1,25 @@
+export type MapEffectId = "radioactivity";
+
+export type MapEffectTarget = "playerUnits" | "enemies";
+
+export interface MapEffectConfig {
+  readonly id: MapEffectId;
+  readonly name: string;
+  readonly maxLevel: number;
+  readonly growthPerSecond: number;
+  readonly hpDrainPercentPerSecond: number;
+  readonly targets: readonly MapEffectTarget[];
+}
+
+const MAP_EFFECTS_DB: Record<MapEffectId, MapEffectConfig> = {
+  radioactivity: {
+    id: "radioactivity",
+    name: "Radioactivity",
+    maxLevel: 1,
+    growthPerSecond: 0.01,
+    hpDrainPercentPerSecond: 0.5,
+    targets: ["playerUnits"],
+  },
+};
+
+export const getMapEffectConfig = (id: MapEffectId): MapEffectConfig => MAP_EFFECTS_DB[id];

--- a/src/db/map-effects-db.ts
+++ b/src/db/map-effects-db.ts
@@ -11,11 +11,17 @@ export interface MapEffectVisualConfig {
   readonly maxNoiseColor: number;
   readonly noiseScale: number;
   readonly noiseDensity?: number;
-  readonly filamentColorContrast: number;
-  readonly filamentAlphaContrast: number;
-  readonly filamentWidth: number;
-  readonly filamentDensity: number;
-  readonly filamentEdgeBlur: number;
+}
+
+export interface MapEffectPostProcessConfig {
+  readonly waveAmplitude: number;
+  readonly waveFrequency: number;
+  readonly waveSpeed: number;
+  readonly jitterStrength: number;
+  readonly jitterFrequency: number;
+  readonly bandSpeed: number;
+  readonly bandWidth: number;
+  readonly bandIntensity: number;
 }
 
 export interface MapEffectConfig {
@@ -26,6 +32,7 @@ export interface MapEffectConfig {
   readonly hpDrainPercentPerSecond: number;
   readonly targets: readonly MapEffectTarget[];
   readonly visuals?: MapEffectVisualConfig;
+  readonly postProcess?: MapEffectPostProcessConfig;
 }
 
 const MAP_EFFECTS_DB: Record<MapEffectId, MapEffectConfig> = {
@@ -39,15 +46,20 @@ const MAP_EFFECTS_DB: Record<MapEffectId, MapEffectConfig> = {
     visuals: {
       tintColor: { r: 0.1, g: 0.9, b: 0.45, a: 1 },
       maxTintAlpha: 0.12,
-      maxNoiseAlpha: 0.2,
-      maxNoiseColor: 0.25,
+      maxNoiseAlpha: 0.02,
+      maxNoiseColor: 0.02,
       noiseScale: 1.4,
       noiseDensity: 0.8,
-      filamentColorContrast: 0.18,
-      filamentAlphaContrast: 0.25,
-      filamentWidth: 0.35,
-      filamentDensity: 0.65,
-      filamentEdgeBlur: 0.4,
+    },
+    postProcess: {
+      waveAmplitude: 14,
+      waveFrequency: 10,
+      waveSpeed: 1.4,
+      jitterStrength: 4,
+      jitterFrequency: 140,
+      bandSpeed: 0.12,
+      bandWidth: 0.16,
+      bandIntensity: 0.2,
     },
   },
 };

--- a/src/db/maps-db.ts
+++ b/src/db/maps-db.ts
@@ -9,6 +9,7 @@ import type { EnemySpawnData } from "../logic/modules/active-map/enemies/enemies
 import type { UnlockCondition } from "@shared/types/unlocks";
 import type { SkillId } from "./skills-db";
 import type { AchievementId } from "./achievements-db";
+import type { MapEffectId } from "./map-effects-db";
 import {
   BrickShapeBlueprint,
   buildBricksFromBlueprints,
@@ -89,6 +90,7 @@ export interface MapConfig {
   readonly spawnPoints?: readonly SceneVector2[];
   readonly enemySpawnPoints?: readonly MapEnemySpawnPointConfig[];
   readonly enemies?: MapEnemyGenerator; // Статичні вороги (турелі), що генеруються один раз при ініціалізації
+  readonly mapEffects?: readonly MapEffectId[];
   readonly unlockedBy?: readonly UnlockCondition<MapId, SkillId>[];
   readonly icon?: string;
   readonly nodePosition: MapNodePosition;
@@ -2137,6 +2139,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
       spawnPoints: [spawnPoint],
       nodePosition: { x: 4, y: 6 },
       icon: "uranium_fields.png",
+      mapEffects: ["radioactivity"],
       bricks: ({ mapLevel }) => {
 
         const numPetals = 3;

--- a/src/logic/modules/active-map/map-effects/map-effects.module.ts
+++ b/src/logic/modules/active-map/map-effects/map-effects.module.ts
@@ -32,6 +32,11 @@ export class MapEffectsModule {
     });
   }
 
+  public getEffectLevel(effectId: MapEffectId): number | null {
+    const effect = this.activeEffects.find((active) => active.id === effectId);
+    return effect ? effect.level : null;
+  }
+
   public tick(deltaMs: number): void {
     if (deltaMs <= 0 || this.activeEffects.length === 0) {
       return;
@@ -53,7 +58,9 @@ export class MapEffectsModule {
         return;
       }
 
-      const damagePercentPerSecond = effect.level * effect.hpDrainPercentPerSecond;
+      const normalizedLevel =
+        effect.maxLevel > 0 ? clampNumber(effect.level / effect.maxLevel, 0, 1) : 0;
+      const damagePercentPerSecond = normalizedLevel * effect.hpDrainPercentPerSecond;
       const damageMultiplier = (damagePercentPerSecond / 100) * deltaSeconds;
       if (damageMultiplier <= 0) {
         return;

--- a/src/logic/modules/active-map/map-effects/map-effects.module.ts
+++ b/src/logic/modules/active-map/map-effects/map-effects.module.ts
@@ -1,0 +1,88 @@
+import { clampNumber } from "@shared/helpers/numbers.helper";
+import { getMapEffectConfig, MapEffectId } from "../../../../db/map-effects-db";
+import type { EnemiesModule } from "../enemies/enemies.module";
+import type { PlayerUnitsModule } from "../player-units/player-units.module";
+import type { MapEffectRuntimeState } from "./map-effects.types";
+
+interface MapEffectsModuleOptions {
+  playerUnits: PlayerUnitsModule;
+  enemies: EnemiesModule;
+}
+
+export class MapEffectsModule {
+  private activeEffects: MapEffectRuntimeState[] = [];
+
+  constructor(private readonly options: MapEffectsModuleOptions) {}
+
+  public reset(): void {
+    this.activeEffects = [];
+  }
+
+  public startRun(effectIds: readonly MapEffectId[]): void {
+    this.activeEffects = effectIds.map((id) => {
+      const config = getMapEffectConfig(id);
+      return {
+        id,
+        level: 0,
+        maxLevel: Math.max(config.maxLevel, 0),
+        growthPerSecond: Math.max(config.growthPerSecond, 0),
+        hpDrainPercentPerSecond: Math.max(config.hpDrainPercentPerSecond, 0),
+        targets: config.targets,
+      };
+    });
+  }
+
+  public tick(deltaMs: number): void {
+    if (deltaMs <= 0 || this.activeEffects.length === 0) {
+      return;
+    }
+    const deltaSeconds = Math.max(deltaMs, 0) / 1000;
+    if (deltaSeconds <= 0) {
+      return;
+    }
+
+    this.activeEffects.forEach((effect) => {
+      if (effect.maxLevel > 0 && effect.growthPerSecond > 0) {
+        effect.level = clampNumber(
+          effect.level + effect.growthPerSecond * deltaSeconds,
+          0,
+          effect.maxLevel,
+        );
+      }
+      if (effect.level <= 0 || effect.hpDrainPercentPerSecond <= 0) {
+        return;
+      }
+
+      const damagePercentPerSecond = effect.level * effect.hpDrainPercentPerSecond;
+      const damageMultiplier = (damagePercentPerSecond / 100) * deltaSeconds;
+      if (damageMultiplier <= 0) {
+        return;
+      }
+
+      if (effect.targets.includes("playerUnits")) {
+        this.options.playerUnits.forEachUnit((unit) => {
+          if (unit.hp <= 0 || unit.maxHp <= 0) {
+            return;
+          }
+          const damage = unit.maxHp * damageMultiplier;
+          if (damage > 0) {
+            this.options.playerUnits.applyDamage(unit.id, damage);
+          }
+        });
+      }
+
+      if (effect.targets.includes("enemies")) {
+        const enemies = this.options.enemies.getEnemies();
+        enemies.forEach((enemy) => {
+          if (enemy.hp <= 0 || enemy.maxHp <= 0) {
+            return;
+          }
+          const damage = enemy.maxHp * damageMultiplier;
+          if (damage > 0) {
+            this.options.enemies.applyDamage(enemy.id, damage);
+          }
+        });
+      }
+    });
+  }
+}

--- a/src/logic/modules/active-map/map-effects/map-effects.module.ts
+++ b/src/logic/modules/active-map/map-effects/map-effects.module.ts
@@ -28,6 +28,7 @@ export class MapEffectsModule {
         growthPerSecond: Math.max(config.growthPerSecond, 0),
         hpDrainPercentPerSecond: Math.max(config.hpDrainPercentPerSecond, 0),
         targets: config.targets,
+        postProcess: config.postProcess,
       };
     });
   }
@@ -35,6 +36,20 @@ export class MapEffectsModule {
   public getEffectLevel(effectId: MapEffectId): number | null {
     const effect = this.activeEffects.find((active) => active.id === effectId);
     return effect ? effect.level : null;
+  }
+
+  public getEffectSnapshot(
+    effectId: MapEffectId
+  ): { level: number; maxLevel: number; postProcess?: MapEffectRuntimeState["postProcess"] } | null {
+    const effect = this.activeEffects.find((active) => active.id === effectId);
+    if (!effect) {
+      return null;
+    }
+    return {
+      level: effect.level,
+      maxLevel: effect.maxLevel,
+      postProcess: effect.postProcess,
+    };
   }
 
   public tick(deltaMs: number): void {

--- a/src/logic/modules/active-map/map-effects/map-effects.types.ts
+++ b/src/logic/modules/active-map/map-effects/map-effects.types.ts
@@ -1,4 +1,8 @@
-import type { MapEffectId, MapEffectTarget } from "../../../../db/map-effects-db";
+import type {
+  MapEffectId,
+  MapEffectPostProcessConfig,
+  MapEffectTarget,
+} from "../../../../db/map-effects-db";
 
 export interface MapEffectRuntimeState {
   id: MapEffectId;
@@ -7,4 +11,5 @@ export interface MapEffectRuntimeState {
   growthPerSecond: number;
   hpDrainPercentPerSecond: number;
   targets: readonly MapEffectTarget[];
+  postProcess?: MapEffectPostProcessConfig;
 }

--- a/src/logic/modules/active-map/map-effects/map-effects.types.ts
+++ b/src/logic/modules/active-map/map-effects/map-effects.types.ts
@@ -1,0 +1,10 @@
+import type { MapEffectId, MapEffectTarget } from "../../../../db/map-effects-db";
+
+export interface MapEffectRuntimeState {
+  id: MapEffectId;
+  level: number;
+  maxLevel: number;
+  growthPerSecond: number;
+  hpDrainPercentPerSecond: number;
+  targets: readonly MapEffectTarget[];
+}

--- a/src/logic/modules/active-map/map/map.const.ts
+++ b/src/logic/modules/active-map/map/map.const.ts
@@ -14,6 +14,7 @@ export const MAP_AUTO_RESTART_BRIDGE_KEY = "maps/autoRestart";
 export const MAP_SELECT_VIEW_TRANSFORM_BRIDGE_KEY = "maps/selectViewTransform";
 export const MAP_CONTROL_HINTS_COLLAPSED_BRIDGE_KEY = "maps/controlHintsCollapsed";
 export const MAP_INSPECTED_TARGET_BRIDGE_KEY = "maps/inspectedTarget";
+export const MAP_EFFECTS_BRIDGE_KEY = "maps/effects";
 
 /**
  * Default map auto-restart state.

--- a/src/logic/modules/active-map/map/map.module.ts
+++ b/src/logic/modules/active-map/map/map.module.ts
@@ -17,6 +17,7 @@ import { buildBricksFromBlueprints } from "../../../services/brick-layout/BrickL
 import { MapSelectionState } from "./map.selection";
 import { MapVisualEffects } from "./map.visual-effects";
 import { MapRunLifecycle } from "./map.run-lifecycle";
+import { MapEffectsModule } from "../map-effects/map-effects.module";
 import {
   MapAutoRestartState,
   MapLevelStats,
@@ -90,6 +91,10 @@ export class MapModule implements GameModule {
     this.newUnlocks = options.newUnlocks;
     this.selection = new MapSelectionState(DEFAULT_MAP_ID);
     const visuals = new MapVisualEffects(options.scene);
+    const mapEffects = new MapEffectsModule({
+      playerUnits: options.playerUnits,
+      enemies: options.enemies,
+    });
     this.runLifecycle = new MapRunLifecycle({
       runState: options.runState,
       resources: options.resources,
@@ -101,6 +106,7 @@ export class MapModule implements GameModule {
       necromancer: options.necromancer,
       visuals,
       scene: options.scene,
+      mapEffects,
     });
 
     options.runState.subscribe((event) => this.handleRunStateEvent(event));
@@ -527,6 +533,7 @@ export class MapModule implements GameModule {
       generateBricks,
       generateUnits,
       generateEnemies,
+      mapEffects: config.mapEffects ?? [],
     });
 
     this.pushSelectedMap();

--- a/src/logic/modules/active-map/map/map.module.ts
+++ b/src/logic/modules/active-map/map/map.module.ts
@@ -90,11 +90,11 @@ export class MapModule implements GameModule {
     this.getSkillLevel = options.getSkillLevel;
     this.newUnlocks = options.newUnlocks;
     this.selection = new MapSelectionState(DEFAULT_MAP_ID);
-    const visuals = new MapVisualEffects(options.scene);
     const mapEffects = new MapEffectsModule({
       playerUnits: options.playerUnits,
       enemies: options.enemies,
     });
+    const visuals = new MapVisualEffects(options.scene, mapEffects);
     this.runLifecycle = new MapRunLifecycle({
       runState: options.runState,
       resources: options.resources,

--- a/src/logic/modules/active-map/map/map.run-lifecycle.ts
+++ b/src/logic/modules/active-map/map/map.run-lifecycle.ts
@@ -136,7 +136,7 @@ export class MapRunLifecycle {
   }
 
   public tick(deltaMs: number): void {
-    this.options.visuals.tick();
+    this.options.visuals.tick(deltaMs);
     this.options.mapEffects.tick(deltaMs);
     if (this.runActive && this.enemySpawnPoints.length > 0) {
       this.enemySpawnController.tick(

--- a/src/logic/modules/active-map/map/map.run-lifecycle.ts
+++ b/src/logic/modules/active-map/map/map.run-lifecycle.ts
@@ -14,6 +14,8 @@ import { NecromancerModule } from "../necromancer/necromancer.module";
 import { ResourceRunController } from "./map.types";
 import { UnitAutomationModule } from "../unit-automation/unit-automation.module";
 import { ArcModule } from "../../scene/arc/arc.module";
+import { MapEffectsModule } from "../map-effects/map-effects.module";
+import type { MapEffectId } from "../../../../db/map-effects-db";
 
 interface MapRunLifecycleOptions {
   runState: MapRunState;
@@ -26,6 +28,7 @@ interface MapRunLifecycleOptions {
   necromancer: NecromancerModule;
   visuals: MapVisualEffects;
   scene: SceneObjectManager;
+  mapEffects: MapEffectsModule;
 }
 
 interface StartRunPayload {
@@ -39,6 +42,7 @@ interface StartRunPayload {
   generateBricks: boolean;
   generateUnits: boolean;
   generateEnemies: boolean;
+  mapEffects: readonly MapEffectId[];
 }
 
 export class MapRunLifecycle {
@@ -56,6 +60,7 @@ export class MapRunLifecycle {
     this.runActive = false;
     this.activeMapLevel = 0;
     this.options.visuals.reset();
+    this.options.mapEffects.reset();
     this.enemySpawnController.reset();
     this.enemySpawnPoints = [];
   }
@@ -100,6 +105,7 @@ export class MapRunLifecycle {
     }
     this.options.visuals.spawnPortals(payload.spawnPoints);
     this.options.resources.startRun();
+    this.options.mapEffects.startRun(payload.mapEffects);
   }
 
   public cleanupActiveMap(): void {
@@ -110,6 +116,7 @@ export class MapRunLifecycle {
     }
     this.runActive = false;
     this.options.visuals.reset();
+    this.options.mapEffects.reset();
     this.options.playerUnits.setUnits([]);
     this.options.bricks.setBricks([]);
     this.options.enemies.setEnemies([]);
@@ -130,6 +137,7 @@ export class MapRunLifecycle {
 
   public tick(deltaMs: number): void {
     this.options.visuals.tick();
+    this.options.mapEffects.tick(deltaMs);
     if (this.runActive && this.enemySpawnPoints.length > 0) {
       this.enemySpawnController.tick(
         deltaMs,
@@ -140,4 +148,3 @@ export class MapRunLifecycle {
     }
   }
 }
-

--- a/src/logic/modules/active-map/map/map.types.ts
+++ b/src/logic/modules/active-map/map/map.types.ts
@@ -21,6 +21,7 @@ import type { TargetSnapshot } from "../targeting/targeting.types";
 import { MapRunState } from "./MapRunState";
 import { MapSceneCleanupContract } from "./map.scene-cleanup";
 import { NewUnlockNotificationService } from "@logic/services/new-unlock-notification/NewUnlockNotification";
+import type { MapEffectPostProcessConfig } from "../../../../db/map-effects-db";
 
 export interface ResourceRunController {
   startRun(): void;
@@ -89,6 +90,14 @@ export interface MapRunResult {
 export interface MapAutoRestartState {
   readonly unlocked: boolean;
   readonly enabled: boolean;
+}
+
+export interface MapEffectsBridgeState {
+  readonly radioactivity: {
+    level: number;
+    maxLevel: number;
+    postProcess?: MapEffectPostProcessConfig;
+  } | null;
 }
 
 export type MapModuleInstance = GameModule & { id: string };

--- a/src/logic/modules/active-map/map/map.visual-effects.ts
+++ b/src/logic/modules/active-map/map/map.visual-effects.ts
@@ -1,6 +1,5 @@
 import { SceneObjectManager } from "@core/logic/provided/services/scene-object-manager/SceneObjectManager";
 import type { SceneSize, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
-import { createSolidFill } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.helpers";
 import { createRadialGradientFill } from "@shared/helpers/scene-fill.helper";
 import { clampNumber } from "@shared/helpers/numbers.helper";
 import { getMapEffectConfig } from "../../../../db/map-effects-db";
@@ -158,27 +157,50 @@ export class MapVisualEffects {
       y: camera.position.y + camera.viewportSize.height / 2,
     };
     const size = this.resolveViewportSize(camera.viewportSize);
-    const fill = createSolidFill(
-      {
-        r: visuals.tintColor.r,
-        g: visuals.tintColor.g,
-        b: visuals.tintColor.b,
-        a: visuals.maxTintAlpha * intensity * (0.85 + 0.15 * flicker),
-      },
-      {
-        noise: {
-          colorAmplitude: visuals.maxNoiseColor * artifactStrength * (0.75 + 0.25 * pulse),
-          alphaAmplitude: visuals.maxNoiseAlpha * artifactStrength * (0.75 + 0.25 * flicker),
-          scale: visuals.noiseScale,
-          density: visuals.noiseDensity,
+    const baseAlpha = visuals.maxTintAlpha * intensity * (0.9 + 0.1 * flicker);
+    const radius = Math.max(size.width, size.height) * (0.6 + 0.2 * pulse);
+    const noiseEnabled = visuals.maxNoiseAlpha > 0 || visuals.maxNoiseColor > 0;
+    const fill = createRadialGradientFill(
+      radius,
+      [
+        {
+          offset: 0,
+          color: {
+            r: visuals.tintColor.r,
+            g: visuals.tintColor.g,
+            b: visuals.tintColor.b,
+            a: baseAlpha,
+          },
         },
-        filaments: {
-          colorContrast: visuals.filamentColorContrast * artifactStrength,
-          alphaContrast: visuals.filamentAlphaContrast * artifactStrength,
-          width: visuals.filamentWidth,
-          density: visuals.filamentDensity * artifactStrength,
-          edgeBlur: visuals.filamentEdgeBlur,
+        {
+          offset: 0.55,
+          color: {
+            r: visuals.tintColor.r,
+            g: visuals.tintColor.g,
+            b: visuals.tintColor.b,
+            a: baseAlpha * 0.6,
+          },
         },
+        {
+          offset: 1,
+          color: {
+            r: visuals.tintColor.r,
+            g: visuals.tintColor.g,
+            b: visuals.tintColor.b,
+            a: 0,
+          },
+        },
+      ],
+      {
+        start: { x: 0, y: 0 },
+        noise: noiseEnabled
+          ? {
+              colorAmplitude: visuals.maxNoiseColor * artifactStrength,
+              alphaAmplitude: visuals.maxNoiseAlpha * artifactStrength,
+              scale: visuals.noiseScale,
+              density: visuals.noiseDensity,
+            }
+          : undefined,
       }
     );
 

--- a/src/logic/modules/active-map/player-units/player-units.module.ts
+++ b/src/logic/modules/active-map/player-units/player-units.module.ts
@@ -656,6 +656,10 @@ export class PlayerUnitsModule implements GameModule {
     return found;
   }
 
+  public forEachUnit(visitor: (unit: PlayerUnitState) => void): void {
+    this.unitOrder.forEach((unit) => visitor(this.cloneUnit(unit)));
+  }
+
   public forEachUnitNear(
     position: SceneVector2,
     radius: number,

--- a/src/ui/renderers/objects/implementations/screen-overlay/ScreenOverlayRenderer.ts
+++ b/src/ui/renderers/objects/implementations/screen-overlay/ScreenOverlayRenderer.ts
@@ -1,0 +1,25 @@
+import {
+  DynamicPrimitive,
+  ObjectRegistration,
+  ObjectRenderer,
+} from "../../ObjectRenderer";
+import type { SceneObjectInstance } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import { createDynamicRectanglePrimitive } from "../../../primitives";
+
+export class ScreenOverlayRenderer extends ObjectRenderer {
+  public register(instance: SceneObjectInstance): ObjectRegistration {
+    const dynamicPrimitives: DynamicPrimitive[] = [];
+
+    dynamicPrimitives.push(
+      createDynamicRectanglePrimitive(instance, {
+        getSize: (target) => target.data.size,
+        getFill: (target) => target.data.fill,
+      })
+    );
+
+    return {
+      staticPrimitives: [],
+      dynamicPrimitives,
+    };
+  }
+}

--- a/src/ui/renderers/objects/implementations/screen-overlay/index.ts
+++ b/src/ui/renderers/objects/implementations/screen-overlay/index.ts
@@ -1,0 +1,1 @@
+export { ScreenOverlayRenderer } from "./ScreenOverlayRenderer";

--- a/src/ui/renderers/objects/index.ts
+++ b/src/ui/renderers/objects/index.ts
@@ -12,6 +12,7 @@ import { AuraRenderer } from "./implementations/aura";
 import { SpellProjectileRingRenderer } from "./implementations/spell-projectile-ring";
 import { SandStormRenderer } from "./implementations/sand-storm";
 import { PersistentAoeSpellRenderer } from "./implementations/persistent-aoe-spell";
+import { ScreenOverlayRenderer } from "./implementations/screen-overlay";
 import { TiedObjectsRegistry } from "./TiedObjectsRegistry";
 
 export { ObjectsRendererManager } from "./ObjectsRendererManager";
@@ -58,6 +59,7 @@ export const createObjectsRendererManager = (): ObjectsRendererManager => {
     // unitProjectileRing - now rendered via GPU instancing (RingGpuRenderer)
     ["sandStorm", new SandStormRenderer()],
     ["spellPersistentAoe", new PersistentAoeSpellRenderer()],
+    ["screenOverlay", new ScreenOverlayRenderer()],
   ]);
   const tiedObjectsRegistry = new TiedObjectsRegistry();
   return new ObjectsRendererManager(renderers, tiedObjectsRegistry);

--- a/src/ui/renderers/shaders/radiationPostProcess.glsl.ts
+++ b/src/ui/renderers/shaders/radiationPostProcess.glsl.ts
@@ -1,0 +1,64 @@
+export const RADIATION_POST_PROCESS_VERTEX_SHADER = `#version 300 es
+precision highp float;
+
+in vec2 a_position;
+in vec2 a_uv;
+
+out vec2 v_uv;
+
+void main() {
+  v_uv = a_uv;
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}
+`;
+
+export const RADIATION_POST_PROCESS_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+
+in vec2 v_uv;
+
+uniform sampler2D u_sceneTexture;
+uniform float u_time;
+uniform float u_intensity;
+uniform vec2 u_resolution;
+uniform float u_waveAmplitude;
+uniform float u_waveFrequency;
+uniform float u_waveSpeed;
+uniform float u_jitterStrength;
+uniform float u_jitterFrequency;
+uniform float u_bandSpeed;
+uniform float u_bandWidth;
+uniform float u_bandIntensity;
+
+out vec4 fragColor;
+
+float hash(float n) {
+  return fract(sin(n) * 43758.5453123);
+}
+
+void main() {
+  float intensity = clamp(u_intensity, 0.0, 1.0);
+  vec2 uv = v_uv;
+
+  float wave = sin(uv.y * u_waveFrequency + u_time * u_waveSpeed);
+  float waveShift = wave * u_waveAmplitude * intensity / max(u_resolution.x, 1.0);
+
+  float line = floor(uv.y * u_jitterFrequency);
+  float jitterSeed = line + floor(u_time * 60.0);
+  float jitter = (hash(jitterSeed) - 0.5) * 2.0;
+  float jitterShift = jitter * u_jitterStrength * intensity / max(u_resolution.x, 1.0);
+
+  uv.x += waveShift + jitterShift;
+  uv = clamp(uv, vec2(0.0), vec2(1.0));
+
+  vec4 color = texture(u_sceneTexture, uv);
+
+  float bandPos = fract(u_time * u_bandSpeed);
+  float bandDist = abs(uv.y - bandPos);
+  float band = smoothstep(u_bandWidth, 0.0, bandDist);
+  float bandGlow = band * u_bandIntensity * intensity;
+  color.rgb += bandGlow;
+
+  fragColor = color;
+}
+`;

--- a/src/ui/renderers/utils/RadiationPostProcess.ts
+++ b/src/ui/renderers/utils/RadiationPostProcess.ts
@@ -1,0 +1,204 @@
+import { compileShader, linkProgram } from "./webglProgram";
+import {
+  RADIATION_POST_PROCESS_FRAGMENT_SHADER,
+  RADIATION_POST_PROCESS_VERTEX_SHADER,
+} from "../shaders/radiationPostProcess.glsl";
+import type { MapEffectPostProcessConfig } from "@db/map-effects-db";
+
+interface PostProcessResources {
+  program: WebGLProgram;
+  vertexShader: WebGLShader;
+  fragmentShader: WebGLShader;
+  vertexBuffer: WebGLBuffer;
+  vertexArray: WebGLVertexArrayObject;
+  framebuffer: WebGLFramebuffer;
+  texture: WebGLTexture;
+}
+
+export class RadiationPostProcess {
+  private resources: PostProcessResources | null = null;
+  private width = 0;
+  private height = 0;
+
+  public beginFrame(gl: WebGL2RenderingContext, width: number, height: number): boolean {
+    if (!this.ensureResources(gl)) {
+      return false;
+    }
+    this.resize(gl, width, height);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.resources!.framebuffer);
+    gl.viewport(0, 0, width, height);
+    return true;
+  }
+
+  public render(
+    gl: WebGL2RenderingContext,
+    timeSeconds: number,
+    intensity: number,
+    config: MapEffectPostProcessConfig,
+  ): void {
+    if (!this.resources || intensity <= 0) {
+      return;
+    }
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.viewport(0, 0, this.width, this.height);
+    gl.useProgram(this.resources.program);
+    gl.bindVertexArray(this.resources.vertexArray);
+
+    const textureLocation = gl.getUniformLocation(
+      this.resources.program,
+      "u_sceneTexture"
+    );
+    if (textureLocation) {
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, this.resources.texture);
+      gl.uniform1i(textureLocation, 0);
+    }
+
+    this.setUniform(gl, "u_time", timeSeconds);
+    this.setUniform(gl, "u_intensity", intensity);
+    this.setUniform2(gl, "u_resolution", this.width, this.height);
+    this.setUniform(gl, "u_waveAmplitude", config.waveAmplitude);
+    this.setUniform(gl, "u_waveFrequency", config.waveFrequency);
+    this.setUniform(gl, "u_waveSpeed", config.waveSpeed);
+    this.setUniform(gl, "u_jitterStrength", config.jitterStrength);
+    this.setUniform(gl, "u_jitterFrequency", config.jitterFrequency);
+    this.setUniform(gl, "u_bandSpeed", config.bandSpeed);
+    this.setUniform(gl, "u_bandWidth", config.bandWidth);
+    this.setUniform(gl, "u_bandIntensity", config.bandIntensity);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+  }
+
+  public dispose(gl: WebGL2RenderingContext): void {
+    if (!this.resources) {
+      return;
+    }
+    gl.deleteBuffer(this.resources.vertexBuffer);
+    gl.deleteVertexArray(this.resources.vertexArray);
+    gl.deleteTexture(this.resources.texture);
+    gl.deleteFramebuffer(this.resources.framebuffer);
+    gl.deleteProgram(this.resources.program);
+    gl.deleteShader(this.resources.vertexShader);
+    gl.deleteShader(this.resources.fragmentShader);
+    this.resources = null;
+  }
+
+  private ensureResources(gl: WebGL2RenderingContext): boolean {
+    if (this.resources) {
+      return true;
+    }
+    const vertexShader = compileShader(
+      gl,
+      gl.VERTEX_SHADER,
+      RADIATION_POST_PROCESS_VERTEX_SHADER
+    );
+    const fragmentShader = compileShader(
+      gl,
+      gl.FRAGMENT_SHADER,
+      RADIATION_POST_PROCESS_FRAGMENT_SHADER
+    );
+    const program = linkProgram(gl, vertexShader, fragmentShader);
+
+    const vertexBuffer = gl.createBuffer();
+    const vertexArray = gl.createVertexArray();
+    const framebuffer = gl.createFramebuffer();
+    const texture = gl.createTexture();
+
+    if (!vertexBuffer || !vertexArray || !framebuffer || !texture) {
+      return false;
+    }
+
+    gl.bindVertexArray(vertexArray);
+    gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+
+    const vertices = new Float32Array([
+      -1, -1, 0, 0,
+      1, -1, 1, 0,
+      -1, 1, 0, 1,
+      -1, 1, 0, 1,
+      1, -1, 1, 0,
+      1, 1, 1, 1,
+    ]);
+    gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+
+    const positionLocation = gl.getAttribLocation(program, "a_position");
+    const uvLocation = gl.getAttribLocation(program, "a_uv");
+    if (positionLocation >= 0) {
+      gl.enableVertexAttribArray(positionLocation);
+      gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 16, 0);
+    }
+    if (uvLocation >= 0) {
+      gl.enableVertexAttribArray(uvLocation);
+      gl.vertexAttribPointer(uvLocation, 2, gl.FLOAT, false, 16, 8);
+    }
+
+    this.resources = {
+      program,
+      vertexShader,
+      fragmentShader,
+      vertexBuffer,
+      vertexArray,
+      framebuffer,
+      texture,
+    };
+    return true;
+  }
+
+  private resize(gl: WebGL2RenderingContext, width: number, height: number): void {
+    if (!this.resources || (this.width === width && this.height === height)) {
+      return;
+    }
+    this.width = width;
+    this.height = height;
+    gl.bindTexture(gl.TEXTURE_2D, this.resources.texture);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      width,
+      height,
+      0,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      null
+    );
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.resources.framebuffer);
+    gl.framebufferTexture2D(
+      gl.FRAMEBUFFER,
+      gl.COLOR_ATTACHMENT0,
+      gl.TEXTURE_2D,
+      this.resources.texture,
+      0
+    );
+  }
+
+  private setUniform(gl: WebGL2RenderingContext, name: string, value: number): void {
+    if (!this.resources) {
+      return;
+    }
+    const location = gl.getUniformLocation(this.resources.program, name);
+    if (location) {
+      gl.uniform1f(location, value);
+    }
+  }
+
+  private setUniform2(
+    gl: WebGL2RenderingContext,
+    name: string,
+    x: number,
+    y: number
+  ): void {
+    if (!this.resources) {
+      return;
+    }
+    const location = gl.getUniformLocation(this.resources.program, name);
+    if (location) {
+      gl.uniform2f(location, x, y);
+    }
+  }
+}

--- a/src/ui/renderers/utils/RadiationPostProcess.ts
+++ b/src/ui/renderers/utils/RadiationPostProcess.ts
@@ -88,6 +88,7 @@ export class RadiationPostProcess {
     if (!this.resources) {
       return;
     }
+    console.warn("[RadiationPostProcess] Blitting scene to screen (fallback).");
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this.resources.framebuffer);
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
     gl.blitFramebuffer(

--- a/src/ui/screens/Scene/SceneScreen.tsx
+++ b/src/ui/screens/Scene/SceneScreen.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_SPELL_OPTIONS,
   SPELL_OPTIONS_BRIDGE_KEY,
 } from "@logic/modules/active-map/spellcasting/spellcasting.const";
+import { MAP_EFFECTS_BRIDGE_KEY } from "@logic/modules/active-map/map/map.const";
 import { NECROMANCER_SPAWN_OPTIONS_BRIDGE_KEY } from "@logic/modules/active-map/necromancer/necromancer.const";
 import { useSceneRunState } from "./hooks/useSceneRunState";
 import { useSceneCameraInteraction } from "./hooks/useSceneCameraInteraction";
@@ -36,6 +37,7 @@ import { SceneTutorialBridgeMonitor } from "./components/tutorial/SceneTutorialB
 import { SceneSummoningPanelContainer } from "./components/summoning/SceneSummoningPanelContainer";
 
 const EMPTY_SPAWN_OPTIONS: NecromancerSpawnOption[] = [];
+const DEFAULT_MAP_EFFECTS_STATE = { radioactivity: null };
 
 interface SceneScreenProps {
   onExit: () => void;
@@ -72,6 +74,11 @@ export const SceneScreen: React.FC<SceneScreenProps> = ({
     bridge,
     SPELL_OPTIONS_BRIDGE_KEY,
     DEFAULT_SPELL_OPTIONS
+  );
+  const mapEffectsRef = useBridgeRef(
+    bridge,
+    MAP_EFFECTS_BRIDGE_KEY,
+    DEFAULT_MAP_EFFECTS_STATE
   );
   const [summoningTooltipContent, setSummoningTooltipContent] =
     useState<SceneTooltipContent | null>(null);
@@ -161,6 +168,7 @@ export const SceneScreen: React.FC<SceneScreenProps> = ({
       scene,
       spellcasting,
       gameLoop,
+      mapEffectsRef,
       selectedSpellIdRef,
       spellOptionsRef,
       isPauseOpen,

--- a/src/ui/screens/Scene/hooks/useSceneCameraInteraction.ts
+++ b/src/ui/screens/Scene/hooks/useSceneCameraInteraction.ts
@@ -20,11 +20,13 @@ import {
   useSceneCanvas,
 } from "./useSceneCanvas";
 import type { GameLoopUiApi } from "@core/logic/provided/services/game-loop/game-loop.types";
+import type { MapEffectsBridgeState } from "@logic/modules/active-map/map/map.types";
 
 interface UseSceneCameraInteractionArgs {
   scene: SceneUiApi;
   spellcasting: SpellcastingModuleUiApi;
   gameLoop: GameLoopUiApi;
+  mapEffectsRef: MutableRefObject<MapEffectsBridgeState>;
   selectedSpellIdRef: MutableRefObject<SpellId | null>;
   spellOptionsRef: MutableRefObject<SpellOption[]>;
   isPauseOpen: boolean;
@@ -82,6 +84,7 @@ export const useSceneCameraInteraction = ({
   lastPointerPositionRef,
   onSpellCast,
   onInspectTarget,
+  mapEffectsRef,
 }: UseSceneCameraInteractionArgs): UseSceneCameraInteractionResult => {
   // Delay scale initialization until viewport is properly sized
   const hasInitializedScaleRef = useRef(false);
@@ -166,6 +169,7 @@ export const useSceneCameraInteraction = ({
     scene,
     spellcasting,
     gameLoop,
+    mapEffectsRef,
     canvasRef,
     wrapperRef,
     summoningPanelRef,

--- a/src/ui/screens/Scene/hooks/useSceneCanvas.ts
+++ b/src/ui/screens/Scene/hooks/useSceneCanvas.ts
@@ -363,6 +363,9 @@ export const useSceneCanvas = ({
             canvas.width,
             canvas.height
           );
+          if (!postProcessActiveRef.current) {
+            console.warn("[RadiationPostProcess] Disabled due to framebuffer setup failure.");
+          }
         } else {
           postProcessActiveRef.current = false;
           gl.bindFramebuffer(gl.FRAMEBUFFER, null);
@@ -426,7 +429,8 @@ export const useSceneCanvas = ({
             );
             gl.enable(gl.BLEND);
           } else {
-            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+            console.warn("[RadiationPostProcess] Skipped render; falling back to blit.");
+            postProcessRef.current.blitToScreen(gl);
           }
         }
         // Tick FPS counter (no separate rAF needed)

--- a/src/ui/screens/Scene/hooks/useSceneCanvas.ts
+++ b/src/ui/screens/Scene/hooks/useSceneCanvas.ts
@@ -357,10 +357,14 @@ export const useSceneCanvas = ({
           radiation && radiation.maxLevel > 0 ? radiation.level / radiation.maxLevel : 0;
         const config = radiation?.postProcess;
         const active = Boolean(config && intensity > 0.01);
-        postProcessActiveRef.current = active;
         if (active) {
-          postProcessRef.current.beginFrame(gl, canvas.width, canvas.height);
+          postProcessActiveRef.current = postProcessRef.current.beginFrame(
+            gl,
+            canvas.width,
+            canvas.height
+          );
         } else {
+          postProcessActiveRef.current = false;
           gl.bindFramebuffer(gl.FRAMEBUFFER, null);
           gl.viewport(0, 0, canvas.width, canvas.height);
         }
@@ -413,12 +417,14 @@ export const useSceneCanvas = ({
           const intensity =
             radiation && radiation.maxLevel > 0 ? radiation.level / radiation.maxLevel : 0;
           if (radiation?.postProcess && intensity > 0.01) {
+            gl.disable(gl.BLEND);
             postProcessRef.current.render(
               gl,
               timestamp / 1000,
               intensity,
               radiation.postProcess
             );
+            gl.enable(gl.BLEND);
           } else {
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
           }

--- a/src/ui/screens/Scene/hooks/useSceneCanvas.ts
+++ b/src/ui/screens/Scene/hooks/useSceneCanvas.ts
@@ -127,6 +127,7 @@ export const useSceneCanvas = ({
   const postProcessRef = useRef(new RadiationPostProcess());
   const postProcessActiveRef = useRef(false);
   const postProcessLastReasonRef = useRef<string | null>(null);
+  const postProcessLastSampleLogRef = useRef(0);
   // Separate ref for right mouse panning to track previous position
   const rightMouseLastPositionRef = useRef<{ x: number; y: number } | null>(null);
   const rightMouseDownPositionRef = useRef<{ x: number; y: number } | null>(null);
@@ -443,6 +444,20 @@ export const useSceneCanvas = ({
               radiation.postProcess
             );
             gl.enable(gl.BLEND);
+            if (timestamp - postProcessLastSampleLogRef.current > 2000) {
+              postProcessLastSampleLogRef.current = timestamp;
+              const sample = postProcessRef.current.sampleFramebufferPixel(gl);
+              if (sample) {
+                console.info("[RadiationPostProcess] FBO sample:", {
+                  r: sample[0],
+                  g: sample[1],
+                  b: sample[2],
+                  a: sample[3],
+                });
+              } else {
+                console.warn("[RadiationPostProcess] FBO sample unavailable.");
+              }
+            }
             if (!rendered) {
               console.warn("[RadiationPostProcess] Render failed; falling back to blit.");
               postProcessRef.current.blitToScreen(gl);

--- a/src/ui/screens/Scene/hooks/useSceneCanvas.ts
+++ b/src/ui/screens/Scene/hooks/useSceneCanvas.ts
@@ -126,6 +126,7 @@ export const useSceneCanvas = ({
   const movableStatsLastUpdateRef = useRef(0);
   const postProcessRef = useRef(new RadiationPostProcess());
   const postProcessActiveRef = useRef(false);
+  const postProcessLastReasonRef = useRef<string | null>(null);
   // Separate ref for right mouse panning to track previous position
   const rightMouseLastPositionRef = useRef<{ x: number; y: number } | null>(null);
   const rightMouseDownPositionRef = useRef<{ x: number; y: number } | null>(null);
@@ -357,6 +358,20 @@ export const useSceneCanvas = ({
           radiation && radiation.maxLevel > 0 ? radiation.level / radiation.maxLevel : 0;
         const config = radiation?.postProcess;
         const active = Boolean(config && intensity > 0.01);
+        const nextReason = active
+          ? "active"
+          : !radiation
+            ? "no-radioactivity"
+            : !config
+              ? "no-postprocess-config"
+              : "intensity-too-low";
+        if (postProcessLastReasonRef.current !== nextReason) {
+          postProcessLastReasonRef.current = nextReason;
+          console.info("[RadiationPostProcess] State:", {
+            reason: nextReason,
+            intensity: Number(intensity.toFixed(3)),
+          });
+        }
         if (active) {
           postProcessActiveRef.current = postProcessRef.current.beginFrame(
             gl,

--- a/src/ui/screens/Scene/hooks/useSceneCanvas.ts
+++ b/src/ui/screens/Scene/hooks/useSceneCanvas.ts
@@ -446,20 +446,6 @@ export const useSceneCanvas = ({
               radiation.postProcess
             );
             gl.enable(gl.BLEND);
-            if (timestamp - postProcessLastSampleLogRef.current > 2000) {
-              postProcessLastSampleLogRef.current = timestamp;
-              const sample = postProcessRef.current.sampleFramebufferPixel(gl);
-              if (sample) {
-                console.info("[RadiationPostProcess] FBO sample:", {
-                  r: sample[0],
-                  g: sample[1],
-                  b: sample[2],
-                  a: sample[3],
-                });
-              } else {
-                console.warn("[RadiationPostProcess] FBO sample unavailable.");
-              }
-            }
             if (!rendered) {
               console.warn("[RadiationPostProcess] Render failed; falling back to blit.");
               postProcessRef.current.blitToScreen(gl);

--- a/src/ui/screens/Scene/hooks/useSceneCanvas.ts
+++ b/src/ui/screens/Scene/hooks/useSceneCanvas.ts
@@ -436,13 +436,17 @@ export const useSceneCanvas = ({
             radiation && radiation.maxLevel > 0 ? radiation.level / radiation.maxLevel : 0;
           if (radiation?.postProcess && intensity > 0.01) {
             gl.disable(gl.BLEND);
-            postProcessRef.current.render(
+            const rendered = postProcessRef.current.render(
               gl,
               timestamp / 1000,
               intensity,
               radiation.postProcess
             );
             gl.enable(gl.BLEND);
+            if (!rendered) {
+              console.warn("[RadiationPostProcess] Render failed; falling back to blit.");
+              postProcessRef.current.blitToScreen(gl);
+            }
           } else {
             console.warn("[RadiationPostProcess] Skipped render; falling back to blit.");
             postProcessRef.current.blitToScreen(gl);

--- a/src/ui/screens/Scene/hooks/useWebGLRenderLoop.ts
+++ b/src/ui/screens/Scene/hooks/useWebGLRenderLoop.ts
@@ -31,6 +31,15 @@ export type AfterUpdateCallback = (
 ) => void;
 
 /**
+ * Callback called before base scene render
+ */
+export type BeforeRenderCallback = (
+  timestamp: number,
+  gl: WebGL2RenderingContext,
+  cameraState: SceneCameraState
+) => void;
+
+/**
  * Callback called after base scene render but before effects
  */
 export type BeforeEffectsCallback = (
@@ -61,6 +70,8 @@ export interface CreateWebGLRenderLoopOptions {
   afterApplyChanges?: AfterApplyChangesCallback;
   /** Optional callback after scene update */
   afterUpdate?: AfterUpdateCallback;
+  /** Optional callback before base scene render */
+  beforeRender?: BeforeRenderCallback;
   /** Optional callback before effects rendering */
   beforeEffects?: BeforeEffectsCallback;
   /** Optional callback after all rendering */
@@ -102,6 +113,7 @@ export const createWebGLRenderLoop = (
     beforeUpdate,
     afterApplyChanges,
     afterUpdate,
+    beforeRender,
     beforeEffects,
     afterRender,
   } = options;
@@ -137,6 +149,11 @@ export const createWebGLRenderLoop = (
     // Step 7: After update callback
     if (afterUpdate) {
       afterUpdate(timestamp, scene, cameraState);
+    }
+
+    // Step 7.5: Before render callback
+    if (beforeRender) {
+      beforeRender(timestamp, gl, cameraState);
     }
 
     // Step 7: Render base scene


### PR DESCRIPTION
### Motivation
- Introduce a system for map-wide environmental effects (e.g., radioactivity) that evolve over time and affect units on the map.
- Allow maps to opt into these effects via their configuration so specific maps can apply global hazards.

### Description
- Add a map effect registry `src/db/map-effects-db.ts` defining `radioactivity` and its parameters and expose `getMapEffectConfig`.
- Extend `MapConfig` in `src/db/maps-db.ts` with a new `mapEffects` field and enable `radioactivity` for the `uranium_fields` map.
- Add runtime types `src/logic/modules/active-map/map-effects/map-effects.types.ts` and a `MapEffectsModule` implementation in `src/logic/modules/active-map/map-effects/map-effects.module.ts` that manages effect levels, growth, and per-tick HP drain applied to `playerUnits` and `enemies`.
- Wire the module into the map lifecycle by instantiating `MapEffectsModule` in `MapModule` and threading it through `MapRunLifecycle` (`startRun`, `tick`, `reset`, and cleanup) so effects are started and ticked during runs.
- Expose `forEachUnit` in `PlayerUnitsModule` to allow map-wide logic to iterate player units, and use existing `applyDamage` APIs to inflict damage.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e69876adc8320964dec3b5a181d02)