### PR TITLE
Add projectiles_rain spell behavior and Magic Storm

### DIFF
--- a/src/db/spells-db.ts
+++ b/src/db/spells-db.ts
@@ -167,6 +167,9 @@ export interface SpellProjectilesRainConfig {
   origin: ProjectilesRainOrigin;
   damage: SpellDamageConfig;
   projectile: SpellProjectileConfig;
+  highlightArea?: {
+    fill: SceneFill;
+  };
 }
 
 interface SpellBaseConfig {
@@ -300,6 +303,17 @@ const MAGIC_STORM_PROJECTILE_FILL: SceneFill = {
     { offset: 0, color: { r: 0.55, g: 0.7, b: 1, a: 0.85 } },
     { offset: 0.45, color: { r: 0.45, g: 0.45, b: 0.95, a: 0.55 } },
     { offset: 1, color: { r: 0.15, g: 0.2, b: 0.6, a: 0 } },
+  ],
+};
+
+const MAGIC_STORM_HIGHLIGHT_FILL: SceneFill = {
+  fillType: FILL_TYPES.RADIAL_GRADIENT,
+  start: { x: 0, y: 0 },
+  end: 150,
+  stops: [
+    { offset: 0, color: { r: 0.6, g: 0.35, b: 1, a: 0.25 } },
+    { offset: 0.45, color: { r: 0.45, g: 0.25, b: 0.9, a: 0.18 } },
+    { offset: 1, color: { r: 0.2, g: 0.1, b: 0.5, a: 0 } },
   ],
 };
 
@@ -555,6 +569,9 @@ const SPELL_DB: Record<SpellId, SpellConfig> = {
         },
         aoe: { radius: 55, splash: 1 },
         ignoreTargetsOnPath: true,
+      },
+      highlightArea: {
+        fill: MAGIC_STORM_HIGHLIGHT_FILL,
       },
     },
   },

