### PR TITLE
Log GPU status and warn on software rendering at Electron startup

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -35,7 +35,26 @@ function createWindow() {
   });
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  const gpuStatus = app.getGPUFeatureStatus();
+  console.log('[electron][gpu] Feature status:', gpuStatus);
+  try {
+    const gpuInfo = await app.getGPUInfo('basic');
+    console.log('[electron][gpu] Basic info:', gpuInfo);
+  } catch (error) {
+    console.warn('[electron][gpu] Failed to read basic GPU info.', error);
+  }
+
+  const gpuStatusValues = Object.values(gpuStatus ?? {});
+  const usesSoftwareRendering = gpuStatusValues.some(
+    (value) => typeof value === 'string' && value.includes('software')
+  );
+  if (usesSoftwareRendering) {
+    console.warn(
+      '[electron][gpu] Software rendering detected. Consider запуск із прапорцями ' +
+        'ELECTRON_FORCE_GPU=true або ELECTRON_DISABLE_SW=true.'
+    );
+  }
   protocol.registerFileProtocol('file', (request, callback) => {
     const urlPath = decodeURIComponent(new URL(request.url).pathname);
     const normalizedPath = urlPath.replace(/\\/g, '/');


### PR DESCRIPTION
### Motivation
- Provide immediate diagnostic output at app startup to detect SwiftShader or other software rendering.
- Make it quick to confirm or exclude software rendering as the cause of rendering or performance issues.
- Offer actionable guidance when software rendering is detected by suggesting GPU-related environment flags.

### Description
- Make the `app.whenReady()` handler `async` and call `app.getGPUFeatureStatus()` to log GPU feature status.
- Call `app.getGPUInfo('basic')` inside a `try/catch` and log the basic GPU info or a warning on failure.
- Detect any GPU feature status values containing the substring `"software"` and emit a `console.warn` suggesting `ELECTRON_FORCE_GPU=true` or `ELECTRON_DISABLE_SW=true`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696faf95a0f48320b0eac28855fad747)