### PR TITLE
Add Bezier curve thickness and remake Dead Oak with Bezier trunk/branches

### DIFF
--- a/src/core/logic/ui/BridgeSchema.ts
+++ b/src/core/logic/ui/BridgeSchema.ts
@@ -3,7 +3,7 @@
  * Визначає всі ключі та їх типи для перевірки під час компіляції.
  */
 
-import type { MapId } from "../../../db/maps-db";
+import type { MapId } from "../../../db/maps/maps-db";
 import type { UnitDesignId } from "@logic/modules/camp/unit-design/unit-design.types";
 import type { PlayerUnitType } from "@db/player-units-db";
 import type { PlayerUnitBlueprintStats } from "@shared/types/player-units";

--- a/src/db/buildings-db.ts
+++ b/src/db/buildings-db.ts
@@ -1,4 +1,4 @@
-import type { MapId } from "./maps-db";
+import type { MapId } from "./maps/maps-db";
 import type { SkillId } from "./skills-db";
 import type { UnlockCondition } from "@shared/types/unlocks";
 import { RESOURCE_IDS, ResourceAmount, ResourceId } from "./resources-db";

--- a/src/db/crafting-recipes-db.ts
+++ b/src/db/crafting-recipes-db.ts
@@ -1,7 +1,7 @@
 import { ResourceAmount, ResourceId } from "./resources-db";
 import { SkillId } from "./skills-db";
 import { UnlockConditionList } from "@shared/types/unlocks";
-import { MapId } from "./maps-db";
+import { MapId } from "./maps/maps-db";
 
 export type CraftingRecipeId = "tools" | "paper" | "wire";
 

--- a/src/db/maps-db.ts
+++ b/src/db/maps-db.ts
@@ -1635,10 +1635,10 @@ const MAPS_DB: Record<MapId, MapConfig> = {
     } satisfies MapConfig;
   })(),
   deadOak: (() => {
-    const size: SceneSize = { width: 1200, height: 1000 };
+    const size: SceneSize = { width: 1400, height: 1200 };
     const centerX = size.width / 2;
-    const groundY = size.height - 150;
-    const spawnPoint: SceneVector2 = { x: 200, y: 200 };
+    const groundY = size.height - 180;
+    const spawnPoint: SceneVector2 = { x: 240, y: 240 };
 
     return {
       name: "Dead Oak",
@@ -1649,9 +1649,9 @@ const MAPS_DB: Record<MapId, MapConfig> = {
       bricks: ({ mapLevel }) => {
         const baseLevel = Math.max(0, Math.floor(mapLevel));
         const woodLevel = baseLevel + 1;
-        const trunkTopY = groundY - 420;
-        const trunkWidthBase = 160;
-        const trunkWidthTop = 90;
+        const trunkTopY = groundY - 520;
+        const trunkWidthBase = 190;
+        const trunkWidthTop = 110;
 
         const trunkOutline = [
           {
@@ -1693,76 +1693,148 @@ const MAPS_DB: Record<MapId, MapConfig> = {
 
         const leftMainSegments = [
           {
-            start: { x: centerX - 30, y: trunkTopY + 110 },
-            control1: { x: centerX - 120, y: trunkTopY + 40 },
-            control2: { x: centerX - 240, y: trunkTopY - 60 },
-            end: { x: centerX - 340, y: trunkTopY - 140 },
+            start: { x: centerX - 40, y: trunkTopY + 140 },
+            control1: { x: centerX - 160, y: trunkTopY + 60 },
+            control2: { x: centerX - 300, y: trunkTopY - 40 },
+            end: { x: centerX - 420, y: trunkTopY - 150 },
           },
           {
-            start: { x: centerX - 340, y: trunkTopY - 140 },
-            control1: { x: centerX - 380, y: trunkTopY - 200 },
-            control2: { x: centerX - 420, y: trunkTopY - 250 },
-            end: { x: centerX - 460, y: trunkTopY - 300 },
+            start: { x: centerX - 420, y: trunkTopY - 150 },
+            control1: { x: centerX - 470, y: trunkTopY - 230 },
+            control2: { x: centerX - 520, y: trunkTopY - 300 },
+            end: { x: centerX - 560, y: trunkTopY - 360 },
           },
         ] as const;
 
         const rightMainSegments = [
           {
-            start: { x: centerX + 30, y: trunkTopY + 110 },
-            control1: { x: centerX + 120, y: trunkTopY + 40 },
-            control2: { x: centerX + 240, y: trunkTopY - 60 },
-            end: { x: centerX + 340, y: trunkTopY - 140 },
+            start: { x: centerX + 40, y: trunkTopY + 140 },
+            control1: { x: centerX + 160, y: trunkTopY + 60 },
+            control2: { x: centerX + 300, y: trunkTopY - 40 },
+            end: { x: centerX + 420, y: trunkTopY - 150 },
           },
           {
-            start: { x: centerX + 340, y: trunkTopY - 140 },
-            control1: { x: centerX + 380, y: trunkTopY - 200 },
-            control2: { x: centerX + 420, y: trunkTopY - 260 },
-            end: { x: centerX + 460, y: trunkTopY - 310 },
+            start: { x: centerX + 420, y: trunkTopY - 150 },
+            control1: { x: centerX + 470, y: trunkTopY - 230 },
+            control2: { x: centerX + 520, y: trunkTopY - 310 },
+            end: { x: centerX + 560, y: trunkTopY - 370 },
           },
         ] as const;
 
         const topSegments = [
           {
-            start: { x: centerX - 10, y: trunkTopY + 30 },
-            control1: { x: centerX - 40, y: trunkTopY - 60 },
-            control2: { x: centerX + 20, y: trunkTopY - 180 },
-            end: { x: centerX - 10, y: trunkTopY - 260 },
+            start: { x: centerX - 20, y: trunkTopY + 60 },
+            control1: { x: centerX - 60, y: trunkTopY - 80 },
+            control2: { x: centerX + 30, y: trunkTopY - 220 },
+            end: { x: centerX - 10, y: trunkTopY - 340 },
           },
         ] as const;
 
         const leftTwigSegments = [
           {
-            start: { x: centerX - 220, y: trunkTopY - 40 },
-            control1: { x: centerX - 260, y: trunkTopY - 110 },
-            control2: { x: centerX - 320, y: trunkTopY - 190 },
-            end: { x: centerX - 380, y: trunkTopY - 220 },
+            start: { x: centerX - 260, y: trunkTopY - 60 },
+            control1: { x: centerX - 320, y: trunkTopY - 140 },
+            control2: { x: centerX - 400, y: trunkTopY - 230 },
+            end: { x: centerX - 470, y: trunkTopY - 260 },
           },
         ] as const;
 
         const rightTwigSegments = [
           {
-            start: { x: centerX + 220, y: trunkTopY - 40 },
-            control1: { x: centerX + 260, y: trunkTopY - 110 },
-            control2: { x: centerX + 320, y: trunkTopY - 190 },
-            end: { x: centerX + 380, y: trunkTopY - 220 },
+            start: { x: centerX + 260, y: trunkTopY - 60 },
+            control1: { x: centerX + 320, y: trunkTopY - 140 },
+            control2: { x: centerX + 400, y: trunkTopY - 230 },
+            end: { x: centerX + 470, y: trunkTopY - 260 },
           },
         ] as const;
 
         const lowerLeftTwigSegments = [
           {
-            start: { x: centerX - 90, y: trunkTopY + 170 },
-            control1: { x: centerX - 160, y: trunkTopY + 150 },
-            control2: { x: centerX - 220, y: trunkTopY + 110 },
-            end: { x: centerX - 280, y: trunkTopY + 90 },
+            start: { x: centerX - 110, y: trunkTopY + 210 },
+            control1: { x: centerX - 200, y: trunkTopY + 190 },
+            control2: { x: centerX - 280, y: trunkTopY + 140 },
+            end: { x: centerX - 360, y: trunkTopY + 120 },
           },
         ] as const;
 
         const lowerRightTwigSegments = [
           {
-            start: { x: centerX + 90, y: trunkTopY + 170 },
-            control1: { x: centerX + 160, y: trunkTopY + 150 },
-            control2: { x: centerX + 220, y: trunkTopY + 110 },
-            end: { x: centerX + 280, y: trunkTopY + 90 },
+            start: { x: centerX + 110, y: trunkTopY + 210 },
+            control1: { x: centerX + 200, y: trunkTopY + 190 },
+            control2: { x: centerX + 280, y: trunkTopY + 140 },
+            end: { x: centerX + 360, y: trunkTopY + 120 },
+          },
+        ] as const;
+
+        const upperLeftSegments = [
+          {
+            start: { x: centerX - 120, y: trunkTopY - 80 },
+            control1: { x: centerX - 200, y: trunkTopY - 140 },
+            control2: { x: centerX - 280, y: trunkTopY - 240 },
+            end: { x: centerX - 360, y: trunkTopY - 320 },
+          },
+        ] as const;
+
+        const upperRightSegments = [
+          {
+            start: { x: centerX + 120, y: trunkTopY - 80 },
+            control1: { x: centerX + 200, y: trunkTopY - 140 },
+            control2: { x: centerX + 280, y: trunkTopY - 240 },
+            end: { x: centerX + 360, y: trunkTopY - 320 },
+          },
+        ] as const;
+
+        const leftSideBranchSegments = [
+          {
+            start: { x: centerX - 300, y: trunkTopY - 110 },
+            control1: { x: centerX - 360, y: trunkTopY - 140 },
+            control2: { x: centerX - 420, y: trunkTopY - 180 },
+            end: { x: centerX - 470, y: trunkTopY - 200 },
+          },
+        ] as const;
+
+        const rightSideBranchSegments = [
+          {
+            start: { x: centerX + 300, y: trunkTopY - 110 },
+            control1: { x: centerX + 360, y: trunkTopY - 140 },
+            control2: { x: centerX + 420, y: trunkTopY - 180 },
+            end: { x: centerX + 470, y: trunkTopY - 200 },
+          },
+        ] as const;
+
+        const topLeftTwigSegments = [
+          {
+            start: { x: centerX - 40, y: trunkTopY - 240 },
+            control1: { x: centerX - 100, y: trunkTopY - 280 },
+            control2: { x: centerX - 140, y: trunkTopY - 340 },
+            end: { x: centerX - 180, y: trunkTopY - 400 },
+          },
+        ] as const;
+
+        const topRightTwigSegments = [
+          {
+            start: { x: centerX + 40, y: trunkTopY - 240 },
+            control1: { x: centerX + 100, y: trunkTopY - 280 },
+            control2: { x: centerX + 140, y: trunkTopY - 340 },
+            end: { x: centerX + 180, y: trunkTopY - 400 },
+          },
+        ] as const;
+
+        const farLeftTwigSegments = [
+          {
+            start: { x: centerX - 520, y: trunkTopY - 300 },
+            control1: { x: centerX - 580, y: trunkTopY - 340 },
+            control2: { x: centerX - 620, y: trunkTopY - 380 },
+            end: { x: centerX - 660, y: trunkTopY - 430 },
+          },
+        ] as const;
+
+        const farRightTwigSegments = [
+          {
+            start: { x: centerX + 520, y: trunkTopY - 300 },
+            control1: { x: centerX + 580, y: trunkTopY - 340 },
+            control2: { x: centerX + 620, y: trunkTopY - 380 },
+            end: { x: centerX + 660, y: trunkTopY - 430 },
           },
         ] as const;
 
@@ -1771,7 +1843,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           {
             segments: leftMainSegments,
             spacing: 26,
-            thickness: 70,
+            thickness: 80,
           },
           { level: woodLevel },
         );
@@ -1781,7 +1853,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           {
             segments: rightMainSegments,
             spacing: 26,
-            thickness: 70,
+            thickness: 80,
           },
           { level: woodLevel },
         );
@@ -1791,7 +1863,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           {
             segments: topSegments,
             spacing: 24,
-            thickness: 55,
+            thickness: 60,
           },
           { level: woodLevel },
         );
@@ -1801,7 +1873,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           {
             segments: leftTwigSegments,
             spacing: 22,
-            thickness: 36,
+            thickness: 34,
           },
           { level: woodLevel },
         );
@@ -1811,7 +1883,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           {
             segments: rightTwigSegments,
             spacing: 22,
-            thickness: 36,
+            thickness: 34,
           },
           { level: woodLevel },
         );
@@ -1821,7 +1893,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           {
             segments: lowerLeftTwigSegments,
             spacing: 22,
-            thickness: 32,
+            thickness: 30,
           },
           { level: woodLevel },
         );
@@ -1831,7 +1903,87 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           {
             segments: lowerRightTwigSegments,
             spacing: 22,
-            thickness: 32,
+            thickness: 30,
+          },
+          { level: woodLevel },
+        );
+
+        const upperLeftBranch = bezierCurveWithBricks(
+          "smallWood",
+          {
+            segments: upperLeftSegments,
+            spacing: 22,
+            thickness: 42,
+          },
+          { level: woodLevel },
+        );
+
+        const upperRightBranch = bezierCurveWithBricks(
+          "smallWood",
+          {
+            segments: upperRightSegments,
+            spacing: 22,
+            thickness: 42,
+          },
+          { level: woodLevel },
+        );
+
+        const leftSideBranch = bezierCurveWithBricks(
+          "smallWood",
+          {
+            segments: leftSideBranchSegments,
+            spacing: 20,
+            thickness: 28,
+          },
+          { level: woodLevel },
+        );
+
+        const rightSideBranch = bezierCurveWithBricks(
+          "smallWood",
+          {
+            segments: rightSideBranchSegments,
+            spacing: 20,
+            thickness: 28,
+          },
+          { level: woodLevel },
+        );
+
+        const topLeftTwig = bezierCurveWithBricks(
+          "smallWood",
+          {
+            segments: topLeftTwigSegments,
+            spacing: 20,
+            thickness: 22,
+          },
+          { level: woodLevel },
+        );
+
+        const topRightTwig = bezierCurveWithBricks(
+          "smallWood",
+          {
+            segments: topRightTwigSegments,
+            spacing: 20,
+            thickness: 22,
+          },
+          { level: woodLevel },
+        );
+
+        const farLeftTwig = bezierCurveWithBricks(
+          "smallWood",
+          {
+            segments: farLeftTwigSegments,
+            spacing: 18,
+            thickness: 18,
+          },
+          { level: woodLevel },
+        );
+
+        const farRightTwig = bezierCurveWithBricks(
+          "smallWood",
+          {
+            segments: farRightTwigSegments,
+            spacing: 18,
+            thickness: 18,
           },
           { level: woodLevel },
         );
@@ -1883,6 +2035,14 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           rightTwig,
           lowerLeftTwig,
           lowerRightTwig,
+          upperLeftBranch,
+          upperRightBranch,
+          leftSideBranch,
+          rightSideBranch,
+          topLeftTwig,
+          topRightTwig,
+          farLeftTwig,
+          farRightTwig,
           roots,
         ];
       },

