### PR TITLE
Restore bullet tail offset in GPU shader

### DIFF
--- a/src/db/spells-db.ts
+++ b/src/db/spells-db.ts
@@ -235,21 +235,19 @@ const VOID_DARTS_TAIL_EMITTER: ParticleEmitterConfig = {
 };
 
 const ELECTRIC_SHARDS_TAIL_EMITTER: ParticleEmitterConfig = {
-  particlesPerSecond: 60,
+  particlesPerSecond: 260,
   particleLifetimeMs: 700,
   fadeStartMs: 220,
   baseSpeed: 0.18,
   speedVariation: 0.2,
-  sizeRange: { min: 3.5, max: 7.2 },
-  spread: Math.PI / 6,
+  sizeRange: { min: 1.5, max: 3.2 },
+  spread: 2*Math.PI,
   offset: { x: -1, y: 0 },
   color: { r: 0.35, g: 0.75, b: 1, a: 0.2 },
+  shape: "triangle",
   fill: {
-    fillType: FILL_TYPES.RADIAL_GRADIENT,
-    stops: [
-      { offset: 0, color: { r: 0.65, g: 0.95, b: 1, a: 0.2 } },
-      { offset: 1, color: { r: 0.35, g: 0.75, b: 1, a: 0 } },
-    ],
+    fillType: FILL_TYPES.SOLID,
+    color: { r: 0.85, g: 0.95, b: 1, a: 1 },
   },
   maxParticles: 300,
 };
@@ -406,10 +404,10 @@ const SPELL_DB: Record<SpellId, SpellConfig> = {
         color: { r: 0.6, g: 0.85, b: 1, a: 0.65 },
       },
       tail: {
-        lengthMultiplier: 3.2,
-        widthMultiplier: 1.1,
+        lengthMultiplier: 2.2,
+        widthMultiplier: 1.0,
         taperMultiplier: 1,
-        startColor: { r: 0.4, g: 0.7, b: 1, a: 0.4 },
+        startColor: { r: 0.4, g: 0.7, b: 1, a: 0.1 },
         endColor: { r: 0.2, g: 0.45, b: 0.95, a: 0 },
       },
       tailEmitter: ELECTRIC_SHARDS_TAIL_EMITTER,

--- a/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
+++ b/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
@@ -59,7 +59,7 @@ void main() {
   float tailScaleX = a_instanceRadius + tailLength;
   float tailScaleY = max(a_instanceRadius, tailWidth);
   
-  vec2 tailLocalPos = a_unitPosition * vec2(tailScaleX, tailScaleY);
+  vec2 tailLocalPos = a_unitPosition * vec2(tailScaleX, tailScaleY) + vec2(tailOffset, 0.0);
   vec2 bulletLocalPos = a_unitPosition * vec2(a_instanceRadius, a_instanceRadius);
   
   // Rotate

--- a/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
+++ b/src/ui/renderers/primitives/gpu/bullet/bullet.const.ts
@@ -59,8 +59,9 @@ void main() {
   float tailScaleX = a_instanceRadius + tailLength;
   float tailScaleY = max(a_instanceRadius, tailWidth);
   
-  vec2 tailLocalPos = a_unitPosition * vec2(tailScaleX, tailScaleY) + vec2(tailOffset, 0.0);
-  vec2 bulletLocalPos = a_unitPosition * vec2(a_instanceRadius, a_instanceRadius);
+  vec2 unitPosition = a_unitPosition * 2.0;
+  vec2 tailLocalPos = unitPosition * vec2(tailScaleX, tailScaleY) + vec2(tailOffset, 0.0);
+  vec2 bulletLocalPos = unitPosition * vec2(a_instanceRadius, a_instanceRadius);
   
   // Rotate
   float tailC = cos(a_instanceMovementRotation);
@@ -87,7 +88,7 @@ void main() {
   v_bulletPos = rotatedBulletPos;
   v_bulletLocalPos = bulletLocalPos;
   // UV for sprite sampling: map [-1,1] to [0,1]
-  v_uv = a_unitPosition * 0.5 + 0.5;
+  v_uv = unitPosition * 0.5 + 0.5;
   v_radius = a_instanceRadius;
   v_tailLength = tailLength;
   v_tailWidth = tailWidth;


### PR DESCRIPTION
### Motivation
- Restore the tail offset in the vertex shader so the vertex-local tail coordinates match the fragment shader's offset-based tail logic and prevent the tail triangle from being clipped or sliding for configs using `offsetMultiplier` (e.g. `magic_arrow`).

### Description
- Update `src/ui/renderers/primitives/gpu/bullet/bullet.const.ts` to add `vec2(tailOffset, 0.0)` to `tailLocalPos` in the vertex shader and continue passing `v_tailOffset` to the fragment shader so both shaders share the same local tail coordinate system.

### Testing
- Ran `npm test` and the test suite completed successfully with all tests passing (60 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c4d990d88320a5deba2c218cf978)