### PR TITLE
Align bullet tail origin with bullet center

### DIFF
--- a/src/logic/modules/active-map/projectiles/projectiles.types.ts
+++ b/src/logic/modules/active-map/projectiles/projectiles.types.ts
@@ -101,6 +101,7 @@ export interface UnitProjectileState extends UnitProjectileSpawn {
     radiansPerMs: number;
     rotationRad: number;
   };
+  rendererCustomData: Record<string, unknown>;
   // GPU rendering slot (if using GPU instanced rendering)
   gpuSlot?: BulletSlotHandle;
   // Прапорець для пропуску руху в перший тік

--- a/src/logic/services/bullet-render-bridge/BulletRenderBridge.ts
+++ b/src/logic/services/bullet-render-bridge/BulletRenderBridge.ts
@@ -63,11 +63,12 @@ export const acquireGpuBulletSlot = (config: BulletVisualConfig): BulletSlotHand
 export const updateGpuBulletSlot = (
   handle: BulletSlotHandle,
   position: SceneVector2,
-  rotation: number,
+  movementRotation: number,
+  visualRotation: number,
   radius: number,
   active: boolean
 ): void => {
-  bridge.updateSlot(handle, position, rotation, radius, active);
+  bridge.updateSlot(handle, position, movementRotation, visualRotation, radius, active);
 };
 
 /**

--- a/src/logic/services/bullet-render-bridge/bullet-render-bridge.types.ts
+++ b/src/logic/services/bullet-render-bridge/bullet-render-bridge.types.ts
@@ -32,7 +32,8 @@ export type AcquireSlotFn = (config: BulletVisualConfig) => BulletSlotHandle | n
 export type UpdateSlotFn = (
   handle: BulletSlotHandle,
   position: SceneVector2,
-  rotation: number,
+  movementRotation: number,
+  visualRotation: number,
   radius: number,
   active: boolean
 ) => void;

--- a/src/ui/renderers/objects/implementations/bullet/BulletObjectRenderer.ts
+++ b/src/ui/renderers/objects/implementations/bullet/BulletObjectRenderer.ts
@@ -9,7 +9,7 @@ import {
   createDynamicTrianglePrimitive,
   createParticleEmitterPrimitive,
 } from "../../../primitives";
-import { getRenderComponents, getProjectileShape } from "./helpers";
+import { getRenderComponents, getProjectileShape, getMovementRotation } from "./helpers";
 import { getTailConfig, createTailVertices, createTailFill } from "./tail.helpers";
 import {
   getTailEmitterConfig,
@@ -71,6 +71,7 @@ export class BulletObjectRenderer extends ObjectRenderer {
         createDynamicTrianglePrimitive(instance, {
           vertices: tailVertices,
           fill: tailFill,
+          getRotation: getMovementRotation,
         })
       );
     }

--- a/src/ui/renderers/objects/implementations/bullet/emitter.helpers.ts
+++ b/src/ui/renderers/objects/implementations/bullet/emitter.helpers.ts
@@ -12,7 +12,7 @@ import type {
   BulletEmitterKey,
 } from "./types";
 import type { ParticleEmitterConfig } from "../../../../../logic/interfaces/visuals/particle-emitters-config";
-import { getBulletRadius } from "./helpers";
+import { getBulletRadius, getMovementRotation } from "./helpers";
 
 // Caches for emitter configs
 const tailEmitterConfigCache = new WeakMap<
@@ -172,7 +172,7 @@ export const getTailEmitterOrigin = (
   };
   return transformObjectPoint(
     getInstanceRenderPosition(instance),
-    instance.data.rotation,
+    getMovementRotation(instance),
     offset
   );
 };
@@ -185,7 +185,7 @@ export const createTailParticle = (
   instance: SceneObjectInstance,
   config: BulletTailEmitterRenderConfig
 ): ParticleEmitterParticleState => {
-  const baseDirection = (instance.data.rotation ?? 0) + Math.PI;
+  const baseDirection = getMovementRotation(instance) + Math.PI;
   const halfSpread = config.spread / 2;
   const direction =
     baseDirection + (config.spread > 0 ? randomBetween(-halfSpread, halfSpread) : 0);
@@ -225,7 +225,7 @@ export const getGpuSpawnConfig = (
   spawnRadiusMin: 0,
   spawnRadiusMax: 0,
   arc: 0,
-  direction: (instance.data.rotation ?? 0) + Math.PI,
+  direction: getMovementRotation(instance) + Math.PI,
   spread: config.spread,
   radialVelocity: false,
 });

--- a/src/ui/renderers/objects/implementations/bullet/helpers.ts
+++ b/src/ui/renderers/objects/implementations/bullet/helpers.ts
@@ -77,6 +77,18 @@ export const getBulletRadius = (instance: SceneObjectInstance): number => {
 };
 
 /**
+ * Gets projectile movement rotation (used for tail/emitters)
+ */
+export const getMovementRotation = (instance: SceneObjectInstance): number => {
+  const data = instance.data.customData as BulletRendererCustomData | undefined;
+  const rotation =
+    typeof data?.movementRotation === "number" && Number.isFinite(data.movementRotation)
+      ? data.movementRotation
+      : instance.data.rotation;
+  return typeof rotation === "number" && Number.isFinite(rotation) ? rotation : 0;
+};
+
+/**
  * Gets projectile shape (circle or sprite)
  */
 export const getProjectileShape = (instance: SceneObjectInstance): "circle" | "sprite" => {

--- a/src/ui/renderers/objects/implementations/bullet/tail.helpers.ts
+++ b/src/ui/renderers/objects/implementations/bullet/tail.helpers.ts
@@ -92,10 +92,11 @@ export const createTailVertices = (
 
   const tailLength = radius * tail.lengthMultiplier;
   const tailHalfWidth = (radius * tail.widthMultiplier) / 2;
+  const tailStartX = -radius;
   const vertices: [SceneVector2, SceneVector2, SceneVector2] = [
-    { x: 0, y: tailHalfWidth },
-    { x: 0, y: -tailHalfWidth },
-    { x: -tailLength, y: 0 },
+    { x: tailStartX, y: tailHalfWidth },
+    { x: tailStartX, y: -tailHalfWidth },
+    { x: tailStartX - tailLength, y: 0 },
   ];
 
   tailVerticesCache.set(instance, { radius, tailRef: tail, vertices });
@@ -114,10 +115,11 @@ export const createTailFill = (instance: SceneObjectInstance): SceneLinearGradie
   }
 
   const tailLength = radius * tail.lengthMultiplier;
+  const tailStartX = -radius;
   const fill: SceneLinearGradientFill = {
     fillType: FILL_TYPES.LINEAR_GRADIENT,
-    start: { x: 0, y: 0 },
-    end: { x: -tailLength, y: 0 },
+    start: { x: tailStartX, y: 0 },
+    end: { x: tailStartX - tailLength, y: 0 },
     stops: [
       { offset: 0, color: { ...tail.startColor } },
       { offset: 1, color: { ...tail.endColor } },

--- a/src/ui/renderers/objects/implementations/bullet/tail.helpers.ts
+++ b/src/ui/renderers/objects/implementations/bullet/tail.helpers.ts
@@ -92,11 +92,10 @@ export const createTailVertices = (
 
   const tailLength = radius * tail.lengthMultiplier;
   const tailHalfWidth = (radius * tail.widthMultiplier) / 2;
-  const tailStartX = -radius;
   const vertices: [SceneVector2, SceneVector2, SceneVector2] = [
-    { x: tailStartX, y: tailHalfWidth },
-    { x: tailStartX, y: -tailHalfWidth },
-    { x: tailStartX - tailLength, y: 0 },
+    { x: 0, y: tailHalfWidth },
+    { x: 0, y: -tailHalfWidth },
+    { x: -tailLength, y: 0 },
   ];
 
   tailVerticesCache.set(instance, { radius, tailRef: tail, vertices });
@@ -115,11 +114,10 @@ export const createTailFill = (instance: SceneObjectInstance): SceneLinearGradie
   }
 
   const tailLength = radius * tail.lengthMultiplier;
-  const tailStartX = -radius;
   const fill: SceneLinearGradientFill = {
     fillType: FILL_TYPES.LINEAR_GRADIENT,
-    start: { x: tailStartX, y: 0 },
-    end: { x: tailStartX - tailLength, y: 0 },
+    start: { x: 0, y: 0 },
+    end: { x: -tailLength, y: 0 },
     stops: [
       { offset: 0, color: { ...tail.startColor } },
       { offset: 1, color: { ...tail.endColor } },

--- a/src/ui/renderers/objects/implementations/bullet/tail.helpers.ts
+++ b/src/ui/renderers/objects/implementations/bullet/tail.helpers.ts
@@ -93,9 +93,9 @@ export const createTailVertices = (
   const tailLength = radius * tail.lengthMultiplier;
   const tailHalfWidth = (radius * tail.widthMultiplier) / 2;
   const vertices: [SceneVector2, SceneVector2, SceneVector2] = [
-    { x: -radius / 2, y: tailHalfWidth },
-    { x: -radius / 2, y: -tailHalfWidth },
-    { x: -radius / 2 - tailLength, y: 0 },
+    { x: 0, y: tailHalfWidth },
+    { x: 0, y: -tailHalfWidth },
+    { x: -tailLength, y: 0 },
   ];
 
   tailVerticesCache.set(instance, { radius, tailRef: tail, vertices });
@@ -116,8 +116,8 @@ export const createTailFill = (instance: SceneObjectInstance): SceneLinearGradie
   const tailLength = radius * tail.lengthMultiplier;
   const fill: SceneLinearGradientFill = {
     fillType: FILL_TYPES.LINEAR_GRADIENT,
-    start: { x: tailLength, y: 0 },
-    end: { x: 0, y: 0 },
+    start: { x: 0, y: 0 },
+    end: { x: -tailLength, y: 0 },
     stops: [
       { offset: 0, color: { ...tail.startColor } },
       { offset: 1, color: { ...tail.endColor } },

--- a/src/ui/renderers/objects/implementations/bullet/types.ts
+++ b/src/ui/renderers/objects/implementations/bullet/types.ts
@@ -23,6 +23,8 @@ export interface BulletRendererCustomData {
   speed?: number;
   maxSpeed?: number;
   velocity?: SceneVector2;
+  movementRotation?: number;
+  visualRotation?: number;
   bulletGpuKey?: string;
   shape?: "circle" | "sprite";
   renderComponents?: {

--- a/src/ui/renderers/primitives/gpu/bullet/BulletGpuRenderer.ts
+++ b/src/ui/renderers/primitives/gpu/bullet/BulletGpuRenderer.ts
@@ -80,7 +80,8 @@ class BulletGpuRenderer extends GpuBatchRenderer<BulletInstance, BulletBatch, Bu
     const attributes = {
       unitPosition: gl.getAttribLocation(programResult.program, "a_unitPosition"),
       instancePosition: gl.getAttribLocation(programResult.program, "a_instancePosition"),
-      instanceRotation: gl.getAttribLocation(programResult.program, "a_instanceRotation"),
+      instanceMovementRotation: gl.getAttribLocation(programResult.program, "a_instanceMovementRotation"),
+      instanceVisualRotation: gl.getAttribLocation(programResult.program, "a_instanceVisualRotation"),
       instanceRadius: gl.getAttribLocation(programResult.program, "a_instanceRadius"),
       instanceActive: gl.getAttribLocation(programResult.program, "a_instanceActive"),
     };
@@ -150,10 +151,16 @@ class BulletGpuRenderer extends GpuBatchRenderer<BulletInstance, BulletBatch, Bu
     gl.vertexAttribDivisor(this.sharedResourcesExtended.attributes.instancePosition, 1);
     offset += 2 * 4;
 
-    // rotation (float)
-    gl.enableVertexAttribArray(this.sharedResourcesExtended.attributes.instanceRotation);
-    gl.vertexAttribPointer(this.sharedResourcesExtended.attributes.instanceRotation, 1, gl.FLOAT, false, INSTANCE_STRIDE, offset);
-    gl.vertexAttribDivisor(this.sharedResourcesExtended.attributes.instanceRotation, 1);
+    // movement rotation (float)
+    gl.enableVertexAttribArray(this.sharedResourcesExtended.attributes.instanceMovementRotation);
+    gl.vertexAttribPointer(this.sharedResourcesExtended.attributes.instanceMovementRotation, 1, gl.FLOAT, false, INSTANCE_STRIDE, offset);
+    gl.vertexAttribDivisor(this.sharedResourcesExtended.attributes.instanceMovementRotation, 1);
+    offset += 1 * 4;
+
+    // visual rotation (float)
+    gl.enableVertexAttribArray(this.sharedResourcesExtended.attributes.instanceVisualRotation);
+    gl.vertexAttribPointer(this.sharedResourcesExtended.attributes.instanceVisualRotation, 1, gl.FLOAT, false, INSTANCE_STRIDE, offset);
+    gl.vertexAttribDivisor(this.sharedResourcesExtended.attributes.instanceVisualRotation, 1);
     offset += 1 * 4;
 
     // radius (float)
@@ -200,9 +207,10 @@ class BulletGpuRenderer extends GpuBatchRenderer<BulletInstance, BulletBatch, Bu
 
     data[offset + 0] = instance.position.x;
     data[offset + 1] = instance.position.y;
-    data[offset + 2] = instance.rotation;
-    data[offset + 3] = instance.radius;
-    data[offset + 4] = instance.active ? 1 : 0;
+    data[offset + 2] = instance.movementRotation;
+    data[offset + 3] = instance.visualRotation;
+    data[offset + 4] = instance.radius;
+    data[offset + 5] = instance.active ? 1 : 0;
   }
 
   protected setupRenderState(
@@ -278,7 +286,7 @@ class BulletGpuRenderer extends GpuBatchRenderer<BulletInstance, BulletBatch, Bu
   }
 
   protected getActiveFloatIndex(): number {
-    return 4; // active flag
+    return 5; // active flag
   }
 
   protected getVertexCount(_batch: BulletBatch): number {

--- a/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
+++ b/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
@@ -50,7 +50,7 @@ void main() {
   
   float tailLength = a_instanceRadius * u_tailLengthMul;
   float tailWidth = a_instanceRadius * u_tailWidthMul;
-  float tailOffset = -tailLength * 0.5 + a_instanceRadius * u_tailOffsetMul;
+  float tailOffset = a_instanceRadius * u_tailOffsetMul;
   
   // Scale local position to cover bullet + tail
   float tailScaleX = a_instanceRadius + tailLength;

--- a/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
+++ b/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
@@ -51,7 +51,7 @@ void main() {
   
   float tailLength = a_instanceRadius * u_tailLengthMul;
   float tailWidth = a_instanceRadius * u_tailWidthMul;
-  float tailOffset = -a_instanceRadius + a_instanceRadius * u_tailOffsetMul;
+  float tailOffset = a_instanceRadius * u_tailOffsetMul;
   
   // Scale local position to cover bullet + tail
   float tailScaleX = a_instanceRadius + tailLength;

--- a/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
+++ b/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
@@ -51,7 +51,7 @@ void main() {
   
   float tailLength = a_instanceRadius * u_tailLengthMul;
   float tailWidth = a_instanceRadius * u_tailWidthMul;
-  float tailOffset = a_instanceRadius * u_tailOffsetMul;
+  float tailOffset = -a_instanceRadius + a_instanceRadius * u_tailOffsetMul;
   
   // Scale local position to cover bullet + tail
   float tailScaleX = a_instanceRadius + tailLength;

--- a/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
+++ b/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
@@ -4,8 +4,8 @@ import type { BulletVisualConfig } from "./bullet.types";
 
 export const DEFAULT_BATCH_CAPACITY = 256;
 
-// Instance data layout: posX, posY, rotation, radius, active
-export const INSTANCE_FLOATS = 5;
+// Instance data layout: posX, posY, movementRotation, visualRotation, radius, active
+export const INSTANCE_FLOATS = 6;
 export const INSTANCE_STRIDE = INSTANCE_FLOATS * Float32Array.BYTES_PER_ELEMENT;
 
 export const VERTEX_SHADER = `#version 300 es
@@ -17,7 +17,8 @@ in vec2 a_unitPosition;
 
 // Per-instance
 in vec2 a_instancePosition;
-in float a_instanceRotation;
+in float a_instanceMovementRotation;
+in float a_instanceVisualRotation;
 in float a_instanceRadius;
 in float a_instanceActive;
 
@@ -60,15 +61,17 @@ void main() {
   vec2 bulletLocalPos = a_unitPosition * vec2(a_instanceRadius, a_instanceRadius);
   
   // Rotate
-  float c = cos(a_instanceRotation);
-  float s = sin(a_instanceRotation);
+  float tailC = cos(a_instanceMovementRotation);
+  float tailS = sin(a_instanceMovementRotation);
   vec2 rotatedTailPos = vec2(
-    tailLocalPos.x * c - tailLocalPos.y * s,
-    tailLocalPos.x * s + tailLocalPos.y * c
+    tailLocalPos.x * tailC - tailLocalPos.y * tailS,
+    tailLocalPos.x * tailS + tailLocalPos.y * tailC
   );
+  float bulletC = cos(a_instanceVisualRotation);
+  float bulletS = sin(a_instanceVisualRotation);
   vec2 rotatedBulletPos = vec2(
-    bulletLocalPos.x * c - bulletLocalPos.y * s,
-    bulletLocalPos.x * s + bulletLocalPos.y * c
+    bulletLocalPos.x * bulletC - bulletLocalPos.y * bulletS,
+    bulletLocalPos.x * bulletS + bulletLocalPos.y * bulletC
   );
   
   vec2 worldPos = u_renderPass == 0

--- a/src/ui/renderers/primitives/gpu/bullet/bullet.types.ts
+++ b/src/ui/renderers/primitives/gpu/bullet/bullet.types.ts
@@ -32,7 +32,8 @@ export interface BulletVisualConfig {
 
 export interface BulletInstance {
   position: SceneVector2;
-  rotation: number;
+  movementRotation: number;
+  visualRotation: number;
   radius: number;
   active: boolean;
 }
@@ -72,7 +73,8 @@ export interface BulletSharedResources {
   attributes: {
     unitPosition: number;
     instancePosition: number;
-    instanceRotation: number;
+    instanceMovementRotation: number;
+    instanceVisualRotation: number;
     instanceRadius: number;
     instanceActive: number;
   };

--- a/src/ui/screens/Scene/hooks/useWebGLSceneSetup.ts
+++ b/src/ui/screens/Scene/hooks/useWebGLSceneSetup.ts
@@ -118,10 +118,11 @@ export const setupWebGLScene = (
           config,
         });
       },
-      updateSlot: (handle, position, rotation, radius, active) => {
+      updateSlot: (handle, position, movementRotation, visualRotation, radius, active) => {
         bulletGpuRenderer.updateSlot(handle, {
           position,
-          rotation,
+          movementRotation,
+          visualRotation,
           radius,
           active,
         });


### PR DESCRIPTION
### Motivation
- Make GPU bullet tail start at the bullet center when `u_tailOffsetMul = 0` instead of being shifted by a hidden `-0.5 * length` value.
- Ensure CPU tail vertex coordinates and gradient direction match the GPU logic so CPU and GPU renders are consistent.
- Expose any backward offset only via `tailOffsetMultiplier` rather than implicit defaults.

### Description
- Changed GPU vertex shader logic in `src/ui/renderers/primitives/gpu/bullet/bullet.const.ts` to compute `tailOffset` as `a_instanceRadius * u_tailOffsetMul` instead of `-tailLength * 0.5 + a_instanceRadius * u_tailOffsetMul`.
- Updated CPU tail geometry in `src/ui/renderers/objects/implementations/bullet/tail.helpers.ts` by making tail vertices start at `x: 0` and extend to `x: -tailLength` so the tail origin aligns with the bullet center.
- Adjusted the CPU tail fill gradient to use `start: { x: 0, y: 0 }` and `end: { x: -tailLength, y: 0 }` to match the new GPU coordinate convention.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970054d03ac832083611442c6f08308)