--- a/src/logic/modules/active-map/projectiles/ProjectileController.ts
+++ b/src/logic/modules/active-map/projectiles/ProjectileController.ts
@@ -371,41 +371,47 @@ export class UnitProjectileController {
         projectile.position.x += stepX;
         projectile.position.y += stepY;
 
-        const collided = this.findHitTarget(projectile.position, projectile.hitRadius, projectile);
-        if (collided) {
-          hitTarget = collided;
-          const handled = projectile.onHit?.({
-            targetId: collided.id,
-            targetType: collided.type,
-            brickId: isTargetOfType(collided, "brick") ? collided.id : undefined,
-            position: { ...projectile.position },
-          });
-          if (handled !== true) {
-            if (projectile.damageRadius > 0) {
-              this.damage.applyAreaDamage(
-                projectile.position,
-                projectile.damageRadius,
-                projectile.damage,
-                {
-                  rewardMultiplier: projectile.rewardMultiplier,
-                  armorPenetration: projectile.armorPenetration,
-                  skipKnockback: projectile.skipKnockback === true,
-                  knockBackDistance: projectile.knockBackDistance,
-                  knockBackSpeed: projectile.knockBackSpeed,
-                  knockBackDirection: projectile.knockBackDirection,
-                  direction: projectile.direction,
-                  types: projectile.targetTypes,
-                }
-              );
-            } else {
-              this.applyProjectileDamage(projectile, collided);
+        if (!projectile.ignoreTargetsOnPath) {
+          const collided = this.findHitTarget(
+            projectile.position,
+            projectile.hitRadius,
+            projectile,
+          );
+          if (collided) {
+            hitTarget = collided;
+            const handled = projectile.onHit?.({
+              targetId: collided.id,
+              targetType: collided.type,
+              brickId: isTargetOfType(collided, "brick") ? collided.id : undefined,
+              position: { ...projectile.position },
+            });
+            if (handled !== true) {
+              if (projectile.damageRadius > 0) {
+                this.damage.applyAreaDamage(
+                  projectile.position,
+                  projectile.damageRadius,
+                  projectile.damage,
+                  {
+                    rewardMultiplier: projectile.rewardMultiplier,
+                    armorPenetration: projectile.armorPenetration,
+                    skipKnockback: projectile.skipKnockback === true,
+                    knockBackDistance: projectile.knockBackDistance,
+                    knockBackSpeed: projectile.knockBackSpeed,
+                    knockBackDirection: projectile.knockBackDirection,
+                    direction: projectile.direction,
+                    types: projectile.targetTypes,
+                  }
+                );
+              } else {
+                this.applyProjectileDamage(projectile, collided);
+              }
             }
+            this.removeProjectile(projectile);
+            if (projectile.ringTrail) {
+              this.spawnProjectileRing(projectile.position, projectile.ringTrail.config);
+            }
+            break;
           }
-          this.removeProjectile(projectile);
-          if (projectile.ringTrail) {
-            this.spawnProjectileRing(projectile.position, projectile.ringTrail.config);
-          }
-          break;
         }
       }
 

--- a/src/logic/modules/active-map/projectiles/projectiles.types.ts
+++ b/src/logic/modules/active-map/projectiles/projectiles.types.ts
@@ -49,6 +49,7 @@ export interface UnitProjectileSpawn {
   knockBackSpeed?: number;
   knockBackDirection?: SceneVector2;
   skipKnockback?: boolean;
+  ignoreTargetsOnPath?: boolean;
   targetTypes?: TargetType[];
   visual: UnitProjectileVisualConfig;
   onHit?: UnitProjectileOnHit;

--- a/src/logic/modules/active-map/projectiles/projectiles.types.ts
+++ b/src/logic/modules/active-map/projectiles/projectiles.types.ts
@@ -42,6 +42,7 @@ export interface UnitProjectileVisualConfig {
 export interface UnitProjectileSpawn {
   origin: SceneVector2;
   direction: SceneVector2;
+  targetPosition?: SceneVector2;
   damage: number;
   rewardMultiplier: number;
   armorPenetration: number;

--- a/src/logic/modules/active-map/spellcasting/SpellBehaviorRegistry.ts
+++ b/src/logic/modules/active-map/spellcasting/SpellBehaviorRegistry.ts
@@ -3,6 +3,7 @@ import { SpellBehavior, SpellBehaviorDependencies } from "./SpellBehavior";
 import { ProjectileSpellBehavior } from "./implementations/ProjectileSpellBehavior";
 import { WhirlSpellBehavior } from "./implementations/WhirlSpellBehavior";
 import { PersistentAoeSpellBehavior } from "./implementations/PersistentAoeSpellBehavior";
+import { ProjectilesRainSpellBehavior } from "./implementations/ProjectilesRainSpellBehavior";
 
 export class SpellBehaviorRegistry {
   private readonly behaviors = new Map<SpellConfig["type"], SpellBehavior>();
@@ -11,6 +12,7 @@ export class SpellBehaviorRegistry {
     this.behaviors.set("projectile", new ProjectileSpellBehavior(dependencies));
     this.behaviors.set("whirl", new WhirlSpellBehavior(dependencies));
     this.behaviors.set("persistent-aoe", new PersistentAoeSpellBehavior(dependencies));
+    this.behaviors.set("projectiles_rain", new ProjectilesRainSpellBehavior(dependencies));
   }
 
   public getBehavior(type: SpellConfig["type"]): SpellBehavior | undefined {
@@ -25,4 +27,3 @@ export class SpellBehaviorRegistry {
     this.behaviors.set(type, behavior);
   }
 }
-

--- a/src/logic/modules/active-map/spellcasting/implementations/ProjectileSpellBehavior.ts
+++ b/src/logic/modules/active-map/spellcasting/implementations/ProjectileSpellBehavior.ts
@@ -173,6 +173,7 @@ export class ProjectileSpellBehavior implements SpellBehavior {
         rewardMultiplier: 1,
         armorPenetration: 0,
         targetTypes,
+        ignoreTargetsOnPath: projectileConfig.ignoreTargetsOnPath ?? false,
         visual,
         onHit: (hitContext) => {
           const data = this.projectileData.get(objectId);

--- a/src/logic/modules/active-map/spellcasting/implementations/ProjectilesRainSpellBehavior.ts
+++ b/src/logic/modules/active-map/spellcasting/implementations/ProjectilesRainSpellBehavior.ts
@@ -1,0 +1,304 @@
+import {
+  SpellBehavior,
+  SpellBehaviorDependencies,
+  SpellCanCastContext,
+  SpellCastContext,
+} from "../SpellBehavior";
+import type {
+  ProjectilesRainOrigin,
+  SpellDamageConfig,
+  SpellProjectilesRainConfig,
+} from "../../../../../db/spells-db";
+import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { SceneObjectManager } from "@core/logic/provided/services/scene-object-manager/SceneObjectManager";
+import type { BonusValueMap } from "../../../shared/bonuses/bonuses.types";
+import { randomIntInclusive } from "@shared/helpers/numbers.helper";
+import type { UnitProjectileController } from "../../projectiles/ProjectileController";
+import type { DamageService } from "../../targeting/DamageService";
+import type { TargetType } from "../../targeting/targeting.types";
+
+interface ProjectilesRainInstance {
+  spellId: string;
+  center: SceneVector2;
+  origin: ProjectilesRainOrigin;
+  portalOrigin: SceneVector2;
+  durationMs: number;
+  elapsedMs: number;
+  intervalMs: number;
+  intervalAccumulatorMs: number;
+  radius: number;
+  damage: SpellDamageConfig;
+  projectileConfig: SpellProjectilesRainConfig["projectile"];
+  damageMultiplier: number;
+}
+
+export class ProjectilesRainSpellBehavior implements SpellBehavior {
+  public readonly spellType = "projectiles_rain" as const;
+
+  private readonly projectiles: UnitProjectileController;
+  private readonly damage: DamageService;
+  private readonly getSpellPowerMultiplier: () => number;
+  private readonly scene: SceneObjectManager;
+
+  private instances: ProjectilesRainInstance[] = [];
+  private spellPowerMultiplier = 1;
+
+  constructor(dependencies: SpellBehaviorDependencies) {
+    this.projectiles = dependencies.projectiles;
+    this.damage = dependencies.damage;
+    this.getSpellPowerMultiplier = dependencies.getSpellPowerMultiplier;
+    this.scene = dependencies.scene;
+    this.spellPowerMultiplier = dependencies.getSpellPowerMultiplier();
+  }
+
+  public canCast(context: SpellCanCastContext): boolean {
+    return (
+      context.isUnlocked &&
+      context.isMapActive &&
+      context.cooldownRemainingMs <= 0
+    );
+  }
+
+  public cast(context: SpellCastContext): boolean {
+    if (context.config.type !== "projectiles_rain") {
+      return false;
+    }
+    const config = this.sanitizeConfig(context.config.projectilesRain);
+
+    this.instances.push({
+      spellId: context.spellId,
+      center: { ...context.target },
+      origin: config.origin,
+      portalOrigin: { ...context.origin },
+      durationMs: config.durationMs,
+      elapsedMs: 0,
+      intervalMs: config.spawnIntervalMs,
+      intervalAccumulatorMs: 0,
+      radius: config.radius,
+      damage: config.damage,
+      projectileConfig: config.projectile,
+      damageMultiplier: context.spellPowerMultiplier,
+    });
+
+    return true;
+  }
+
+  public tick(deltaMs: number): void {
+    if (deltaMs <= 0 || this.instances.length === 0) {
+      return;
+    }
+
+    const elapsed = Math.max(0, deltaMs);
+    const survivors: ProjectilesRainInstance[] = [];
+
+    for (const instance of this.instances) {
+      instance.elapsedMs += elapsed;
+      instance.intervalAccumulatorMs += elapsed;
+
+      while (instance.intervalAccumulatorMs >= instance.intervalMs) {
+        instance.intervalAccumulatorMs -= instance.intervalMs;
+        this.spawnProjectile(instance);
+      }
+
+      if (instance.elapsedMs < instance.durationMs) {
+        survivors.push(instance);
+      }
+    }
+
+    this.instances = survivors;
+  }
+
+  public clear(): void {
+    this.instances = [];
+  }
+
+  public cleanupExpired(): void {
+    // No-op: rain instances are time-based and cleaned in tick
+  }
+
+  public onBonusValuesChanged(values: BonusValueMap): void {
+    const raw = values["spell_power"];
+    const sanitized = Number.isFinite(raw) ? Math.max(raw, 0) : 1;
+    if (Math.abs(sanitized - this.spellPowerMultiplier) < 1e-6) {
+      return;
+    }
+    this.spellPowerMultiplier = sanitized;
+    for (const instance of this.instances) {
+      instance.damageMultiplier = sanitized;
+    }
+  }
+
+  public serializeState(): unknown {
+    return null;
+  }
+
+  public deserializeState(_data: unknown): void {
+    // Not implemented
+  }
+
+  private spawnProjectile(instance: ProjectilesRainInstance): void {
+    const target = this.getRandomTargetInRadius(instance.center, instance.radius);
+    const origin = this.resolveOrigin(
+      instance.origin,
+      instance.portalOrigin,
+      instance.center,
+      target,
+    );
+    const direction = this.normalizeDirection({
+      x: target.x - origin.x,
+      y: target.y - origin.y,
+    });
+    if (!direction) {
+      return;
+    }
+
+    const damageMultiplier = Math.max(instance.damageMultiplier, 0);
+    const targetTypes =
+      instance.projectileConfig.targetTypes &&
+      instance.projectileConfig.targetTypes.length > 0
+        ? instance.projectileConfig.targetTypes
+        : (["brick"] as TargetType[]);
+
+    const objectId = this.projectiles.spawn({
+      origin,
+      direction,
+      damage: 0,
+      rewardMultiplier: 1,
+      armorPenetration: 0,
+      targetTypes,
+      ignoreTargetsOnPath: instance.projectileConfig.ignoreTargetsOnPath ?? false,
+      visual: {
+        radius: instance.projectileConfig.radius,
+        speed: instance.projectileConfig.speed,
+        lifetimeMs: instance.projectileConfig.lifetimeMs,
+        fill: instance.projectileConfig.fill,
+        spawnOffset: instance.projectileConfig.spawnOffset,
+        tail: instance.projectileConfig.tail,
+        tailEmitter: instance.projectileConfig.tailEmitter,
+        ringTrail: instance.projectileConfig.ringTrail,
+        rotationSpinningDegPerSec:
+          instance.projectileConfig.rotationSpinningDegPerSec,
+        shape: instance.projectileConfig.shape ?? "circle",
+        spriteName: instance.projectileConfig.spriteName,
+        wander: instance.projectileConfig.wander,
+      },
+      onExpired: (position) => {
+        const baseDamage = randomIntInclusive(instance.damage);
+        const finalDamage = Math.max(baseDamage * damageMultiplier, 0);
+        const aoe = instance.projectileConfig.aoe;
+        if (!aoe || aoe.radius <= 0 || finalDamage <= 0) {
+          return;
+        }
+        const splash = Math.max(aoe.splash, 0);
+        const payload = {
+          amount: finalDamage * splash,
+          context: {
+            source: { type: "spell", id: instance.spellId },
+            attackType: "spell-projectiles-rain",
+            tag: instance.spellId,
+            baseDamage,
+            modifiers: {
+              spellPowerMultiplier: damageMultiplier,
+            },
+          },
+          area: { radius: aoe.radius, types: targetTypes },
+        };
+        this.damage.applyAreaDamage(position, aoe.radius, finalDamage * splash, {
+          direction,
+          types: targetTypes,
+          payload,
+        });
+      },
+    });
+
+    if (!objectId) {
+      return;
+    }
+  }
+
+  private sanitizeConfig(config: SpellProjectilesRainConfig): SpellProjectilesRainConfig {
+    return {
+      ...config,
+      durationMs: Math.max(0, Math.floor(config.durationMs)),
+      spawnIntervalMs: Math.max(1, Math.floor(config.spawnIntervalMs)),
+      radius: Math.max(0, config.radius),
+      damage: {
+        min: Math.max(0, config.damage.min),
+        max: Math.max(config.damage.max, config.damage.min),
+      },
+    };
+  }
+
+  private getRandomTargetInRadius(center: SceneVector2, radius: number): SceneVector2 {
+    if (radius <= 0) {
+      return { ...center };
+    }
+    const angle = Math.random() * Math.PI * 2;
+    const magnitude = Math.sqrt(Math.random()) * radius;
+    return {
+      x: center.x + Math.cos(angle) * magnitude,
+      y: center.y + Math.sin(angle) * magnitude,
+    };
+  }
+
+  private resolveOrigin(
+    origin: ProjectilesRainOrigin,
+    portalOrigin: SceneVector2,
+    castTarget: SceneVector2,
+    selectedTarget: SceneVector2,
+  ): SceneVector2 {
+    switch (origin.type) {
+      case "portal":
+        return { ...portalOrigin };
+      case "absolute":
+        return { ...origin.position };
+      case "corner": {
+        return this.resolveCorner(this.scene.getMapSize(), origin.corner);
+      }
+      case "offset-from-target":
+        return {
+          x: castTarget.x + origin.offset.x,
+          y: castTarget.y + origin.offset.y,
+        };
+      case "corner-with-target-delta": {
+        const base =
+          "cornerPosition" in origin
+            ? origin.cornerPosition
+            : this.resolveCorner(this.scene.getMapSize(), origin.corner);
+        return {
+          x: base.x + (selectedTarget.x - castTarget.x),
+          y: base.y + (selectedTarget.y - castTarget.y),
+        };
+      }
+      default:
+        return { ...castTarget };
+    }
+  }
+
+  private resolveCorner(
+    mapSize: { width: number; height: number } | undefined,
+    corner: "top-left" | "top-right" | "bottom-left" | "bottom-right",
+  ): SceneVector2 {
+    if (!mapSize) {
+      return { x: 0, y: 0 };
+    }
+    switch (corner) {
+      case "top-left":
+        return { x: 0, y: 0 };
+      case "top-right":
+        return { x: mapSize.width, y: 0 };
+      case "bottom-left":
+        return { x: 0, y: mapSize.height };
+      case "bottom-right":
+        return { x: mapSize.width, y: mapSize.height };
+    }
+  }
+
+  private normalizeDirection(vector: SceneVector2): SceneVector2 | null {
+    const length = Math.hypot(vector.x, vector.y);
+    if (!Number.isFinite(length) || length <= 0) {
+      return null;
+    }
+    return { x: vector.x / length, y: vector.y / length };
+  }
+}

--- a/src/logic/modules/active-map/spellcasting/implementations/ProjectilesRainSpellBehavior.ts
+++ b/src/logic/modules/active-map/spellcasting/implementations/ProjectilesRainSpellBehavior.ts
@@ -184,6 +184,7 @@ export class ProjectilesRainSpellBehavior implements SpellBehavior {
     const objectId = this.projectiles.spawn({
       origin,
       direction,
+      targetPosition: target,
       damage: 0,
       rewardMultiplier: 1,
       armorPenetration: 0,

--- a/src/logic/modules/active-map/spellcasting/implementations/ProjectilesRainSpellBehavior.ts
+++ b/src/logic/modules/active-map/spellcasting/implementations/ProjectilesRainSpellBehavior.ts
@@ -209,6 +209,21 @@ export class ProjectilesRainSpellBehavior implements SpellBehavior {
         const baseDamage = randomIntInclusive(instance.damage);
         const finalDamage = Math.max(baseDamage * damageMultiplier, 0);
         const aoe = instance.projectileConfig.aoe;
+        const explosion = instance.projectileConfig.explosion;
+        if (explosion) {
+          this.damage.applyAreaDamage(position, 0, 0, {
+            explosionType: explosion,
+            payload: {
+              amount: 0,
+              context: {
+                source: { type: "spell", id: instance.spellId },
+                attackType: "spell-projectiles-rain-explosion",
+                tag: instance.spellId,
+              },
+              explosion: { type: explosion },
+            },
+          });
+        }
         if (!aoe || aoe.radius <= 0 || finalDamage <= 0) {
           return;
         }

--- a/src/logic/modules/active-map/spellcasting/spellcasting.module.ts
+++ b/src/logic/modules/active-map/spellcasting/spellcasting.module.ts
@@ -25,6 +25,7 @@ import type {
   ProjectileSpellOption,
   WhirlSpellOption,
   PersistentAoeSpellOption,
+  ProjectilesRainSpellOption,
   SpellcastingModuleOptions,
 } from "./spellcasting.types";
 import {
@@ -416,6 +417,24 @@ export class SpellcastingModule implements GameModule {
               damageReduction: damageReduction > 0 ? damageReduction : undefined,
               effectDurationSeconds: effectDurationMs > 0 ? effectDurationMs / 1000 : undefined,
             } satisfies PersistentAoeSpellOption;
+          }
+          case "projectiles_rain": {
+            const rainConfig = config as Extract<
+              SpellConfig,
+              { type: "projectiles_rain" }
+            >;
+            const durationSeconds = Math.max(
+              rainConfig.projectilesRain.durationMs / 1000,
+              0,
+            );
+            return {
+              ...base,
+              type: "projectiles_rain",
+              damage: { ...rainConfig.projectilesRain.damage },
+              durationSeconds,
+              spawnIntervalMs: rainConfig.projectilesRain.spawnIntervalMs,
+              radius: rainConfig.projectilesRain.radius,
+            } satisfies ProjectilesRainSpellOption;
           }
           default:
             return base as SpellOption;

--- a/src/logic/modules/active-map/spellcasting/spellcasting.types.ts
+++ b/src/logic/modules/active-map/spellcasting/spellcasting.types.ts
@@ -49,10 +49,19 @@ export interface PersistentAoeSpellOption extends SpellOptionBase {
   effectDurationSeconds?: number; // Duration of the effect on bricks
 }
 
+export interface ProjectilesRainSpellOption extends SpellOptionBase {
+  type: "projectiles_rain";
+  damage: SpellDamageConfig;
+  durationSeconds: number;
+  spawnIntervalMs: number;
+  radius: number;
+}
+
 export type SpellOption =
   | ProjectileSpellOption
   | WhirlSpellOption
-  | PersistentAoeSpellOption;
+  | PersistentAoeSpellOption
+  | ProjectilesRainSpellOption;
 
 export interface SpellcastingModuleOptions {
   bridge: DataBridge;

--- a/src/ui/renderers/objects/implementations/spell-area-highlight/SpellAreaHighlightRenderer.ts
+++ b/src/ui/renderers/objects/implementations/spell-area-highlight/SpellAreaHighlightRenderer.ts
@@ -1,0 +1,19 @@
+import { ObjectRenderer, ObjectRegistration } from "../../ObjectRenderer";
+import type { SceneObjectInstance } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import { createDynamicCirclePrimitive } from "../../../primitives";
+
+const HIGHLIGHT_SEGMENTS = 48;
+
+export class SpellAreaHighlightRenderer extends ObjectRenderer {
+  public register(instance: SceneObjectInstance): ObjectRegistration {
+    return {
+      staticPrimitives: [],
+      dynamicPrimitives: [
+        createDynamicCirclePrimitive(instance, {
+          segments: HIGHLIGHT_SEGMENTS,
+          getFill: (target) => target.data.fill,
+        }),
+      ],
+    };
+  }
+}

--- a/src/ui/renderers/objects/index.ts
+++ b/src/ui/renderers/objects/index.ts
@@ -14,6 +14,7 @@ import { SandStormRenderer } from "./implementations/sand-storm";
 import { PersistentAoeSpellRenderer } from "./implementations/persistent-aoe-spell";
 import { ScreenOverlayRenderer } from "./implementations/screen-overlay";
 import { TiedObjectsRegistry } from "./TiedObjectsRegistry";
+import { SpellAreaHighlightRenderer } from "./implementations/spell-area-highlight/SpellAreaHighlightRenderer";
 
 export { ObjectsRendererManager } from "./ObjectsRendererManager";
 export { TiedObjectsRegistry } from "./TiedObjectsRegistry";
@@ -59,6 +60,7 @@ export const createObjectsRendererManager = (): ObjectsRendererManager => {
     // unitProjectileRing - now rendered via GPU instancing (RingGpuRenderer)
     ["sandStorm", new SandStormRenderer()],
     ["spellPersistentAoe", new PersistentAoeSpellRenderer()],
+    ["spellAreaHighlight", new SpellAreaHighlightRenderer()],
     ["screenOverlay", new ScreenOverlayRenderer()],
   ]);
   const tiedObjectsRegistry = new TiedObjectsRegistry();

--- a/src/ui/screens/Scene/components/summoning/tooltip-factory/createSpellTooltip.ts
+++ b/src/ui/screens/Scene/components/summoning/tooltip-factory/createSpellTooltip.ts
@@ -1,6 +1,7 @@
 import type {
   ProjectileSpellOption,
   PersistentAoeSpellOption,
+  ProjectilesRainSpellOption,
   SpellOption,
   WhirlSpellOption,
 } from "@logic/modules/active-map/spellcasting/spellcasting.types";
@@ -198,12 +199,61 @@ const appendPersistentAoeStats = (
   });
 };
 
+const appendProjectilesRainStats = (
+  spell: ProjectilesRainSpellOption,
+  stats: SceneTooltipStat[],
+): void => {
+  const effectiveMin = spell.damage.min * spell.spellPowerMultiplier;
+  const effectiveMax = spell.damage.max * spell.spellPowerMultiplier;
+  const baseDamageLabel = formatDamageRange(spell.damage.min, spell.damage.max);
+  const multiplierLabel = formatNumber(spell.spellPowerMultiplier, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    compact: false,
+  });
+
+  stats.push({
+    label: "Impact Damage",
+    value: formatDamageRange(effectiveMin, effectiveMax),
+    hint: `Base ${baseDamageLabel} · Spell Power ${multiplierLabel}×`,
+  });
+
+  stats.push({
+    label: "Duration",
+    value: `${formatNumber(spell.durationSeconds, {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+      compact: false,
+    })} s`,
+  });
+
+  stats.push({
+    label: "Spawn Interval",
+    value: `${formatNumber(spell.spawnIntervalMs, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+      compact: false,
+    })} ms`,
+  });
+
+  stats.push({
+    label: "Rain Radius",
+    value: `${formatNumber(spell.radius, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+      compact: false,
+    })} u`,
+  });
+};
+
 export const createSpellTooltip = (spell: SpellOption): SceneTooltipContent => {
   const stats: SceneTooltipStat[] = [];
   if (spell.type === "projectile") {
     appendProjectileStats(spell, stats);
   } else if (spell.type === "whirl") {
     appendWhirlStats(spell, stats);
+  } else if (spell.type === "projectiles_rain") {
+    appendProjectilesRainStats(spell, stats);
   } else {
     appendPersistentAoeStats(spell, stats);
   }


### PR DESCRIPTION
### Motivation
- Introduce a new "rain" style spell that spawns repeated projectiles over a target area with configurable origins and damage behavior.
- Allow certain projectiles (e.g. rain bolts) to bypass collision-on-path so they can fall into an area without hitting intermediate targets.
- Expose rain spell options to the UI so players can see duration, interval and effective damage for the new spell type.

### Description
- Added a new spell type `projectiles_rain` and config shapes in `src/db/spells-db.ts`, including the new `magic-storm` entry and `ProjectilesRainOrigin` / `SpellProjectilesRainConfig` types.
- Implemented `ProjectilesRainSpellBehavior` in `src/logic/modules/active-map/spellcasting/implementations/ProjectilesRainSpellBehavior.ts` which manages timed rain instances, spawns projectiles with randomized targets inside a radius, resolves multiple origin modes (portal/absolute/corner/offset), and applies AoE damage on projectile expiry.
- Added `ignoreTargetsOnPath` flag to projectile spawn types (`UnitProjectileSpawn` / `SpellProjectileConfig`) and threaded it through: `ProjectileSpellBehavior` and the new rain behavior now pass the flag to `UnitProjectileController`, and `ProjectileController` was updated to skip collision checks when `ignoreTargetsOnPath` is true.
- Wired the new behavior into the registry (`SpellBehaviorRegistry`) and the spellcasting module/types (`spellcasting.module.ts`, `spellcasting.types.ts`), and added tooltip support (`createSpellTooltip.ts`) to display `projectiles_rain` stats (impact damage, duration, spawn interval, radius).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975ea0713388320a4c52c3366d6f6c8)