--- a/src/db/maps-db.ts
+++ b/src/db/maps-db.ts
@@ -1638,7 +1638,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
     const size: SceneSize = { width: 1400, height: 1200 };
     const centerX = size.width / 2;
     const groundY = size.height - 180;
-    const spawnPoint: SceneVector2 = { x: 240, y: 240 };
+    const spawnPoint: SceneVector2 = { x: 140, y: 140 };
 
     return {
       name: "Dead Oak",
@@ -1650,8 +1650,8 @@ const MAPS_DB: Record<MapId, MapConfig> = {
         const baseLevel = Math.max(0, Math.floor(mapLevel));
         const woodLevel = baseLevel + 1;
         const trunkTopY = groundY - 520;
-        const trunkWidthBase = 190;
-        const trunkWidthTop = 110;
+        const trunkWidthBase = 170;
+        const trunkWidthTop = 90;
 
         const trunkOutline = [
           {
@@ -1693,148 +1693,73 @@ const MAPS_DB: Record<MapId, MapConfig> = {
 
         const leftMainSegments = [
           {
-            start: { x: centerX - 40, y: trunkTopY + 140 },
-            control1: { x: centerX - 160, y: trunkTopY + 60 },
-            control2: { x: centerX - 300, y: trunkTopY - 40 },
-            end: { x: centerX - 420, y: trunkTopY - 150 },
-          },
-          {
-            start: { x: centerX - 420, y: trunkTopY - 150 },
-            control1: { x: centerX - 470, y: trunkTopY - 230 },
-            control2: { x: centerX - 520, y: trunkTopY - 300 },
-            end: { x: centerX - 560, y: trunkTopY - 360 },
+            start: { x: centerX - 40, y: trunkTopY + 240 },
+            control1: { x: centerX - 160, y: trunkTopY + 160 },
+            control2: { x: centerX - 300, y: trunkTopY + 100 },
+            end: { x: centerX - 360, y: trunkTopY + 80 },
           },
         ] as const;
 
         const rightMainSegments = [
           {
-            start: { x: centerX + 40, y: trunkTopY + 140 },
-            control1: { x: centerX + 160, y: trunkTopY + 60 },
-            control2: { x: centerX + 300, y: trunkTopY - 40 },
-            end: { x: centerX + 420, y: trunkTopY - 150 },
-          },
+            start: { x: centerX + 40, y: trunkTopY + 240 },
+            control1: { x: centerX + 160, y: trunkTopY + 160 },
+            control2: { x: centerX + 300, y: trunkTopY + 100 },
+            end: { x: centerX + 360, y: trunkTopY + 80 },
+          }
+        ] as const;
+
+        const leftMainBottomSegments = [
           {
-            start: { x: centerX + 420, y: trunkTopY - 150 },
-            control1: { x: centerX + 470, y: trunkTopY - 230 },
-            control2: { x: centerX + 520, y: trunkTopY - 310 },
-            end: { x: centerX + 560, y: trunkTopY - 370 },
+            start: { x: centerX - 360, y: trunkTopY + 90 },
+            control1: { x: centerX - 410, y: trunkTopY + 90 },
+            control2: { x: centerX - 490, y: trunkTopY + 130 },
+            end: { x: centerX - 610, y: trunkTopY + 150 },
           },
         ] as const;
 
-        const topSegments = [
+        const rightMainBottomSegments = [
           {
-            start: { x: centerX - 20, y: trunkTopY + 60 },
-            control1: { x: centerX - 60, y: trunkTopY - 80 },
-            control2: { x: centerX + 30, y: trunkTopY - 220 },
-            end: { x: centerX - 10, y: trunkTopY - 340 },
+            start: { x: centerX + 360, y: trunkTopY + 90 },
+            control1: { x: centerX + 410, y: trunkTopY + 90 },
+            control2: { x: centerX + 490, y: trunkTopY + 130 },
+            end: { x: centerX + 610, y: trunkTopY + 150 },
           },
         ] as const;
 
-        const leftTwigSegments = [
+        const leftMainTopSegments = [
           {
-            start: { x: centerX - 260, y: trunkTopY - 60 },
-            control1: { x: centerX - 320, y: trunkTopY - 140 },
-            control2: { x: centerX - 400, y: trunkTopY - 230 },
-            end: { x: centerX - 470, y: trunkTopY - 260 },
+            start: { x: centerX - 360, y: trunkTopY + 70 },
+            control1: { x: centerX - 410, y: trunkTopY + 40 },
+            control2: { x: centerX - 490, y: trunkTopY + 40 },
+            end: { x: centerX - 610, y: trunkTopY - 50 },
           },
         ] as const;
 
-        const rightTwigSegments = [
+        const rightMainTopSegments = [
           {
-            start: { x: centerX + 260, y: trunkTopY - 60 },
-            control1: { x: centerX + 320, y: trunkTopY - 140 },
-            control2: { x: centerX + 400, y: trunkTopY - 230 },
-            end: { x: centerX + 470, y: trunkTopY - 260 },
+            start: { x: centerX + 360, y: trunkTopY + 70 },
+            control1: { x: centerX + 410, y: trunkTopY + 40 },
+            control2: { x: centerX + 490, y: trunkTopY + 40 },
+            end: { x: centerX + 610, y: trunkTopY - 50 },
           },
         ] as const;
 
-        const lowerLeftTwigSegments = [
+        const leftUpperBranchSegments =[
           {
-            start: { x: centerX - 110, y: trunkTopY + 210 },
-            control1: { x: centerX - 200, y: trunkTopY + 190 },
-            control2: { x: centerX - 280, y: trunkTopY + 140 },
-            end: { x: centerX - 360, y: trunkTopY + 120 },
+            start: { x: centerX - 10, y: trunkTopY - 10 },
+            control1: { x: centerX - 210, y: trunkTopY - 140 },
+            control2: { x: centerX - 390, y: trunkTopY - 170 },
+            end: { x: centerX - 550, y: trunkTopY - 200 },
           },
         ] as const;
 
-        const lowerRightTwigSegments = [
+        const rightUpperBranchSegments = [
           {
-            start: { x: centerX + 110, y: trunkTopY + 210 },
-            control1: { x: centerX + 200, y: trunkTopY + 190 },
-            control2: { x: centerX + 280, y: trunkTopY + 140 },
-            end: { x: centerX + 360, y: trunkTopY + 120 },
-          },
-        ] as const;
-
-        const upperLeftSegments = [
-          {
-            start: { x: centerX - 120, y: trunkTopY - 80 },
-            control1: { x: centerX - 200, y: trunkTopY - 140 },
-            control2: { x: centerX - 280, y: trunkTopY - 240 },
-            end: { x: centerX - 360, y: trunkTopY - 320 },
-          },
-        ] as const;
-
-        const upperRightSegments = [
-          {
-            start: { x: centerX + 120, y: trunkTopY - 80 },
-            control1: { x: centerX + 200, y: trunkTopY - 140 },
-            control2: { x: centerX + 280, y: trunkTopY - 240 },
-            end: { x: centerX + 360, y: trunkTopY - 320 },
-          },
-        ] as const;
-
-        const leftSideBranchSegments = [
-          {
-            start: { x: centerX - 300, y: trunkTopY - 110 },
-            control1: { x: centerX - 360, y: trunkTopY - 140 },
-            control2: { x: centerX - 420, y: trunkTopY - 180 },
-            end: { x: centerX - 470, y: trunkTopY - 200 },
-          },
-        ] as const;
-
-        const rightSideBranchSegments = [
-          {
-            start: { x: centerX + 300, y: trunkTopY - 110 },
-            control1: { x: centerX + 360, y: trunkTopY - 140 },
-            control2: { x: centerX + 420, y: trunkTopY - 180 },
-            end: { x: centerX + 470, y: trunkTopY - 200 },
-          },
-        ] as const;
-
-        const topLeftTwigSegments = [
-          {
-            start: { x: centerX - 40, y: trunkTopY - 240 },
-            control1: { x: centerX - 100, y: trunkTopY - 280 },
-            control2: { x: centerX - 140, y: trunkTopY - 340 },
-            end: { x: centerX - 180, y: trunkTopY - 400 },
-          },
-        ] as const;
-
-        const topRightTwigSegments = [
-          {
-            start: { x: centerX + 40, y: trunkTopY - 240 },
-            control1: { x: centerX + 100, y: trunkTopY - 280 },
-            control2: { x: centerX + 140, y: trunkTopY - 340 },
-            end: { x: centerX + 180, y: trunkTopY - 400 },
-          },
-        ] as const;
-
-        const farLeftTwigSegments = [
-          {
-            start: { x: centerX - 520, y: trunkTopY - 300 },
-            control1: { x: centerX - 580, y: trunkTopY - 340 },
-            control2: { x: centerX - 620, y: trunkTopY - 380 },
-            end: { x: centerX - 660, y: trunkTopY - 430 },
-          },
-        ] as const;
-
-        const farRightTwigSegments = [
-          {
-            start: { x: centerX + 520, y: trunkTopY - 300 },
-            control1: { x: centerX + 580, y: trunkTopY - 340 },
-            control2: { x: centerX + 620, y: trunkTopY - 380 },
-            end: { x: centerX + 660, y: trunkTopY - 430 },
+            start: { x: centerX + 10, y: trunkTopY - 10 },
+            control1: { x: centerX + 210, y: trunkTopY - 140 },
+            control2: { x: centerX + 390, y: trunkTopY - 170 },
+            end: { x: centerX + 550, y: trunkTopY - 200 },
           },
         ] as const;
 
@@ -1843,7 +1768,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           {
             segments: leftMainSegments,
             spacing: 26,
-            thickness: 80,
+            thickness: 60,
           },
           { level: woodLevel },
         );
@@ -1853,137 +1778,66 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           {
             segments: rightMainSegments,
             spacing: 26,
-            thickness: 80,
-          },
-          { level: woodLevel },
-        );
-
-        const topBranch = bezierCurveWithBricks(
-          "smallWood",
-          {
-            segments: topSegments,
-            spacing: 24,
             thickness: 60,
           },
           { level: woodLevel },
         );
 
-        const leftTwig = bezierCurveWithBricks(
+        const leftMainBranchBottom = bezierCurveWithBricks(
           "smallWood",
           {
-            segments: leftTwigSegments,
-            spacing: 22,
-            thickness: 34,
+            segments: leftMainBottomSegments,
+            spacing: 26,
+            thickness: 40,
           },
           { level: woodLevel },
         );
 
-        const rightTwig = bezierCurveWithBricks(
+        const rightMainBranchBottom = bezierCurveWithBricks(
           "smallWood",
           {
-            segments: rightTwigSegments,
-            spacing: 22,
-            thickness: 34,
+            segments: rightMainBottomSegments,
+            spacing: 26,
+            thickness: 40,
           },
           { level: woodLevel },
         );
 
-        const lowerLeftTwig = bezierCurveWithBricks(
+        const leftMainBranchTop = bezierCurveWithBricks(
           "smallWood",
           {
-            segments: lowerLeftTwigSegments,
-            spacing: 22,
+            segments: leftMainTopSegments,
+            spacing: 26,
+            thickness: 40,
+          },
+          { level: woodLevel },
+        );
+        const rightMainBranchTop = bezierCurveWithBricks(
+          "smallWood",
+          {
+            segments: rightMainTopSegments,
+            spacing: 26,
+            thickness: 40,
+          },
+          { level: woodLevel },
+        );
+
+        const leftUpperBranch = bezierCurveWithBricks(
+          "smallWood",
+          {
+            segments: leftUpperBranchSegments,
+            spacing: 26,
             thickness: 30,
           },
           { level: woodLevel },
         );
 
-        const lowerRightTwig = bezierCurveWithBricks(
+        const rightUpperBranch = bezierCurveWithBricks(
           "smallWood",
           {
-            segments: lowerRightTwigSegments,
-            spacing: 22,
+            segments: rightUpperBranchSegments,
+            spacing: 26,
             thickness: 30,
-          },
-          { level: woodLevel },
-        );
-
-        const upperLeftBranch = bezierCurveWithBricks(
-          "smallWood",
-          {
-            segments: upperLeftSegments,
-            spacing: 22,
-            thickness: 42,
-          },
-          { level: woodLevel },
-        );
-
-        const upperRightBranch = bezierCurveWithBricks(
-          "smallWood",
-          {
-            segments: upperRightSegments,
-            spacing: 22,
-            thickness: 42,
-          },
-          { level: woodLevel },
-        );
-
-        const leftSideBranch = bezierCurveWithBricks(
-          "smallWood",
-          {
-            segments: leftSideBranchSegments,
-            spacing: 20,
-            thickness: 28,
-          },
-          { level: woodLevel },
-        );
-
-        const rightSideBranch = bezierCurveWithBricks(
-          "smallWood",
-          {
-            segments: rightSideBranchSegments,
-            spacing: 20,
-            thickness: 28,
-          },
-          { level: woodLevel },
-        );
-
-        const topLeftTwig = bezierCurveWithBricks(
-          "smallWood",
-          {
-            segments: topLeftTwigSegments,
-            spacing: 20,
-            thickness: 22,
-          },
-          { level: woodLevel },
-        );
-
-        const topRightTwig = bezierCurveWithBricks(
-          "smallWood",
-          {
-            segments: topRightTwigSegments,
-            spacing: 20,
-            thickness: 22,
-          },
-          { level: woodLevel },
-        );
-
-        const farLeftTwig = bezierCurveWithBricks(
-          "smallWood",
-          {
-            segments: farLeftTwigSegments,
-            spacing: 18,
-            thickness: 18,
-          },
-          { level: woodLevel },
-        );
-
-        const farRightTwig = bezierCurveWithBricks(
-          "smallWood",
-          {
-            segments: farRightTwigSegments,
-            spacing: 18,
-            thickness: 18,
           },
           { level: woodLevel },
         );
@@ -2030,20 +1884,183 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           trunk,
           leftMainBranch,
           rightMainBranch,
-          topBranch,
-          leftTwig,
-          rightTwig,
-          lowerLeftTwig,
-          lowerRightTwig,
-          upperLeftBranch,
-          upperRightBranch,
-          leftSideBranch,
-          rightSideBranch,
-          topLeftTwig,
-          topRightTwig,
-          farLeftTwig,
-          farRightTwig,
+          leftMainBranchBottom,
+          rightMainBranchBottom,
+          leftMainBranchTop,
+          rightMainBranchTop,
+          leftUpperBranch,
+          rightUpperBranch,
           roots,
+         bezierCurveWithBricks(
+            "smallWood",
+            {
+              segments: [
+                {
+                  start: { x: centerX - 10, y: trunkTopY - 10 },
+                  control1: { x: centerX - 30, y: trunkTopY - 70 },
+                  control2: { x: centerX - 50, y: trunkTopY - 110 },
+                  end: { x: centerX - 50, y: trunkTopY - 140 },
+                },
+                {
+                  start: { x: centerX - 50, y: trunkTopY - 140 },
+                  control1: { x: centerX - 90, y: trunkTopY - 160 },
+                  control2: { x: centerX - 150, y: trunkTopY - 190 },
+                  end: { x: centerX - 210, y: trunkTopY - 230 },
+                },
+                {
+                  start: { x: centerX - 210, y: trunkTopY - 230 },
+                  control1: { x: centerX - 250, y: trunkTopY - 250 },
+                  control2: { x: centerX - 280, y: trunkTopY - 280 },
+                  end: { x: centerX - 310, y: trunkTopY - 360 },
+                },
+                
+              ],
+              spacing: 26,
+              thickness: 28,
+            },
+            { level: woodLevel },
+          ),
+          bezierCurveWithBricks(
+            "smallWood",
+            {
+              segments: [
+                {
+                  start: { x: centerX + 10, y: trunkTopY - 10 },
+                  control1: { x: centerX + 30, y: trunkTopY - 70 },
+                  control2: { x: centerX + 50, y: trunkTopY - 110 },
+                  end: { x: centerX + 50, y: trunkTopY - 140 },
+                },
+                {
+                  start: { x: centerX + 50, y: trunkTopY - 140 },
+                  control1: { x: centerX + 90, y: trunkTopY - 160 },
+                  control2: { x: centerX + 150, y: trunkTopY - 190 },
+                  end: { x: centerX + 210, y: trunkTopY - 230 },
+                },
+                {
+                  start: { x: centerX + 210, y: trunkTopY - 230 },
+                  control1: { x: centerX + 250, y: trunkTopY - 250 },
+                  control2: { x: centerX + 280, y: trunkTopY - 280 },
+                  end: { x: centerX + 310, y: trunkTopY - 360 },
+                },
+                
+              ],
+              spacing: 26,
+              thickness: 28,
+            },
+            { level: woodLevel },
+          ),
+          bezierCurveWithBricks(
+            "smallWood",
+            {
+              segments: [
+                {
+                  start: { x: centerX - 50, y: trunkTopY - 140 },
+                  control1: { x: centerX - 60, y: trunkTopY - 210 },
+                  control2: { x: centerX - 120, y: trunkTopY - 240 },
+                  end: { x: centerX - 130, y: trunkTopY - 390 },
+                },
+              ],
+              spacing: 26,
+              thickness: 20,
+            },
+            { level: woodLevel },
+          ),
+          bezierCurveWithBricks(
+            "smallWood",
+            {
+              segments: [
+                {
+                  start: { x: centerX + 50, y: trunkTopY - 140 },
+                  control1: { x: centerX + 60, y: trunkTopY - 210 },
+                  control2: { x: centerX + 120, y: trunkTopY - 240 },
+                  end: { x: centerX + 130, y: trunkTopY - 390 },
+                },
+              ],
+              spacing: 26,
+              thickness: 20,
+            },
+            { level: woodLevel },
+          ),
+          bezierCurveWithBricks(
+            "smallWood",
+            {
+              segments: [
+                {
+                  start: { x: centerX + 50, y: trunkTopY - 140 },
+                  control1: { x: centerX + 10, y: trunkTopY - 210 },
+                  control2: { x: centerX - 30, y: trunkTopY - 240 },
+                  end: { x: centerX - 10, y: trunkTopY - 390 },
+                },
+              ],
+              spacing: 26,
+              thickness: 20,
+            },
+            { level: woodLevel },
+          ),
+          bezierCurveWithBricks(
+            "smallWood",
+            {
+              segments: [
+                {
+                  start: { x: centerX + 150, y: trunkTopY + 210 },
+                  control1: { x: centerX + 190, y: trunkTopY + 240 },
+                  control2: { x: centerX + 320, y: trunkTopY + 270 },
+                  end: { x: centerX + 430, y: trunkTopY + 300 },
+                },
+              ],
+              spacing: 26,
+              thickness: 20,
+            },
+            { level: woodLevel },
+          ),
+          bezierCurveWithBricks(
+            "smallWood",
+            {
+              segments: [
+                {
+                  start: { x: centerX - 150, y: trunkTopY + 210 },
+                  control1: { x: centerX - 190, y: trunkTopY + 240 },
+                  control2: { x: centerX - 320, y: trunkTopY + 270 },
+                  end: { x: centerX - 430, y: trunkTopY + 300 },
+                },
+              ],
+              spacing: 26,
+              thickness: 20,
+            },
+            { level: woodLevel },
+          ),
+          bezierCurveWithBricks(
+            "smallWood",
+            {
+              segments: [
+                {
+                  start: { x: centerX + 150, y: trunkTopY - 70 },
+                  control1: { x: centerX + 250, y: trunkTopY - 90 },
+                  control2: { x: centerX + 320, y: trunkTopY - 60 },
+                  end: { x: centerX + 460, y: trunkTopY - 80 },
+                },
+              ],
+              spacing: 26,
+              thickness: 20,
+            },
+            { level: woodLevel },
+          ),
+          bezierCurveWithBricks(
+            "smallWood",
+            {
+              segments: [
+                {
+                  start: { x: centerX - 150, y: trunkTopY - 70 },
+                  control1: { x: centerX - 250, y: trunkTopY - 90 },
+                  control2: { x: centerX - 320, y: trunkTopY - 60 },
+                  end: { x: centerX - 460, y: trunkTopY - 80 },
+                },
+              ],
+              spacing: 26,
+              thickness: 20,
+            },
+            { level: woodLevel },
+          ),
         ];
       },
       playerUnits: [

--- a/src/db/maps-db.ts
+++ b/src/db/maps-db.ts
@@ -1649,170 +1649,227 @@ const MAPS_DB: Record<MapId, MapConfig> = {
       bricks: ({ mapLevel }) => {
         const baseLevel = Math.max(0, Math.floor(mapLevel));
         const woodLevel = baseLevel + 1;
+        const trunkTopY = groundY - 420;
+        const trunkWidthBase = 160;
+        const trunkWidthTop = 90;
 
-        const createRectangle = (
-          x: number,
-          y: number,
-          width: number,
-          height: number,
-        ): SceneVector2[] => [
-          { x, y },
-          { x: x + width, y },
-          { x: x + width, y: y + height },
-          { x, y: y + height },
-        ];
+        const trunkOutline = [
+          {
+            start: { x: centerX - trunkWidthBase / 2, y: groundY },
+            control1: { x: centerX - trunkWidthBase / 2 - 20, y: groundY - 140 },
+            control2: { x: centerX - trunkWidthTop / 2 - 30, y: trunkTopY + 160 },
+            end: { x: centerX - trunkWidthTop / 2, y: trunkTopY },
+          },
+          {
+            start: { x: centerX - trunkWidthTop / 2, y: trunkTopY },
+            control1: { x: centerX - trunkWidthTop / 4, y: trunkTopY - 20 },
+            control2: { x: centerX + trunkWidthTop / 4, y: trunkTopY - 20 },
+            end: { x: centerX + trunkWidthTop / 2, y: trunkTopY },
+          },
+          {
+            start: { x: centerX + trunkWidthTop / 2, y: trunkTopY },
+            control1: { x: centerX + trunkWidthTop / 2 + 30, y: trunkTopY + 160 },
+            control2: { x: centerX + trunkWidthBase / 2 + 20, y: groundY - 140 },
+            end: { x: centerX + trunkWidthBase / 2, y: groundY },
+          },
+          {
+            start: { x: centerX + trunkWidthBase / 2, y: groundY },
+            control1: { x: centerX + trunkWidthBase / 4, y: groundY + 20 },
+            control2: { x: centerX - trunkWidthBase / 4, y: groundY + 20 },
+            end: { x: centerX - trunkWidthBase / 2, y: groundY },
+          },
+        ] as const;
 
-        // Main trunk (thick, slightly tapered)
-        const trunkWidth = 100;
-        const trunkHeight = 400;
-        const trunkX = centerX - trunkWidth / 2;
-        const trunkY = groundY - trunkHeight;
-
-        const trunk = polygonWithBricks(
+        const trunk = bezierPolygonWithBricks(
           "smallWood",
           {
-            vertices: [
-              { x: trunkX + 10, y: trunkY },
-              { x: trunkX + trunkWidth - 10, y: trunkY },
-              { x: trunkX + trunkWidth, y: groundY },
-              { x: trunkX, y: groundY },
-            ],
+            outline: trunkOutline,
+            spacing: 28,
+            sampleStep: 14,
+            alignToEdge: true,
           },
           { level: woodLevel },
         );
 
-        // Main branches extending from trunk
-        // Left main branch (going up-left)
-        const leftMainBranch = polygonWithBricks(
+        const leftMainSegments = [
+          {
+            start: { x: centerX - 30, y: trunkTopY + 110 },
+            control1: { x: centerX - 120, y: trunkTopY + 40 },
+            control2: { x: centerX - 240, y: trunkTopY - 60 },
+            end: { x: centerX - 340, y: trunkTopY - 140 },
+          },
+          {
+            start: { x: centerX - 340, y: trunkTopY - 140 },
+            control1: { x: centerX - 380, y: trunkTopY - 200 },
+            control2: { x: centerX - 420, y: trunkTopY - 250 },
+            end: { x: centerX - 460, y: trunkTopY - 300 },
+          },
+        ] as const;
+
+        const rightMainSegments = [
+          {
+            start: { x: centerX + 30, y: trunkTopY + 110 },
+            control1: { x: centerX + 120, y: trunkTopY + 40 },
+            control2: { x: centerX + 240, y: trunkTopY - 60 },
+            end: { x: centerX + 340, y: trunkTopY - 140 },
+          },
+          {
+            start: { x: centerX + 340, y: trunkTopY - 140 },
+            control1: { x: centerX + 380, y: trunkTopY - 200 },
+            control2: { x: centerX + 420, y: trunkTopY - 260 },
+            end: { x: centerX + 460, y: trunkTopY - 310 },
+          },
+        ] as const;
+
+        const topSegments = [
+          {
+            start: { x: centerX - 10, y: trunkTopY + 30 },
+            control1: { x: centerX - 40, y: trunkTopY - 60 },
+            control2: { x: centerX + 20, y: trunkTopY - 180 },
+            end: { x: centerX - 10, y: trunkTopY - 260 },
+          },
+        ] as const;
+
+        const leftTwigSegments = [
+          {
+            start: { x: centerX - 220, y: trunkTopY - 40 },
+            control1: { x: centerX - 260, y: trunkTopY - 110 },
+            control2: { x: centerX - 320, y: trunkTopY - 190 },
+            end: { x: centerX - 380, y: trunkTopY - 220 },
+          },
+        ] as const;
+
+        const rightTwigSegments = [
+          {
+            start: { x: centerX + 220, y: trunkTopY - 40 },
+            control1: { x: centerX + 260, y: trunkTopY - 110 },
+            control2: { x: centerX + 320, y: trunkTopY - 190 },
+            end: { x: centerX + 380, y: trunkTopY - 220 },
+          },
+        ] as const;
+
+        const lowerLeftTwigSegments = [
+          {
+            start: { x: centerX - 90, y: trunkTopY + 170 },
+            control1: { x: centerX - 160, y: trunkTopY + 150 },
+            control2: { x: centerX - 220, y: trunkTopY + 110 },
+            end: { x: centerX - 280, y: trunkTopY + 90 },
+          },
+        ] as const;
+
+        const lowerRightTwigSegments = [
+          {
+            start: { x: centerX + 90, y: trunkTopY + 170 },
+            control1: { x: centerX + 160, y: trunkTopY + 150 },
+            control2: { x: centerX + 220, y: trunkTopY + 110 },
+            end: { x: centerX + 280, y: trunkTopY + 90 },
+          },
+        ] as const;
+
+        const leftMainBranch = bezierCurveWithBricks(
           "smallWood",
           {
-            vertices: [
-              { x: centerX - 30, y: trunkY + 80 },
-              { x: centerX - 20, y: trunkY + 50 },
-              { x: centerX - 200, y: trunkY - 120 },
-              { x: centerX - 220, y: trunkY - 100 },
-            ],
+            segments: leftMainSegments,
+            spacing: 26,
+            thickness: 70,
           },
           { level: woodLevel },
         );
 
-        // Right main branch (going up-right)
-        const rightMainBranch = polygonWithBricks(
+        const rightMainBranch = bezierCurveWithBricks(
           "smallWood",
           {
-            vertices: [
-              { x: centerX + 20, y: trunkY + 50 },
-              { x: centerX + 30, y: trunkY + 80 },
-              { x: centerX + 220, y: trunkY - 100 },
-              { x: centerX + 200, y: trunkY - 120 },
-            ],
+            segments: rightMainSegments,
+            spacing: 26,
+            thickness: 70,
           },
           { level: woodLevel },
         );
 
-        // Center top branch (going straight up)
-        const topBranch = polygonWithBricks(
+        const topBranch = bezierCurveWithBricks(
           "smallWood",
           {
-            vertices: [
-              { x: centerX - 25, y: trunkY },
-              { x: centerX + 25, y: trunkY },
-              { x: centerX + 15, y: trunkY - 180 },
-              { x: centerX - 15, y: trunkY - 180 },
-            ],
+            segments: topSegments,
+            spacing: 24,
+            thickness: 55,
           },
           { level: woodLevel },
         );
 
-        // Smaller sub-branches
-        // Left sub-branch 1
-        const leftSubBranch1 = polygonWithBricks(
+        const leftTwig = bezierCurveWithBricks(
           "smallWood",
           {
-            vertices: [
-              { x: centerX - 160, y: trunkY - 80 },
-              { x: centerX - 140, y: trunkY - 90 },
-              { x: centerX - 280, y: trunkY - 200 },
-              { x: centerX - 300, y: trunkY - 180 },
-            ],
+            segments: leftTwigSegments,
+            spacing: 22,
+            thickness: 36,
           },
           { level: woodLevel },
         );
 
-        // Left sub-branch 2 (lower)
-        const leftSubBranch2 = polygonWithBricks(
+        const rightTwig = bezierCurveWithBricks(
           "smallWood",
           {
-            vertices: [
-              { x: centerX - 80, y: trunkY + 120 },
-              { x: centerX - 60, y: trunkY + 100 },
-              { x: centerX - 180, y: trunkY + 20 },
-              { x: centerX - 200, y: trunkY + 40 },
-            ],
+            segments: rightTwigSegments,
+            spacing: 22,
+            thickness: 36,
           },
           { level: woodLevel },
         );
 
-        // Right sub-branch 1
-        const rightSubBranch1 = polygonWithBricks(
+        const lowerLeftTwig = bezierCurveWithBricks(
           "smallWood",
           {
-            vertices: [
-              { x: centerX + 140, y: trunkY - 90 },
-              { x: centerX + 160, y: trunkY - 80 },
-              { x: centerX + 300, y: trunkY - 180 },
-              { x: centerX + 280, y: trunkY - 200 },
-            ],
+            segments: lowerLeftTwigSegments,
+            spacing: 22,
+            thickness: 32,
           },
           { level: woodLevel },
         );
 
-        // Right sub-branch 2 (lower)
-        const rightSubBranch2 = polygonWithBricks(
+        const lowerRightTwig = bezierCurveWithBricks(
           "smallWood",
           {
-            vertices: [
-              { x: centerX + 60, y: trunkY + 100 },
-              { x: centerX + 80, y: trunkY + 120 },
-              { x: centerX + 200, y: trunkY + 40 },
-              { x: centerX + 180, y: trunkY + 20 },
-            ],
+            segments: lowerRightTwigSegments,
+            spacing: 22,
+            thickness: 32,
           },
           { level: woodLevel },
         );
 
-        // Top sub-branches (smaller twigs)
-        const topLeftTwig = polygonWithBricks(
-          "smallWood",
+        const rootsOutline = [
           {
-            vertices: [
-              { x: centerX - 10, y: trunkY - 140 },
-              { x: centerX, y: trunkY - 150 },
-              { x: centerX - 80, y: trunkY - 250 },
-              { x: centerX - 100, y: trunkY - 240 },
-            ],
+            start: { x: centerX - 180, y: groundY },
+            control1: { x: centerX - 160, y: groundY + 40 },
+            control2: { x: centerX - 60, y: groundY + 60 },
+            end: { x: centerX, y: groundY + 50 },
           },
-          { level: woodLevel },
-        );
-
-        const topRightTwig = polygonWithBricks(
-          "smallWood",
           {
-            vertices: [
-              { x: centerX, y: trunkY - 150 },
-              { x: centerX + 10, y: trunkY - 140 },
-              { x: centerX + 100, y: trunkY - 240 },
-              { x: centerX + 80, y: trunkY - 250 },
-            ],
+            start: { x: centerX, y: groundY + 50 },
+            control1: { x: centerX + 60, y: groundY + 60 },
+            control2: { x: centerX + 160, y: groundY + 40 },
+            end: { x: centerX + 180, y: groundY },
           },
-          { level: woodLevel },
-        );
+          {
+            start: { x: centerX + 180, y: groundY },
+            control1: { x: centerX + 140, y: groundY - 10 },
+            control2: { x: centerX + 80, y: groundY - 10 },
+            end: { x: centerX, y: groundY - 10 },
+          },
+          {
+            start: { x: centerX, y: groundY - 10 },
+            control1: { x: centerX - 80, y: groundY - 10 },
+            control2: { x: centerX - 140, y: groundY - 10 },
+            end: { x: centerX - 180, y: groundY },
+          },
+        ] as const;
 
-        // Ground/roots
-        const roots = polygonWithBricks(
+        const roots = bezierPolygonWithBricks(
           "smallWood",
           {
-            vertices: createRectangle(centerX - 150, groundY, 300, 40),
+            outline: rootsOutline,
+            spacing: 26,
+            sampleStep: 12,
+            alignToEdge: true,
           },
           { level: woodLevel },
         );
@@ -1822,12 +1879,10 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           leftMainBranch,
           rightMainBranch,
           topBranch,
-          leftSubBranch1,
-          leftSubBranch2,
-          rightSubBranch1,
-          rightSubBranch2,
-          topLeftTwig,
-          topRightTwig,
+          leftTwig,
+          rightTwig,
+          lowerLeftTwig,
+          lowerRightTwig,
           roots,
         ];
       },

--- a/src/db/maps/helpers/bush-helper.ts
+++ b/src/db/maps/helpers/bush-helper.ts
@@ -1,0 +1,469 @@
+import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { BrickShapeBlueprint } from "../../../logic/services/brick-layout/BrickLayoutService";
+import { bezierCurveWithBricks } from "../../../logic/services/brick-layout/BrickLayoutService";
+import type { BezierSegment, CurveParams } from "../../../logic/services/brick-layout/brick-layout.types";
+
+/**
+ * ✅ TUNABLE CONSTANTS (your request)
+ * STEP = 3 means: total slots per side = STEP * N
+ * MIN_FREE_SLOTS = 1 means: at least 1 empty slot between neighboring branches (=> +2 spacing)
+ */
+const BRANCH_SLOT_STEP = 3;
+const BRANCH_MIN_FREE_SLOTS = 2;
+
+const vAdd = (a: SceneVector2, b: SceneVector2): SceneVector2 => ({ x: a.x + b.x, y: a.y + b.y });
+const vSub = (a: SceneVector2, b: SceneVector2): SceneVector2 => ({ x: a.x - b.x, y: a.y - b.y });
+const vMul = (a: SceneVector2, k: number): SceneVector2 => ({ x: a.x * k, y: a.y * k });
+const vLen = (a: SceneVector2): number => Math.hypot(a.x, a.y);
+const vNorm = (a: SceneVector2): SceneVector2 => {
+  const l = vLen(a);
+  return l > 1e-9 ? { x: a.x / l, y: a.y / l } : { x: 1, y: 0 };
+};
+const vLerp = (a: SceneVector2, b: SceneVector2, t: number): SceneVector2 => vAdd(a, vMul(vSub(b, a), t));
+
+const dir = (angleRad: number): SceneVector2 => ({ x: Math.cos(angleRad), y: Math.sin(angleRad) });
+const perp = (d: SceneVector2): SceneVector2 => ({ x: -d.y, y: d.x });
+
+function clamp(n: number, a: number, b: number) {
+  return Math.max(a, Math.min(b, n));
+}
+const clamp01 = (t: number) => clamp(t, 0, 1);
+
+function makeBezier(
+  start: SceneVector2,
+  angle: number,
+  length: number,
+  bendPx: number,
+  c1t = 0.33,
+  c2t = 0.72,
+): readonly BezierSegment[] {
+  const d = dir(angle);
+  const p = perp(d);
+  const end = vAdd(start, vMul(d, length));
+
+  const c1 = vAdd(vAdd(start, vMul(d, length * c1t)), vMul(p, bendPx));
+  const c2 = vAdd(vAdd(start, vMul(d, length * c2t)), vMul(p, -bendPx * 0.6));
+
+  return [{ start, control1: c1, control2: c2, end }];
+}
+
+const degToRad = (deg: number) => (deg * Math.PI) / 180;
+const sgn = (i: number) => (i % 2 === 0 ? 1 : -1);
+
+// deterministic “noise” (0..1 / -1..1)
+const hash01 = (n: number) => {
+  const x = Math.sin(n * 12.9898) * 43758.5453;
+  return x - Math.floor(x);
+};
+const signedHash = (n: number) => hash01(n) * 2 - 1;
+
+function sideBranchDelta(
+  side: "L" | "R",
+  centered: number, // -1..1 within the same side
+  minAngleRad: number,
+  spreadRad: number,
+  jitterRad: number,
+  verticalBiasRad: number,
+): number {
+  const sign = side === "L" ? -1 : 1;
+
+  const spreadTerm = centered * (spreadRad * 0.35);
+  let magnitude = minAngleRad + spreadTerm + jitterRad + verticalBiasRad;
+
+  magnitude = Math.max(minAngleRad, magnitude);
+
+  const maxAngle = Math.max(minAngleRad + degToRad(10), minAngleRad + spreadRad * 0.55);
+  magnitude = Math.min(magnitude, maxAngle, Math.PI / 2.4);
+
+  return sign * magnitude;
+}
+
+function twigSignWithSharedPhase(j: number, m: number, branchTwigSeed: number): 1 | -1 {
+  if (m <= 1) return (hash01(branchTwigSeed + 11.11) < 0.5 ? -1 : 1) as 1 | -1;
+
+  const phase = hash01(branchTwigSeed + 77.7) < 0.5 ? 0 : 1;
+  const isNeg = ((j + phase) % 2) === 0;
+  return (isNeg ? -1 : 1) as 1 | -1;
+}
+
+/**
+ * ✅ Slot-based height planner per side (NO height jitter).
+ *
+ * For N branches:
+ * - slotsCount = STEP * N
+ * - branch j may choose slot in [j*STEP .. j*STEP+(STEP-1)]
+ * - and must be at least (MIN_FREE_SLOTS+1) slots above previous chosen slot.
+ *
+ * Returns array of t's (length N), each being the CENTER of its chosen slot.
+ */
+function buildSlotHeights(params: { count: number; startT: number; endT: number; seedBase: number }): number[] {
+  const { count, startT, endT, seedBase } = params;
+  if (count <= 0) return [];
+
+  const span = Math.max(1e-6, endT - startT);
+  const slotsCount = BRANCH_SLOT_STEP * count;
+  const slotDT = span / slotsCount;
+
+  const chosenSlots: number[] = [];
+  let prev = -BRANCH_SLOT_STEP;
+
+  const gap = BRANCH_MIN_FREE_SLOTS + 1; // +1 because adjacency already consumes 1 slot
+
+  for (let j = 0; j < count; j++) {
+    const baseLo = j * BRANCH_SLOT_STEP;
+    const baseHi = j * BRANCH_SLOT_STEP + (BRANCH_SLOT_STEP - 1);
+
+    // enforce min distance from previous
+    const lo = Math.max(baseLo, prev + gap);
+    const hi = baseHi;
+
+    // If impossible (too tight), clamp to lo (still monotonic and safe)
+    let slot: number;
+    if (lo > hi) {
+      slot = lo;
+    } else {
+      const r = hash01(seedBase + j * 19.19);
+      slot = lo + Math.floor(r * (hi - lo + 1)); // inclusive
+    }
+
+    console.log(`slot: ${j}`, slot, lo, hi, seedBase + j * 19.19);
+
+    chosenSlots.push(slot);
+    prev = slot;
+  }
+
+  // Map slot index -> center t of that slot, clamped
+  const t: number[] = [];
+  for (let j = 0; j < chosenSlots.length; j++) {
+    const s = chosenSlots[j]!;
+
+    // псевдо-рандом в межах слота (0..1)
+    const u01 = hash01(seedBase + 999.123 + j * 41.77);
+
+    // щоб не липло до країв слота (опційно, але рекомендую)
+    const margin = 0.18; // 18% знизу/зверху слота не використовуємо
+    const u = margin + u01 * (1 - 2 * margin); // [margin..1-margin]
+
+    const pos = (s + u) * slotDT;
+    t.push(clamp(startT + pos, startT, endT));
+  }
+
+  return t;
+}
+
+export type BrickTreeParams = {
+  origin: SceneVector2;
+  size: number;
+  upAngleRad?: number;
+
+  topBranchesCount?: number;
+  sideBranchesCount: number;
+  branchingsPerSide: number;
+
+  trunkThickness: number;
+  mainBranchThickness: number;
+  twigThickness: number;
+
+  brickType: Parameters<typeof bezierCurveWithBricks>[0];
+  brickLevel: number;
+  spacing?: number;
+
+  trunkLenMul?: number;
+  topLenMul?: number;
+  sideLenMul?: number;
+  twigLenMul?: number;
+
+  /** ✅ NEW: multiplies all side-branch lengths (applied on top of sideLenMul) */
+  branchesLenMul?: number;
+
+  /** ✅ NEW: multiplies all twig lengths (applied on top of twigLenMul) */
+  twigsLenMul?: number;
+
+  minTwigLenPx?: number;
+
+  minSideAngleDeg?: number;
+  sideSpreadRad?: number;
+  topSpreadRad?: number;
+  twigSpreadRad?: number;
+
+  branchStartT?: number;
+  branchEndT?: number;
+
+  bendTrunkPx?: number;
+  bendTopPx?: number;
+  bendSidePx?: number;
+  bendTwigPx?: number;
+
+  balanceSides?: boolean;
+  sideBias?: number;
+
+  angleJitterRad?: number;
+  lenJitter?: number;
+  bendJitter?: number;
+  verticalBias?: number;
+
+  minTwigBranchAngleDeg?: number;
+  maxTwigBranchAngleDeg?: number;
+
+  twigAt?: readonly number[];
+
+  topStartSideOffsetPx?: number;
+  twigStartSideOffsetPx?: number;
+};
+
+export function brickTreeDeterministic(params: BrickTreeParams): readonly BrickShapeBlueprint[] {
+  const {
+    origin,
+    size,
+    upAngleRad = -Math.PI / 2,
+
+    topBranchesCount = 1,
+    sideBranchesCount,
+    branchingsPerSide,
+
+    trunkThickness,
+    mainBranchThickness,
+    twigThickness,
+
+    brickType,
+    brickLevel,
+    spacing = 26,
+
+    trunkLenMul = 1.15,
+    topLenMul = 0.55,
+    sideLenMul = 0.70,
+    twigLenMul = 0.42,
+
+    // ✅ NEW defaults
+    branchesLenMul = 1,
+    twigsLenMul = 1,
+
+    minTwigLenPx = 80,
+
+    minSideAngleDeg = 45,
+    sideSpreadRad = Math.PI * 0.75,
+    topSpreadRad = Math.PI * 0.22,
+    twigSpreadRad = Math.PI * 0.55,
+
+    branchStartT = 0.55,
+    branchEndT = 0.92,
+
+    bendTrunkPx = 22,
+    bendTopPx = 10,
+    bendSidePx = 18,
+    bendTwigPx = 10,
+
+    balanceSides = true,
+    sideBias = 0,
+
+    angleJitterRad = 0.22,
+    lenJitter = 0.12,
+    bendJitter = 0.30,
+    verticalBias = 0.22,
+
+    minTwigBranchAngleDeg = 30,
+    maxTwigBranchAngleDeg = 75,
+
+    twigAt = [0.50, 0.70, 0.84],
+
+    topStartSideOffsetPx = 10,
+    twigStartSideOffsetPx = 10,
+  } = params;
+
+  const out: BrickShapeBlueprint[] = [];
+
+  // 1) Trunk
+  const trunkLenPx = size * trunkLenMul;
+  const trunkSegs = makeBezier(origin, upAngleRad, trunkLenPx, bendTrunkPx, 0.28, 0.76);
+  out.push(
+    bezierCurveWithBricks(
+      brickType,
+      { segments: trunkSegs, spacing, thickness: trunkThickness } satisfies CurveParams,
+      { level: brickLevel },
+    ),
+  );
+
+  const trunkEnd = trunkSegs[0]!.end;
+  const trunkDir = vNorm(vSub(trunkEnd, origin));
+  const trunkPerp = perp(trunkDir);
+
+  // 2) Top branches (split sideways on trunk perpendicular)
+  const topN = clamp(topBranchesCount, 0, 6);
+  for (let i = 0; i < topN; i++) {
+    const centered = topN <= 1 ? 0 : (i / (topN - 1)) * 2 - 1;
+    const seed = 9001 + i * 17 + topN * 31;
+
+    const angJ = signedHash(seed + 1) * (angleJitterRad * 0.35);
+    const lenJ = signedHash(seed + 2) * (lenJitter * 0.35);
+    const bendM = 1 + signedHash(seed + 3) * (bendJitter * 0.35);
+
+    const angle = upAngleRad + centered * (topSpreadRad * 0.5) + sgn(i) * 0.06 + angJ;
+    const len =
+      Math.max(size * 0.30, size * topLenMul * (0.95 - 0.08 * Math.abs(centered))) * (1 + lenJ);
+    const bend = bendTopPx * sgn(i) * (1.0 - 0.15 * (i % 3)) * bendM;
+
+    const start = vAdd(trunkEnd, vMul(trunkPerp, centered * topStartSideOffsetPx));
+
+    const segs = makeBezier(start, angle, len, bend, 0.30, 0.76);
+    out.push(
+      bezierCurveWithBricks(
+        brickType,
+        { segments: segs, spacing, thickness: mainBranchThickness } satisfies CurveParams,
+        { level: brickLevel },
+      ),
+    );
+  }
+
+  // 3) Side branches
+  const minSideAngle = degToRad(minSideAngleDeg);
+  const sideN = clamp(sideBranchesCount, 0, 12);
+
+  type Side = "L" | "R";
+  const sides: Side[] = [];
+
+  if (!balanceSides) {
+    for (let i = 0; i < sideN; i++) sides.push(i % 2 === 0 ? "L" : "R");
+  } else {
+    const bias = clamp(sideBias, -1, 1);
+    const biasShift = Math.round(bias * Math.min(2, sideN));
+    let rightCount = Math.floor(sideN / 2) + (sideN % 2) + biasShift;
+    rightCount = clamp(rightCount, 0, sideN);
+    const leftCount = sideN - rightCount;
+
+    for (let i = 0; i < leftCount; i++) sides.push("L");
+    for (let i = 0; i < rightCount; i++) sides.push("R");
+  }
+
+  const leftCount = sides.filter((s) => s === "L").length;
+  const rightCount = sides.length - leftCount;
+
+  // ✅ Slot-based heights PER SIDE (independent, but same slot scheme if counts equal)
+  const leftHeights = buildSlotHeights({
+    count: leftCount,
+    startT: branchStartT,
+    endT: branchEndT,
+    seedBase: 10001,
+  });
+
+  const rightHeights = buildSlotHeights({
+    count: rightCount,
+    startT: branchStartT,
+    endT: branchEndT,
+    seedBase: 20001,
+  });
+
+  let leftK = 0;
+  let rightK = 0;
+
+  for (let i = 0; i < sides.length; i++) {
+    const side = sides[i]!;
+    const k = side === "L" ? leftK++ : rightK++;
+    const count = side === "L" ? leftCount : rightCount;
+
+    const sideSeed = side === "L" ? 101 : 203;
+    const seed = sideSeed + k * 17 + sideN * 31;
+
+    const heightT = (side === "L" ? leftHeights[k] : rightHeights[k]) ?? (branchStartT + 0.2);
+    const sideStart = vLerp(origin, trunkEnd, heightT);
+
+    const centered = count <= 1 ? 0 : (k / (count - 1)) * 2 - 1;
+
+    const v = clamp01((heightT - branchStartT) / Math.max(1e-6, branchEndT - branchStartT));
+    const vBiasRad = (v - 0.5) * verticalBias;
+
+    const angJ = signedHash(seed + 2) * angleJitterRad;
+
+    const delta = sideBranchDelta(side, centered, minSideAngle, sideSpreadRad, angJ, vBiasRad);
+    const sideAngle = upAngleRad + delta;
+
+    const lenJ = signedHash(seed + 3) * lenJitter;
+
+    // ✅ NEW: apply branchesLenMul on top of sideLenMul
+    const sideLen =
+      size *
+      sideLenMul *
+      branchesLenMul *
+      (0.95 - 0.10 * Math.abs(centered)) *
+      (1 + lenJ);
+
+    const bendM = 1 + signedHash(seed + 4) * bendJitter;
+    const sideBend = bendSidePx * (side === "L" ? -1 : 1) * (0.90 - 0.10 * (k % 3)) * bendM;
+
+    const sideSegs = makeBezier(sideStart, sideAngle, sideLen, sideBend);
+    out.push(
+      bezierCurveWithBricks(
+        brickType,
+        { segments: sideSegs, spacing, thickness: mainBranchThickness } satisfies CurveParams,
+        { level: brickLevel },
+      ),
+    );
+
+    // 4) Twigs
+    const m = clamp(branchingsPerSide, 0, 10);
+    const sideEnd = sideSegs[0]!.end;
+
+    const minA = degToRad(minTwigBranchAngleDeg);
+    const maxA = degToRad(maxTwigBranchAngleDeg);
+
+    const branchTwigSeed = seed * 13 + 555;
+
+    const parentDir = vNorm(vSub(sideEnd, sideStart));
+    const parentPerp = perp(parentDir);
+    const parentAngle = Math.atan2(parentDir.y, parentDir.x);
+
+    const overlapPx = Math.min(6, twigStartSideOffsetPx * 0.4);
+
+    for (let j = 0; j < m; j++) {
+      const tj = twigAt[(j + i) % twigAt.length]!;
+      const twigStartCenter = vLerp(sideStart, sideEnd, tj);
+
+      const twigCentered = m <= 1 ? 0 : (j / (m - 1)) * 2 - 1;
+
+      const twigSeed = branchTwigSeed + j * 7;
+
+      const twigAngJ = signedHash(twigSeed + 1) * (angleJitterRad * 0.55);
+      const twigLenJ = signedHash(twigSeed + 2) * (lenJitter * 0.65);
+      const twigBendM = 1 + signedHash(twigSeed + 3) * (bendJitter * 0.55);
+
+      const desiredRel =
+        twigCentered * (twigSpreadRad * 0.5) +
+        sgn(i + j) * (0.10 + 0.03 * (k % 4)) +
+        twigAngJ;
+
+      const mag = clamp(Math.abs(desiredRel), minA, maxA);
+
+      const sign = twigSignWithSharedPhase(j, m, branchTwigSeed);
+      const rel = sign * mag;
+
+      const twigAngle = parentAngle + rel;
+
+      const twigStart = vAdd(
+        vAdd(twigStartCenter, vMul(parentPerp, sign * twigStartSideOffsetPx)),
+        vMul(parentDir, -overlapPx),
+      );
+
+      // ✅ NEW: apply twigsLenMul on top of twigLenMul (before clamp)
+      const rawTwigLen =
+        size *
+        twigLenMul *
+        twigsLenMul *
+        (0.95 - 0.10 * Math.abs(twigCentered) - 0.06 * (j % 3));
+
+      const twigLen = Math.max(minTwigLenPx, rawTwigLen * (1 + twigLenJ));
+
+      const twigBend = bendTwigPx * sign * (1.0 - 0.18 * (j % 3)) * twigBendM;
+
+      const twigSegs = makeBezier(twigStart, twigAngle, twigLen, twigBend, 0.30, 0.74);
+
+      out.push(
+        bezierCurveWithBricks(
+          brickType,
+          { segments: twigSegs, spacing, thickness: twigThickness } satisfies CurveParams,
+          { level: brickLevel },
+        ),
+      );
+    }
+  }
+
+  return out;
+}

--- a/src/db/maps/maps-db.ts
+++ b/src/db/maps/maps-db.ts
@@ -1,15 +1,15 @@
-import { BrickType, getBrickConfig } from "./bricks-db";
+import { BrickType, getBrickConfig } from "../bricks-db";
 import {
   SceneSize,
   SceneVector2,
 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
-import { PlayerUnitType } from "./player-units-db";
-import type { EnemyType } from "./enemies-db";
-import type { EnemySpawnData } from "../logic/modules/active-map/enemies/enemies.types";
+import { PlayerUnitType } from "../player-units-db";
+import type { EnemyType } from "../enemies-db";
+import type { EnemySpawnData } from "../../logic/modules/active-map/enemies/enemies.types";
 import type { UnlockCondition } from "@shared/types/unlocks";
-import type { SkillId } from "./skills-db";
-import type { AchievementId } from "./achievements-db";
-import type { MapEffectId } from "./map-effects-db";
+import type { SkillId } from "../skills-db";
+import type { AchievementId } from "../achievements-db";
+import type { MapEffectId } from "../map-effects-db";
 import {
   BrickShapeBlueprint,
   buildBricksFromBlueprints,
@@ -20,8 +20,9 @@ import {
   polygonWithBricks,
   squareWithBricks,
   templateWithBricks,
-} from "../logic/services/brick-layout/BrickLayoutService";
-import { transformBezierOutline } from "../logic/services/brick-layout/brick-layout.helpers";
+} from "../../logic/services/brick-layout/BrickLayoutService";
+import { transformBezierOutline } from "../../logic/services/brick-layout/brick-layout.helpers";
+import { brickTreeDeterministic } from "./helpers/bush-helper";
 
 export type MapId =
   | "tutorialZone"
@@ -3709,53 +3710,123 @@ const MAPS_DB: Record<MapId, MapConfig> = {
           { level: iceLevel },
         );
 
-        const trees = treeConfigs.flatMap((tree) => {
-          const trunkHeight = 180 * tree.scale;
-          const trunkWidth = 60 * tree.scale;
-          const trunkBottomY = tree.base.y;
-          const trunkTopY = trunkBottomY - trunkHeight;
-
-          const trunk = polygonWithBricks(
-            "smallWood",
-            {
-              vertices: createRectangle(
-                tree.base.x - trunkWidth / 2,
-                trunkTopY,
-                trunkWidth,
-                trunkHeight,
-              ),
-            },
-            { level: treeTrunkLevel },
-          );
-
-          const canopyLayers = [
-            { width: 320, height: 260, offset: 20 },
-            { width: 260, height: 220, offset: 120 },
-            { width: 190, height: 180, offset: 210 },
-          ];
-
-          const canopy = canopyLayers.map((layer) => {
-            const baseCenter: SceneVector2 = {
-              x: tree.base.x,
-              y: trunkTopY + layer.offset * tree.scale,
-            };
-            return polygonWithBricks(
-              "smallWood",
-              {
-                vertices: createTriangle(
-                  baseCenter,
-                  layer.width * tree.scale,
-                  layer.height * tree.scale,
-                ),
-              },
-              { level: treeCanopyLevel },
-            );
-          });
-
-          return [trunk, ...canopy];
+        const bush1 = brickTreeDeterministic({
+          origin: { x: 1180, y: 480 },
+          size: 260,
+          mainBranchThickness: 19,
+          twigThickness: 18,
+          trunkThickness: 38,
+          sideBranchesCount: 4,
+          branchingsPerSide: 2,
+          topBranchesCount: 2,
+          minSideAngleDeg: 60,
+          sideSpreadRad: Math.PI * 0.1,
+          topSpreadRad: Math.PI * 0.22,
+          twigSpreadRad: Math.PI * 0.25,
+          branchStartT: 0.25,
+          bendTrunkPx: 22,
+          bendTopPx: 10,
+          bendSidePx: 18,
+          bendTwigPx: 10,
+          brickType: "smallWood",
+          brickLevel: treeCanopyLevel,
+          spacing: 26,
+          angleJitterRad: 0.72,
+          lenJitter: 0.12,
+          bendJitter: 0.30,
+          verticalBias: 0.22,
+          //heightJitterT: 0.27,
         });
 
-        return [frozenLake, ...trees];
+        const bush2 = brickTreeDeterministic({
+          origin: { x: 1250, y: 980 },
+          size: 260,
+          mainBranchThickness: 19,
+          twigThickness: 18,
+          trunkThickness: 38,
+          sideBranchesCount: 3,
+          branchingsPerSide: 2,
+          topBranchesCount: 3,
+          minSideAngleDeg: 60,
+          sideSpreadRad: Math.PI * 0.4,
+          topSpreadRad: Math.PI * 0.42,
+          twigSpreadRad: Math.PI * 0.15,
+          branchStartT: 0.25,
+          bendTrunkPx: 22,
+          bendTopPx: 10,
+          bendSidePx: 18,
+          bendTwigPx: 10,
+          brickType: "smallWood",
+          brickLevel: treeCanopyLevel,
+          spacing: 26,
+          angleJitterRad: 0.72,
+          lenJitter: 0.12,
+          bendJitter: 0.30,
+          verticalBias: 0.22,
+          //heightJitterT: 0.27,
+        });
+
+        const bush3 = brickTreeDeterministic({
+          origin: { x: 1150, y: 1180 },
+          size: 160,
+          mainBranchThickness: 19,
+          twigThickness: 18,
+          trunkThickness: 38,
+          sideBranchesCount: 2,
+          branchingsPerSide: 3,
+          topBranchesCount: 3,
+          minSideAngleDeg: 60,
+          branchesLenMul: 1.4,
+          sideSpreadRad: Math.PI * 0.4,
+          topSpreadRad: Math.PI * 0.42,
+          twigSpreadRad: Math.PI * 0.15,
+          branchStartT: 0.05,
+          branchEndT: 0.25,
+          bendTrunkPx: 22,
+          bendTopPx: 10,
+          bendSidePx: 18,
+          bendTwigPx: 10,
+          brickType: "smallWood",
+          brickLevel: treeCanopyLevel,
+          spacing: 26,
+          angleJitterRad: 0.72,
+          lenJitter: 0.12,
+          bendJitter: 0.30,
+          verticalBias: 0.22,
+          //heightJitterT: 0.27,
+        });
+
+        const bush4 = brickTreeDeterministic({
+          origin: { x: 250, y: 980 },
+          size: 360,
+          mainBranchThickness: 19,
+          twigThickness: 18,
+          trunkThickness: 38,
+          sideBranchesCount: 6,
+          branchingsPerSide: 2,
+          topBranchesCount: 3,
+          minSideAngleDeg: 60,
+          sideSpreadRad: Math.PI * 0.4,
+          topSpreadRad: Math.PI * 0.42,
+          twigSpreadRad: Math.PI * 0.15,
+          branchStartT: 0.15,
+          bendTrunkPx: 22,
+          bendTopPx: 10,
+          bendSidePx: 18,
+          bendTwigPx: 10,
+          brickType: "smallWood",
+          brickLevel: treeCanopyLevel,
+          spacing: 26,
+          angleJitterRad: 0.72,
+          lenJitter: 0.12,
+          bendJitter: 0.30,
+          verticalBias: 0.22,
+          twigAt: [0.25, 0.45, 0.65],
+          //heightJitterT: 0.27,
+        });
+
+
+        return [frozenLake, ...bush1, ...bush2, ...bush3, ...bush4];
       },
       playerUnits: [
         {

--- a/src/db/resources-db.ts
+++ b/src/db/resources-db.ts
@@ -1,4 +1,4 @@
-import type { MapId } from "./maps-db";
+import type { MapId } from "./maps/maps-db";
 import type { SkillId } from "./skills-db";
 import type { UnlockCondition } from "@shared/types/unlocks";
 

--- a/src/db/unit-modules-db.ts
+++ b/src/db/unit-modules-db.ts
@@ -1,5 +1,5 @@
 import { ResourceAmount } from "./resources-db";
-import type { MapId } from "./maps-db";
+import type { MapId } from "./maps/maps-db";
 import type { SkillId } from "./skills-db";
 import type { UnlockCondition } from "@shared/types/unlocks";
 import { FILL_TYPES } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.const";

--- a/src/logic/modules/active-map/enemies/enemies.spawn-controller.ts
+++ b/src/logic/modules/active-map/enemies/enemies.spawn-controller.ts
@@ -1,5 +1,5 @@
 import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
-import type { MapEnemySpawnPointConfig, MapEnemySpawnTypeConfig } from "../../../../db/maps-db";
+import type { MapEnemySpawnPointConfig, MapEnemySpawnTypeConfig } from "../../../../db/maps/maps-db";
 import type { EnemyType } from "../../../../db/enemies-db";
 import type { EnemiesModule } from "./enemies.module";
 import type { EnemySpawnData } from "./enemies.types";

--- a/src/logic/modules/active-map/map/map.const.ts
+++ b/src/logic/modules/active-map/map/map.const.ts
@@ -1,4 +1,4 @@
-import type { MapId } from "../../../../db/maps-db";
+import type { MapId } from "../../../../db/maps/maps-db";
 import type { SkillId } from "../../../../db/skills-db";
 import type { MapAutoRestartState } from "./map.types";
 

--- a/src/logic/modules/active-map/map/map.module.ts
+++ b/src/logic/modules/active-map/map/map.module.ts
@@ -11,7 +11,7 @@ import {
   getMapConfig,
   getMapList,
   isMapId,
-} from "../../../../db/maps-db";
+} from "../../../../db/maps/maps-db";
 import type { BonusEffectMap } from "@shared/types/bonuses";
 import { buildBricksFromBlueprints } from "../../../services/brick-layout/BrickLayoutService";
 import { MapSelectionState } from "./map.selection";

--- a/src/logic/modules/active-map/map/map.run-lifecycle.ts
+++ b/src/logic/modules/active-map/map/map.run-lifecycle.ts
@@ -8,7 +8,7 @@ import { PlayerUnitsModule } from "../player-units/player-units.module";
 import type { PlayerUnitSpawnData } from "../player-units/player-units.types";
 import { EnemiesModule } from "../enemies/enemies.module";
 import { EnemySpawnController } from "../enemies/enemies.spawn-controller";
-import type { MapEnemySpawnPointConfig } from "../../../../db/maps-db";
+import type { MapEnemySpawnPointConfig } from "../../../../db/maps/maps-db";
 import type { EnemySpawnData } from "../enemies/enemies.types";
 import { NecromancerModule } from "../necromancer/necromancer.module";
 import { ResourceRunController } from "./map.types";

--- a/src/logic/modules/active-map/map/map.selection.ts
+++ b/src/logic/modules/active-map/map/map.selection.ts
@@ -1,4 +1,4 @@
-import { MapId } from "../../../../db/maps-db";
+import { MapId } from "../../../../db/maps/maps-db";
 import { MapSaveData } from "./map.types";
 
 export class MapSelectionState {

--- a/src/logic/modules/active-map/map/map.types.ts
+++ b/src/logic/modules/active-map/map/map.types.ts
@@ -15,7 +15,7 @@ import { EventLogModule } from "../../shared/event-log/event-log.module";
 import { ArcModule } from "../../scene/arc/arc.module";
 import { EnemiesModule } from "../enemies/enemies.module";
 import type { EnemyRuntimeState } from "../enemies/enemies.types";
-import { MapId, MapListEntry as MapListEntryConfig } from "../../../../db/maps-db";
+import { MapId, MapListEntry as MapListEntryConfig } from "../../../../db/maps/maps-db";
 import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import type { TargetSnapshot } from "../targeting/targeting.types";
 import { MapRunState } from "./MapRunState";

--- a/src/logic/modules/shared/achievements/achievements.module.ts
+++ b/src/logic/modules/shared/achievements/achievements.module.ts
@@ -5,7 +5,7 @@ import {
   AchievementId,
   getAchievementConfig,
 } from "../../../../db/achievements-db";
-import { getMapConfig, getMapList, MapId } from "../../../../db/maps-db";
+import { getMapConfig, getMapList, MapId } from "../../../../db/maps/maps-db";
 import type { MapLevelStats, MapStats } from "../../active-map/map/map.types";
 import type { BonusEffectPreview } from "@shared/types/bonuses";
 import type {

--- a/src/logic/modules/shared/achievements/achievements.types.ts
+++ b/src/logic/modules/shared/achievements/achievements.types.ts
@@ -1,6 +1,6 @@
 import type { BonusEffectPreview } from "@shared/types/bonuses";
 import type { AchievementId } from "../../../../db/achievements-db";
-import type { MapId } from "../../../../db/maps-db";
+import type { MapId } from "../../../../db/maps/maps-db";
 import type { DataBridge } from "@/core/logic/ui/DataBridge";
 import type { BonusesModule } from "../bonuses/bonuses.module";
 

--- a/src/logic/services/brick-layout/brick-layout.generators.ts
+++ b/src/logic/services/brick-layout/brick-layout.generators.ts
@@ -439,14 +439,20 @@ export const generateBezierCurveBricks = (
     return [];
   }
 
+  const spacingConfig = getBrickSpacing(brickType);
   const spacing = clampPositive(
-    options.spacing ?? getBrickSpacing(brickType).tangential,
-    getBrickSpacing(brickType).tangential,
+    options.spacing ?? spacingConfig.tangential,
+    spacingConfig.tangential,
   );
   const sampleStep = clampPositive(
     options.sampleStep ?? spacing * 0.5,
     DEFAULT_BEZIER_SAMPLE_STEP,
   );
+  const thickness = Number.isFinite(options.thickness) ? Math.max(0, options.thickness ?? 0) : 0;
+  const thicknessSpacing = spacingConfig.radial;
+  const bandCount = Math.max(1, Math.floor(thickness / thicknessSpacing) + 1);
+  const startOffset = -((bandCount - 1) / 2) * thicknessSpacing;
+  const offsets = Array.from({ length: bandCount }, (_, index) => startOffset + index * thicknessSpacing);
   const points = sampleBezierPath(options.segments, sampleStep);
   if (points.length < 2) {
     return [];
@@ -476,12 +482,16 @@ export const generateBezierCurveBricks = (
       const x = previous.x + (current.x - previous.x) * t;
       const y = previous.y + (current.y - previous.y) * t;
       const angle = Math.atan2(current.y - previous.y, current.x - previous.x) + rotationOffset;
+      const normalX = -Math.sin(angle);
+      const normalY = Math.cos(angle);
 
-      bricks.push({
-        position: { x, y },
-        rotation: angle,
-        type: brickType,
-        level,
+      offsets.forEach((offset) => {
+        bricks.push({
+          position: { x: x + normalX * offset, y: y + normalY * offset },
+          rotation: angle,
+          type: brickType,
+          level,
+        });
       });
 
       nextDistance += spacing;

--- a/src/logic/services/brick-layout/brick-layout.types.ts
+++ b/src/logic/services/brick-layout/brick-layout.types.ts
@@ -71,6 +71,7 @@ export interface BezierCurveWithBricksOptions {
   readonly spacing?: number;
   readonly sampleStep?: number;
   readonly rotationOffset?: number;
+  readonly thickness?: number;
 }
 
 export interface BezierTransformOptions {

--- a/src/logic/services/brick-layout/brick-layout.types.ts
+++ b/src/logic/services/brick-layout/brick-layout.types.ts
@@ -143,3 +143,16 @@ export interface BrickSpacing {
   radial: number;
   tangential: number;
 }
+
+export type BezierSegment = {
+  start: SceneVector2;
+  control1: SceneVector2;
+  control2: SceneVector2;
+  end: SceneVector2;
+};
+
+export type CurveParams = {
+  segments: readonly BezierSegment[];
+  spacing: number;
+  thickness: number;
+};

--- a/src/logic/services/unlock/UnlockService.ts
+++ b/src/logic/services/unlock/UnlockService.ts
@@ -1,4 +1,4 @@
-import { getMapConfig, MapId } from "../../../db/maps-db";
+import { getMapConfig, MapId } from "../../../db/maps/maps-db";
 import { getSkillConfig, SkillId } from "../../../db/skills-db";
 import type { UnlockServiceOptions, GameUnlockCondition } from "./unlock.types";
 import { CACHE_TTL_MS } from "./unlock.const";

--- a/src/logic/services/unlock/unlock-progression.adapter.ts
+++ b/src/logic/services/unlock/unlock-progression.adapter.ts
@@ -1,5 +1,5 @@
 import type { ProgressionSource } from "@core/logic/provided/services/gameplay-ports";
-import type { MapId } from "@db/maps-db";
+import type { MapId } from "@/db/maps/maps-db";
 import type { SkillId } from "@db/skills-db";
 import type { UnlockConditionList } from "@shared/types/unlocks";
 import { UnlockService } from "./UnlockService";

--- a/src/logic/services/unlock/unlock.types.ts
+++ b/src/logic/services/unlock/unlock.types.ts
@@ -1,4 +1,4 @@
-import type { MapId } from "../../../db/maps-db";
+import type { MapId } from "../../../db/maps/maps-db";
 import type { SkillId } from "../../../db/skills-db";
 import type { MapStats } from "../../modules/active-map/map/map.types";
 import type { UnlockCondition } from "@shared/types/unlocks";

--- a/src/ui/screens/VoidCamp/VoidCampScreen.tsx
+++ b/src/ui/screens/VoidCamp/VoidCampScreen.tsx
@@ -5,7 +5,7 @@ import {
   CampContent,
   CampTabKey,
 } from "@screens/VoidCamp/components/CampContent/CampContent";
-import { MapId } from "@db/maps-db";
+import { MapId } from "@/db/maps/maps-db";
 import { GAME_VERSIONS } from "@db/version-db";
 import {
   MAP_CLEARED_LEVELS_BRIDGE_KEY,

--- a/src/ui/screens/VoidCamp/components/CampContent/CampContent.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/CampContent.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { MapId } from "@db/maps-db";
+import { MapId } from "@/db/maps/maps-db";
 import { MapListEntry } from "@logic/modules/active-map/map/map.types";
 import { CampTabsMenu } from "./TabMenu/CampTabsMenu";
 import { CampTabPanels } from "./TabPanels/CampTabPanels";

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/CampTabPanels.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/CampTabPanels.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { MapId, getMapConfig } from "@db/maps-db";
+import { MapId, getMapConfig } from "@/db/maps/maps-db";
 import { MapListEntry } from "@logic/modules/active-map/map/map.types";
 import { SkillTreeView } from "@/ui/screens/VoidCamp/components/CampContent/TabPanels/SkillTree/SkillTreeView";
 import { ModulesWorkshopView } from "@/ui/screens/VoidCamp/components/CampContent/TabPanels/ModulesWorkshop/ModulesWorkshopView";

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.tsx
@@ -4,7 +4,7 @@ import type {
   MouseEvent as ReactMouseEvent,
   WheelEvent as ReactWheelEvent,
 } from "react";
-import { MapId, getMapConfig } from "@db/maps-db";
+import { MapId, getMapConfig } from "@/db/maps/maps-db";
 import { getAssetUrl } from "@shared/helpers/assets.helper";
 import { MapListEntry } from "@logic/modules/active-map/map/map.types";
 import { classNames } from "@ui-shared/classNames";

--- a/src/ui/screens/VoidCamp/components/ResourceSidebar/ResourceSidebar.tsx
+++ b/src/ui/screens/VoidCamp/components/ResourceSidebar/ResourceSidebar.tsx
@@ -5,7 +5,7 @@ import { formatNumber } from "@ui-shared/format/number";
 import { useAppLogic } from "@ui/contexts/AppLogicContext";
 import { useBridgeValue } from "@ui/shared/useBridgeValue";
 import { MAP_LAST_PLAYED_BRIDGE_KEY } from "@logic/modules/active-map/map/map.const";
-import { getMapConfig, MapId } from "@db/maps-db";
+import { getMapConfig, MapId } from "@/db/maps/maps-db";
 import { useCallback } from "react";
 
 interface ResourceSidebarProps {


### PR DESCRIPTION
### Motivation
- Improve the visual silhouette of the "Dead Oak" map by replacing simple polygons with Bezier-based trunk, branches and roots to produce more organic branching. 
- Allow Bezier curve generators to produce thicker branches by emitting bricks in multiple offset bands so curves can have configurable width.

### Description
- Added `thickness?: number` to `BezierCurveWithBricksOptions` to expose per-curve width. (`src/logic/services/brick-layout/brick-layout.types.ts`).
- Updated `generateBezierCurveBricks` to compute radial offsets based on brick spacing and emit multiple parallel bands of bricks along the curve when `thickness` is provided. (`src/logic/services/brick-layout/brick-layout.generators.ts`).
- Reworked `deadOak` map to use `bezierPolygonWithBricks` for the trunk and roots and `bezierCurveWithBricks` for main branches/twigs with tuned `spacing` and `thickness` values for a branched look, replacing the previous rectangular/polygon branch pieces. (`src/db/maps-db.ts`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bba1848748320a7057ce4b8e42d8f)