### PR TITLE
Add interpolated rotations for GPU bullets

### DIFF
--- a/src/shared/helpers/angle.helper.ts
+++ b/src/shared/helpers/angle.helper.ts
@@ -62,3 +62,19 @@ export const normalizeRotation = (
   const normalized = normalizeAngle(value);
   return normalized === 0 ? 0 : normalized;
 };
+
+/**
+ * Interpolates between two angles using the shortest path.
+ * Handles non-finite values by falling back to 0.
+ */
+export const lerpAngle = (from: number, to: number, t: number): number => {
+  if (!Number.isFinite(from) || !Number.isFinite(to) || !Number.isFinite(t)) {
+    return 0;
+  }
+  const twoPi = Math.PI * 2;
+  const fromNormalized = normalizeAngle(from);
+  const toNormalized = normalizeAngle(to);
+  const delta =
+    ((toNormalized - fromNormalized + Math.PI * 3) % twoPi) - Math.PI;
+  return normalizeAngle(fromNormalized + delta * t);
+};

--- a/src/ui/screens/Scene/hooks/useSceneCanvas.ts
+++ b/src/ui/screens/Scene/hooks/useSceneCanvas.ts
@@ -298,7 +298,7 @@ export const useSceneCanvas = ({
       },
       afterApplyChanges: (timestamp, scene, cameraState) => {
         const objectsRenderer = webglRenderer.getObjectsRenderer();
-        const interpolatedBulletPositions = getInterpolatedBulletPositionsRef.current();
+        const interpolatedBulletStates = getInterpolatedBulletPositionsRef.current();
 
         // Apply interpolated unit positions
         const interpolatedUnitPositions = getInterpolatedUnitPositionsRef.current();
@@ -330,7 +330,11 @@ export const useSceneCanvas = ({
           objectsRenderer.applyInterpolatedPositions(interpolatedEnemyPositions);
         }
         // Apply interpolated bullet positions for emitter spawn origins
-        if (interpolatedBulletPositions.size > 0) {
+        if (interpolatedBulletStates.size > 0) {
+          const interpolatedBulletPositions = new Map<string, { x: number; y: number }>();
+          interpolatedBulletStates.forEach((state, key) => {
+            interpolatedBulletPositions.set(key, state.position);
+          });
           objectsRenderer.applyInterpolatedBulletPositions(interpolatedBulletPositions);
         }
       },
@@ -410,9 +414,9 @@ export const useSceneCanvas = ({
           timestamp,
         );
         // GPU instanced bullets with interpolation
-        const interpolatedBulletPositions = getInterpolatedBulletPositionsRef.current();
-        if (interpolatedBulletPositions.size > 0) {
-          applyInterpolatedBulletPositions(interpolatedBulletPositions);
+        const interpolatedBulletStates = getInterpolatedBulletPositionsRef.current();
+        if (interpolatedBulletStates.size > 0) {
+          applyInterpolatedBulletPositions(interpolatedBulletStates);
         }
         bulletGpuRenderer.beforeRender(gl, timestamp);
         bulletGpuRenderer.render(gl, cameraState.position, cameraState.viewportSize, timestamp);


### PR DESCRIPTION
### Motivation
- GPU-instanced bullets needed smooth rotation interpolation (movement vs visual rotation) in addition to position to avoid visual snapping during render interpolation.
- Provide a shortest-path angle lerp helper to correctly interpolate across the ±π boundary.

### Description
- Added `lerpAngle` helper to `src/shared/helpers/angle.helper.ts` for shortest-path angular interpolation and non-finite safety handling.
- Extended `getAllActiveBullets` in `src/ui/renderers/primitives/gpu/bullet/BulletGpuRenderer.ts` to return `movementRotation` and `visualRotation` for each active instance.
- Introduced `BulletInterpolatedState` and changed `applyInterpolatedBulletPositions` to accept interpolated state objects and update `instance.movementRotation` / `instance.visualRotation` as well as the instance VBO slots at `offset + 2` and `offset + 3`.
- Enhanced `usePositionInterpolation` (`src/ui/screens/Scene/hooks/usePositionInterpolation.ts`) to track `prev/next` movement and visual rotations in snapshots, interpolate them via `lerpAngle`, and return a map of `BulletInterpolatedState` objects alongside positions.
- Updated render loop usage in `src/ui/screens/Scene/hooks/useSceneCanvas.ts` to pass the new interpolated bullet states to the GPU update path and still provide a plain position map where earlier code expects positions (e.g., emitter spawn origins).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970dafb7a388320bfb2e7604020ecbb)