### PR TITLE
Add snowfall visual effects with rectangular spawn & GPU culling

### DIFF
--- a/src/db/maps/map-definitions/frozenForest.ts
+++ b/src/db/maps/map-definitions/frozenForest.ts
@@ -2,6 +2,7 @@ import type { SceneSize, SceneVector2 } from "@core/logic/provided/services/scen
 import { circleWithBricks } from "../../../logic/services/brick-layout/BrickLayoutService";
 import { brickTreeDeterministic } from "../helpers/bush-helper";
 import type { MapConfig } from "../maps-db.types";
+import { FILL_TYPES } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.const";
 
 const mapConfig = (() => {
   const size: SceneSize = { width: 1500, height: 1500 };
@@ -50,15 +51,23 @@ const mapConfig = (() => {
     visualEffects: {
       snowfall: {
         emitter: {
-          particlesPerSecond: 180,
-          particleLifetimeMs: 5200,
+          particlesPerSecond: 80,
+          particleLifetimeMs: 15200,
           fadeStartMs: 4200,
           fadeInMs: 200,
-          sizeRange: { min: 0.8, max: 2.4 },
+          sizeRange: { min: 2.8, max: 15.4 },
           color: { r: 0.95, g: 0.98, b: 1, a: 0.9 },
+          fill: {
+            fillType: FILL_TYPES.RADIAL_GRADIENT,
+            start: { x: 0, y: 0 },
+            stops: [
+              { offset: 0, color: { r: 0.95, g: 0.98, b: 1, a: 0.9 } },
+              { offset: 1, color: { r: 0.95, g: 0.98, b: 1, a: 0.1 } },
+            ],
+          },
           shape: "circle",
-          baseSpeed: 0.03,
-          speedVariation: 0.02,
+          baseSpeed: 0.1,
+          speedVariation: 0.025,
           direction: Math.PI / 2,
           spread: Math.PI / 10,
           maxParticles: 700,

--- a/src/db/maps/map-definitions/frozenForest.ts
+++ b/src/db/maps/map-definitions/frozenForest.ts
@@ -47,6 +47,30 @@ const mapConfig = (() => {
     nodePosition: { x: 3, y: -1 },
     icon: "frozen_forest.png",
     lockedForDemo: true,
+    visualEffects: {
+      snowfall: {
+        emitter: {
+          particlesPerSecond: 180,
+          particleLifetimeMs: 5200,
+          fadeStartMs: 4200,
+          fadeInMs: 200,
+          sizeRange: { min: 0.8, max: 2.4 },
+          color: { r: 0.95, g: 0.98, b: 1, a: 0.9 },
+          shape: "circle",
+          baseSpeed: 0.03,
+          speedVariation: 0.02,
+          direction: Math.PI / 2,
+          spread: Math.PI / 10,
+          maxParticles: 700,
+        },
+        spawnArea: {
+          height: 160,
+          horizontalPadding: 220,
+          topOffset: 0,
+        },
+        cullPadding: 220,
+      },
+    },
     bricks: ({ mapLevel }) => {
       const baseLevel = Math.max(0, Math.floor(mapLevel));
       const iceLevel = baseLevel;

--- a/src/db/maps/maps-db.types.ts
+++ b/src/db/maps/maps-db.types.ts
@@ -7,6 +7,7 @@ import type { SkillId } from "../skills-db";
 import type { AchievementId } from "../achievements-db";
 import type { MapEffectId } from "../map-effects-db";
 import type { BrickShapeBlueprint } from "../../logic/services/brick-layout/BrickLayoutService";
+import type { ParticleEmitterConfig } from "../../logic/interfaces/visuals/particle-emitters-config";
 
 export type MapId =
   | "tutorialZone"
@@ -81,6 +82,7 @@ export interface MapConfig {
   readonly enemySpawnPoints?: readonly MapEnemySpawnPointConfig[];
   readonly enemies?: MapEnemyGenerator;
   readonly mapEffects?: readonly MapEffectId[];
+  readonly visualEffects?: MapVisualEffectsConfig;
   readonly unlockedBy?: readonly UnlockCondition<MapId, SkillId>[];
   readonly icon?: string;
   readonly nodePosition: MapNodePosition;
@@ -101,4 +103,20 @@ export interface MapListEntry {
 export interface MapPlayerUnitConfig {
   readonly type: PlayerUnitType;
   readonly position: SceneVector2;
+}
+
+export interface MapSnowfallSpawnArea {
+  readonly height: number;
+  readonly horizontalPadding: number;
+  readonly topOffset?: number;
+}
+
+export interface MapSnowfallEffectConfig {
+  readonly emitter: ParticleEmitterConfig;
+  readonly spawnArea?: MapSnowfallSpawnArea;
+  readonly cullPadding?: number;
+}
+
+export interface MapVisualEffectsConfig {
+  readonly snowfall?: MapSnowfallEffectConfig;
 }

--- a/src/logic/modules/active-map/map/map.module.ts
+++ b/src/logic/modules/active-map/map/map.module.ts
@@ -546,6 +546,7 @@ export class MapModule implements GameModule {
       generateUnits,
       generateEnemies,
       mapEffects: config.mapEffects ?? [],
+      visualEffects: config.visualEffects,
     });
 
     this.pushSelectedMap();

--- a/src/logic/modules/active-map/map/map.run-lifecycle.ts
+++ b/src/logic/modules/active-map/map/map.run-lifecycle.ts
@@ -9,6 +9,7 @@ import type { PlayerUnitSpawnData } from "../player-units/player-units.types";
 import { EnemiesModule } from "../enemies/enemies.module";
 import { EnemySpawnController } from "../enemies/enemies.spawn-controller";
 import type { MapEnemySpawnPointConfig } from "../../../../db/maps/maps-db";
+import type { MapVisualEffectsConfig } from "../../../../db/maps/maps-db.types";
 import type { EnemySpawnData } from "../enemies/enemies.types";
 import { NecromancerModule } from "../necromancer/necromancer.module";
 import { ResourceRunController } from "./map.types";
@@ -43,6 +44,7 @@ interface StartRunPayload {
   generateUnits: boolean;
   generateEnemies: boolean;
   mapEffects: readonly MapEffectId[];
+  visualEffects?: MapVisualEffectsConfig;
 }
 
 export class MapRunLifecycle {
@@ -90,6 +92,7 @@ export class MapRunLifecycle {
     this.options.unitsAutomation.onMapStart();
     this.options.scene.setMapSize(payload.sceneSize);
     this.options.visuals.reset();
+    this.options.visuals.setVisualEffects(payload.visualEffects ?? null);
     this.options.visuals.clearPendingFocus();
     this.options.playerUnits.prepareForMap();
     this.options.bricks.setBricks(payload.generateBricks ? payload.bricks : []);

--- a/src/logic/modules/active-map/map/map.visual-effects.ts
+++ b/src/logic/modules/active-map/map/map.visual-effects.ts
@@ -296,6 +296,7 @@ export class MapVisualEffects {
         color: { r: 1, g: 1, b: 1, a: 1 },
         customData: {
           id: SNOWFALL_OBJECT_ID,
+          autoAnimate: true,
           emitter: this.snowfallConfig.emitter,
           spawnRect,
           cullRect,
@@ -308,6 +309,7 @@ export class MapVisualEffects {
       position: { x: 0, y: 0 },
       customData: {
         id: SNOWFALL_OBJECT_ID,
+        autoAnimate: true,
         emitter: this.snowfallConfig.emitter,
         spawnRect,
         cullRect,

--- a/src/logic/modules/active-map/map/map.visual-effects.ts
+++ b/src/logic/modules/active-map/map/map.visual-effects.ts
@@ -4,15 +4,20 @@ import { createRadialGradientFill } from "@shared/helpers/scene-fill.helper";
 import { clampNumber } from "@shared/helpers/numbers.helper";
 import { getMapEffectConfig } from "../../../../db/map-effects-db";
 import type { MapEffectsModule } from "../map-effects/map-effects.module";
+import type { MapSnowfallEffectConfig, MapVisualEffectsConfig } from "../../../../db/maps/maps-db.types";
 
 const CAMERA_FOCUS_TICKS = 6;
 const RADIOACTIVITY_OVERLAY_ID = "map-radioactivity-overlay";
+const SNOWFALL_OBJECT_ID = "map-snowfall";
+const DEFAULT_SNOW_CULL_PADDING = 200;
 
 export class MapVisualEffects {
   private portalObjects: { id: string; position: SceneVector2 }[] = [];
   private pendingCameraFocus: { point: SceneVector2; ticksRemaining: number } | null = null;
   private radioactivityOverlayId: string | null = null;
   private radioactivityElapsedMs = 0;
+  private snowfallObjectId: string | null = null;
+  private snowfallConfig: MapSnowfallEffectConfig | null = null;
 
   constructor(
     private readonly scene: SceneObjectManager,
@@ -23,6 +28,8 @@ export class MapVisualEffects {
     this.clearPortalObjects();
     this.pendingCameraFocus = null;
     this.clearRadioactivityOverlay();
+    this.clearSnowfall();
+    this.snowfallConfig = null;
   }
 
   public setCameraFocus(point: SceneVector2): void {
@@ -82,6 +89,14 @@ export class MapVisualEffects {
     this.applyPendingCameraFocus();
     this.updatePortalObjects();
     this.updateRadioactivityOverlay(deltaMs);
+    this.updateSnowfall();
+  }
+
+  public setVisualEffects(config: MapVisualEffectsConfig | null): void {
+    this.snowfallConfig = config?.snowfall ?? null;
+    if (!this.snowfallConfig) {
+      this.clearSnowfall();
+    }
   }
 
   public clearPortalObjects(): void {
@@ -234,5 +249,77 @@ export class MapVisualEffects {
     }
     this.scene.removeObject(this.radioactivityOverlayId);
     this.radioactivityOverlayId = null;
+  }
+
+  private updateSnowfall(): void {
+    if (!this.snowfallConfig) {
+      this.clearSnowfall();
+      return;
+    }
+    const camera = this.scene.getCamera();
+    const viewport = this.resolveViewportSize(camera.viewportSize);
+    const spawnArea = this.snowfallConfig.spawnArea;
+    const spawnHeight = Math.max(0, spawnArea?.height ?? 160);
+    const horizontalPadding = Math.max(0, spawnArea?.horizontalPadding ?? 200);
+    const topOffset = Math.max(0, spawnArea?.topOffset ?? 0);
+    const cullPadding = Math.max(
+      DEFAULT_SNOW_CULL_PADDING,
+      this.snowfallConfig.cullPadding ?? DEFAULT_SNOW_CULL_PADDING,
+      spawnHeight + topOffset
+    );
+
+    const spawnTop = camera.position.y - topOffset;
+    const spawnRect = {
+      min: {
+        x: camera.position.x - horizontalPadding,
+        y: spawnTop - spawnHeight,
+      },
+      max: {
+        x: camera.position.x + viewport.width + horizontalPadding,
+        y: spawnTop,
+      },
+    };
+    const cullRect = {
+      min: {
+        x: camera.position.x - cullPadding,
+        y: camera.position.y - cullPadding,
+      },
+      max: {
+        x: camera.position.x + viewport.width + cullPadding,
+        y: camera.position.y + viewport.height + cullPadding,
+      },
+    };
+
+    if (!this.snowfallObjectId) {
+      this.snowfallObjectId = this.scene.addObject("snowfall", {
+        position: { x: 0, y: 0 },
+        color: { r: 1, g: 1, b: 1, a: 1 },
+        customData: {
+          id: SNOWFALL_OBJECT_ID,
+          emitter: this.snowfallConfig.emitter,
+          spawnRect,
+          cullRect,
+        },
+      });
+      return;
+    }
+
+    this.scene.updateObject(this.snowfallObjectId, {
+      position: { x: 0, y: 0 },
+      customData: {
+        id: SNOWFALL_OBJECT_ID,
+        emitter: this.snowfallConfig.emitter,
+        spawnRect,
+        cullRect,
+      },
+    });
+  }
+
+  private clearSnowfall(): void {
+    if (!this.snowfallObjectId) {
+      return;
+    }
+    this.scene.removeObject(this.snowfallObjectId);
+    this.snowfallObjectId = null;
   }
 }

--- a/src/ui/renderers/objects/implementations/snowfall/SnowfallObjectRenderer.ts
+++ b/src/ui/renderers/objects/implementations/snowfall/SnowfallObjectRenderer.ts
@@ -1,0 +1,37 @@
+import type { SceneObjectInstance } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import {
+  DynamicPrimitive,
+  ObjectRegistration,
+  ObjectRenderer,
+} from "../../ObjectRenderer";
+import { createParticleEmitterPrimitive } from "../../../primitives/ParticleEmitterPrimitive";
+import {
+  getEmitterConfig,
+  getEmitterOrigin,
+  spawnSnowfallParticle,
+  updateSnowfallParticle,
+  getGpuSpawnConfig,
+} from "./helpers";
+import type { SnowfallEmitterConfig } from "./types";
+
+export class SnowfallObjectRenderer extends ObjectRenderer {
+  public register(instance: SceneObjectInstance): ObjectRegistration {
+    const dynamicPrimitives: DynamicPrimitive[] = [];
+
+    const emitterPrimitive = createParticleEmitterPrimitive<SnowfallEmitterConfig>(instance, {
+      getConfig: getEmitterConfig,
+      getOrigin: getEmitterOrigin,
+      spawnParticle: spawnSnowfallParticle,
+      updateParticle: updateSnowfallParticle,
+      getGpuSpawnConfig,
+    });
+    if (emitterPrimitive) {
+      dynamicPrimitives.push(emitterPrimitive);
+    }
+
+    return {
+      staticPrimitives: [],
+      dynamicPrimitives,
+    };
+  }
+}

--- a/src/ui/renderers/objects/implementations/snowfall/helpers.ts
+++ b/src/ui/renderers/objects/implementations/snowfall/helpers.ts
@@ -1,0 +1,137 @@
+import type { SceneObjectInstance, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import { sanitizeParticleEmitterConfig } from "../../../primitives/ParticleEmitterPrimitive";
+import type {
+  GpuSpawnConfig,
+  ParticleEmitterParticleState,
+} from "../../../primitives/ParticleEmitterPrimitive";
+import { createCachedEmitterConfigGetter } from "@shared/helpers/emitter-cache.helper";
+import type { SnowfallCustomData, SnowfallEmitterConfig } from "./types";
+
+const sanitizeSnowfallEmitterConfig = (
+  source: SnowfallCustomData["emitter"]
+): SnowfallEmitterConfig | null => {
+  if (!source) {
+    return null;
+  }
+  const base = sanitizeParticleEmitterConfig(source, {
+    defaultColor: { r: 0.9, g: 0.95, b: 1, a: 0.8 },
+    defaultOffset: { x: 0, y: 0 },
+    minCapacity: 64,
+    defaultShape: "circle",
+  });
+  if (!base) {
+    return null;
+  }
+  return {
+    ...base,
+    baseSpeed: Math.max(0, source.baseSpeed ?? 0.02),
+    speedVariation: Math.max(0, source.speedVariation ?? 0.01),
+    spread: Math.max(0, source.spread ?? 0.2),
+    direction: Number.isFinite(source.direction) ? Number(source.direction) : Math.PI / 2,
+    alignToVelocity: source.alignToVelocity === true,
+    alignToVelocityFlip: source.alignToVelocityFlip === true,
+    sizeGrowthRate: source.sizeGrowthRate,
+  };
+};
+
+export const getEmitterConfig = createCachedEmitterConfigGetter<
+  SnowfallCustomData["emitter"],
+  SnowfallEmitterConfig
+>(
+  (instance) => {
+    const custom = instance.data.customData as SnowfallCustomData | undefined;
+    return custom?.emitter;
+  },
+  (source) => sanitizeSnowfallEmitterConfig(source)
+);
+
+export const getEmitterOrigin = (): SceneVector2 => ({ x: 0, y: 0 });
+
+export const spawnSnowfallParticle = (
+  origin: SceneVector2,
+  instance: SceneObjectInstance,
+  config: SnowfallEmitterConfig
+): ParticleEmitterParticleState => {
+  const custom = instance.data.customData as SnowfallCustomData | undefined;
+  const spawnRect = custom?.spawnRect;
+  const position = spawnRect
+    ? {
+        x: spawnRect.min.x + Math.random() * (spawnRect.max.x - spawnRect.min.x),
+        y: spawnRect.min.y + Math.random() * (spawnRect.max.y - spawnRect.min.y),
+      }
+    : { x: origin.x, y: origin.y };
+
+  const spread = Math.max(0, config.spread);
+  const angle =
+    spread > 0
+      ? config.direction + (Math.random() * 2 - 1) * (spread * 0.5)
+      : config.direction;
+  const speed = Math.max(
+    0,
+    config.baseSpeed +
+      (config.speedVariation > 0 ? (Math.random() * 2 - 1) * config.speedVariation : 0)
+  );
+  const size =
+    config.sizeRange.min === config.sizeRange.max
+      ? config.sizeRange.min
+      : config.sizeRange.min + Math.random() * (config.sizeRange.max - config.sizeRange.min);
+
+  return {
+    position,
+    velocity: { x: Math.cos(angle) * speed, y: Math.sin(angle) * speed },
+    ageMs: 0,
+    lifetimeMs: config.particleLifetimeMs,
+    size,
+  };
+};
+
+export const updateSnowfallParticle = (
+  particle: ParticleEmitterParticleState,
+  deltaMs: number,
+  instance: SceneObjectInstance,
+  _config: SnowfallEmitterConfig
+): boolean => {
+  particle.ageMs += deltaMs;
+  if (particle.ageMs >= particle.lifetimeMs) {
+    return false;
+  }
+  particle.position.x += particle.velocity.x * deltaMs;
+  particle.position.y += particle.velocity.y * deltaMs;
+
+  const custom = instance.data.customData as SnowfallCustomData | undefined;
+  const cullRect = custom?.cullRect;
+  if (!cullRect) {
+    return true;
+  }
+
+  return !(
+    particle.position.x < cullRect.min.x ||
+    particle.position.y < cullRect.min.y ||
+    particle.position.x > cullRect.max.x ||
+    particle.position.y > cullRect.max.y
+  );
+};
+
+export const getGpuSpawnConfig = (
+  instance: SceneObjectInstance,
+  config: SnowfallEmitterConfig
+): GpuSpawnConfig => {
+  const custom = instance.data.customData as SnowfallCustomData | undefined;
+  return {
+    baseSpeed: config.baseSpeed,
+    speedVariation: config.speedVariation,
+    sizeMin: config.sizeRange.min,
+    sizeMax: config.sizeRange.max,
+    spawnRadiusMin: 0,
+    spawnRadiusMax: 0,
+    arc: 0,
+    direction: config.direction,
+    spread: config.spread,
+    radialVelocity: false,
+    spawnShape: "rect",
+    spawnRectMin: custom?.spawnRect?.min,
+    spawnRectMax: custom?.spawnRect?.max,
+    cullRectMin: custom?.cullRect?.min,
+    cullRectMax: custom?.cullRect?.max,
+  };
+};

--- a/src/ui/renderers/objects/implementations/snowfall/types.ts
+++ b/src/ui/renderers/objects/implementations/snowfall/types.ts
@@ -1,0 +1,21 @@
+import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { ParticleEmitterConfig } from "@logic/interfaces/visuals/particle-emitters-config";
+import type { ParticleEmitterBaseConfig } from "../../../primitives/ParticleEmitterPrimitive";
+
+export interface SnowfallRect {
+  min: SceneVector2;
+  max: SceneVector2;
+}
+
+export interface SnowfallCustomData {
+  emitter?: ParticleEmitterConfig;
+  spawnRect?: SnowfallRect;
+  cullRect?: SnowfallRect;
+}
+
+export type SnowfallEmitterConfig = ParticleEmitterBaseConfig & {
+  baseSpeed: number;
+  speedVariation: number;
+  spread: number;
+  direction: number;
+};

--- a/src/ui/renderers/objects/index.ts
+++ b/src/ui/renderers/objects/index.ts
@@ -15,6 +15,7 @@ import { PersistentAoeSpellRenderer } from "./implementations/persistent-aoe-spe
 import { ScreenOverlayRenderer } from "./implementations/screen-overlay";
 import { TiedObjectsRegistry } from "./TiedObjectsRegistry";
 import { SpellAreaHighlightRenderer } from "./implementations/spell-area-highlight/SpellAreaHighlightRenderer";
+import { SnowfallObjectRenderer } from "./implementations/snowfall/SnowfallObjectRenderer";
 
 export { ObjectsRendererManager } from "./ObjectsRendererManager";
 export { TiedObjectsRegistry } from "./TiedObjectsRegistry";
@@ -61,6 +62,7 @@ export const createObjectsRendererManager = (): ObjectsRendererManager => {
     ["sandStorm", new SandStormRenderer()],
     ["spellPersistentAoe", new PersistentAoeSpellRenderer()],
     ["spellAreaHighlight", new SpellAreaHighlightRenderer()],
+    ["snowfall", new SnowfallObjectRenderer()],
     ["screenOverlay", new ScreenOverlayRenderer()],
   ]);
   const tiedObjectsRegistry = new TiedObjectsRegistry();

--- a/src/ui/renderers/primitives/ParticleEmitterPrimitive.ts
+++ b/src/ui/renderers/primitives/ParticleEmitterPrimitive.ts
@@ -115,6 +115,11 @@ export interface GpuSpawnConfig {
   direction: number;
   spread: number;
   radialVelocity: boolean;
+  spawnShape?: "circle" | "rect";
+  spawnRectMin?: SceneVector2;
+  spawnRectMax?: SceneVector2;
+  cullRectMin?: SceneVector2;
+  cullRectMax?: SceneVector2;
 }
 
 export interface ParticleEmitterPrimitiveOptions<
@@ -248,6 +253,12 @@ interface ParticleSimulationProgram {
     direction: WebGLUniformLocation | null;
     spread: WebGLUniformLocation | null;
     radialVelocity: WebGLUniformLocation | null;
+    spawnShape: WebGLUniformLocation | null;
+    spawnRectMin: WebGLUniformLocation | null;
+    spawnRectMax: WebGLUniformLocation | null;
+    cullEnabled: WebGLUniformLocation | null;
+    cullMin: WebGLUniformLocation | null;
+    cullMax: WebGLUniformLocation | null;
   };
 }
 
@@ -660,34 +671,46 @@ const advanceParticleEmitterStateGpu = <
       dampingWindow > 0 && Number.isFinite(emissionDuration)
         ? spawnRate * clamp01(Math.max(0, emissionDuration - state.ageMs) / dampingWindow)
         : spawnRate;
-    let desiredSpawnCount = Math.min(
+    const desiredSpawnCount = Math.min(
       effectiveSpawnRate * activeDelta,
       state.capacity // Can't spawn more than capacity
     );
 
-    if (desiredSpawnCount > 0) {
-      //if(instance.type === "explosion" && config.emissionDampingInterval){
-        // desiredSpawnCount = 0.1;
-        // console.log(`emissionDampingInterval[${instance.id}]`, state.ageMs, desiredSpawnCount, state.capacity);
-      //}
-      spawnParams = {
-        emitterPosition: origin,
-        emitterRotation: instance.data.rotation ?? 0,
-        spawnStartIndex: state.capacity, // Pass capacity for probability calculation
-        spawnCount: desiredSpawnCount,
-        particleLifetime: config.particleLifetimeMs,
-        baseSpeed: gpuSpawnConfig.baseSpeed,
-        speedVariation: gpuSpawnConfig.speedVariation,
-        sizeMin: gpuSpawnConfig.sizeMin,
-        sizeMax: gpuSpawnConfig.sizeMax,
-        spawnRadiusMin: gpuSpawnConfig.spawnRadiusMin,
-        spawnRadiusMax: gpuSpawnConfig.spawnRadiusMax,
-        arc: gpuSpawnConfig.arc,
-        direction: gpuSpawnConfig.direction,
-        spread: gpuSpawnConfig.spread,
-        radialVelocity: gpuSpawnConfig.radialVelocity,
-      };
-    }
+    const spawnShape = gpuSpawnConfig.spawnShape === "rect" ? 1 : 0;
+    const spawnRectMin = gpuSpawnConfig.spawnRectMin ?? origin;
+    const spawnRectMax = gpuSpawnConfig.spawnRectMax ?? origin;
+    const cullMin = gpuSpawnConfig.cullRectMin ?? origin;
+    const cullMax = gpuSpawnConfig.cullRectMax ?? origin;
+    const cullEnabled =
+      Boolean(gpuSpawnConfig.cullRectMin) && Boolean(gpuSpawnConfig.cullRectMax);
+
+    //if(instance.type === "explosion" && config.emissionDampingInterval){
+    // desiredSpawnCount = 0.1;
+    // console.log(`emissionDampingInterval[${instance.id}]`, state.ageMs, desiredSpawnCount, state.capacity);
+    //}
+    spawnParams = {
+      emitterPosition: origin,
+      emitterRotation: instance.data.rotation ?? 0,
+      spawnStartIndex: state.capacity, // Pass capacity for probability calculation
+      spawnCount: desiredSpawnCount,
+      particleLifetime: config.particleLifetimeMs,
+      baseSpeed: gpuSpawnConfig.baseSpeed,
+      speedVariation: gpuSpawnConfig.speedVariation,
+      sizeMin: gpuSpawnConfig.sizeMin,
+      sizeMax: gpuSpawnConfig.sizeMax,
+      spawnRadiusMin: gpuSpawnConfig.spawnRadiusMin,
+      spawnRadiusMax: gpuSpawnConfig.spawnRadiusMax,
+      arc: gpuSpawnConfig.arc,
+      direction: gpuSpawnConfig.direction,
+      spread: gpuSpawnConfig.spread,
+      radialVelocity: gpuSpawnConfig.radialVelocity,
+      spawnShape,
+      spawnRectMin,
+      spawnRectMax,
+      cullEnabled,
+      cullMin,
+      cullMax,
+    };
 
     // No accumulator in GPU spawn path; probability-based spawn uses fractional counts directly.
     state.spawnAccumulator = 0;
@@ -983,6 +1006,12 @@ uniform float u_arc;
 uniform float u_direction;
 uniform float u_spread;
 uniform float u_radialVelocity;  // 0.0 or 1.0
+uniform float u_spawnShape;      // 0.0 = circle, 1.0 = rect
+uniform vec2 u_spawnRectMin;
+uniform vec2 u_spawnRectMax;
+uniform float u_cullEnabled;     // 0.0 or 1.0
+uniform vec2 u_cullMin;
+uniform vec2 u_cullMax;
 
 out vec2 v_position;
 out vec2 v_velocity;
@@ -1051,12 +1080,17 @@ void main() {
         spawnAngle = u_direction + arcOffset;
       }
       
-      // Random spawn radius
-      float spawnRadius =
-        randRangeLegacy(particleId, 3, u_spawnRadiusRange.x, u_spawnRadiusRange.y);
-      
-      // Calculate spawn position
-      position = u_emitterPosition + vec2(cos(spawnAngle), sin(spawnAngle)) * spawnRadius;
+      if (u_spawnShape > 0.5) {
+        // Rectangle spawn
+        float spawnX = randRangeLegacy(particleId, 3, u_spawnRectMin.x, u_spawnRectMax.x);
+        float spawnY = randRangeLegacy(particleId, 4, u_spawnRectMin.y, u_spawnRectMax.y);
+        position = vec2(spawnX, spawnY);
+      } else {
+        // Radial spawn
+        float spawnRadius =
+          randRangeLegacy(particleId, 3, u_spawnRadiusRange.x, u_spawnRadiusRange.y);
+        position = u_emitterPosition + vec2(cos(spawnAngle), sin(spawnAngle)) * spawnRadius;
+      }
       
       // Calculate velocity direction
       float velocityAngle;
@@ -1068,6 +1102,18 @@ void main() {
       }
       
       velocity = vec2(cos(velocityAngle), sin(velocityAngle)) * speed;
+    }
+  }
+
+  if (u_cullEnabled > 0.5 && isActive > 0.5) {
+    if (
+      position.x < u_cullMin.x ||
+      position.y < u_cullMin.y ||
+      position.x > u_cullMax.x ||
+      position.y > u_cullMax.y
+    ) {
+      isActive = 0.0;
+      age = 0.0;
     }
   }
 
@@ -1120,6 +1166,12 @@ interface GpuSpawnParams {
   direction: number;
   spread: number;
   radialVelocity: boolean;
+  spawnShape: number;
+  spawnRectMin: { x: number; y: number };
+  spawnRectMax: { x: number; y: number };
+  cullEnabled: boolean;
+  cullMin: { x: number; y: number };
+  cullMax: { x: number; y: number };
 }
 
 const stepParticleSimulation = (
@@ -1140,7 +1192,7 @@ const stepParticleSimulation = (
   
   // GPU spawn uniforms
   const u = program.uniforms;
-  if (spawnParams && spawnParams.spawnCount > 0) {
+  if (spawnParams) {
     if (u.emitterPosition) {
       gl.uniform2f(u.emitterPosition, spawnParams.emitterPosition.x, spawnParams.emitterPosition.y);
     }
@@ -1180,10 +1232,31 @@ const stepParticleSimulation = (
     if (u.radialVelocity) {
       gl.uniform1f(u.radialVelocity, spawnParams.radialVelocity ? 1.0 : 0.0);
     }
+    if (u.spawnShape) {
+      gl.uniform1f(u.spawnShape, spawnParams.spawnShape);
+    }
+    if (u.spawnRectMin) {
+      gl.uniform2f(u.spawnRectMin, spawnParams.spawnRectMin.x, spawnParams.spawnRectMin.y);
+    }
+    if (u.spawnRectMax) {
+      gl.uniform2f(u.spawnRectMax, spawnParams.spawnRectMax.x, spawnParams.spawnRectMax.y);
+    }
+    if (u.cullEnabled) {
+      gl.uniform1f(u.cullEnabled, spawnParams.cullEnabled ? 1.0 : 0.0);
+    }
+    if (u.cullMin) {
+      gl.uniform2f(u.cullMin, spawnParams.cullMin.x, spawnParams.cullMin.y);
+    }
+    if (u.cullMax) {
+      gl.uniform2f(u.cullMax, spawnParams.cullMax.x, spawnParams.cullMax.y);
+    }
   } else {
     // No spawn this frame
     if (u.spawnCount) {
       gl.uniform1f(u.spawnCount, 0);
+    }
+    if (u.cullEnabled) {
+      gl.uniform1f(u.cullEnabled, 0);
     }
   }
   
@@ -1296,6 +1369,12 @@ const getSimulationProgram = (
     direction: gl.getUniformLocation(program, "u_direction"),
     spread: gl.getUniformLocation(program, "u_spread"),
     radialVelocity: gl.getUniformLocation(program, "u_radialVelocity"),
+    spawnShape: gl.getUniformLocation(program, "u_spawnShape"),
+    spawnRectMin: gl.getUniformLocation(program, "u_spawnRectMin"),
+    spawnRectMax: gl.getUniformLocation(program, "u_spawnRectMax"),
+    cullEnabled: gl.getUniformLocation(program, "u_cullEnabled"),
+    cullMin: gl.getUniformLocation(program, "u_cullMin"),
+    cullMax: gl.getUniformLocation(program, "u_cullMax"),
   };
 
   const programInfo: ParticleSimulationProgram = {


### PR DESCRIPTION
### Motivation
- Support snow that spawns from a rectangular emitter (including off-screen above the viewport) so flakes appear from the top of the screen rather than only inside a visible rectangle.
- Give maps a configurable visual-effect entry for `snowfall` so designers can tune standard particle-emitter parameters (size, color, rate, lifetime, etc.) from map configs.
- Ensure particles spawned outside the visible area (with padding) are culled and do not indefinitely consume GPU/CPU emitter slots.

### Description
- Extended the GPU spawn API by adding fields to `GpuSpawnConfig` (`spawnShape`, `spawnRectMin`, `spawnRectMax`, `cullRectMin`, `cullRectMax`) and added corresponding shader uniforms and `GpuSpawnParams` handling in `ParticleEmitterPrimitive.ts` to support rectangle-based spawn and culling.
- Implemented rectangle spawn and culling logic inside the GPU simulation shader (`SIMULATION_VERTEX_SHADER`) so newly spawned particles can be created anywhere in a rect and immediately deactivated if they lie outside a supplied `cullRect`.
- Added a dedicated snowfall renderer: `src/ui/renderers/objects/implementations/snowfall/` containing `types.ts`, `helpers.ts`, and `SnowfallObjectRenderer.ts`, with helpers that sanitize emitter configs, provide CPU spawn/update fallbacks that respect a `cullRect`, and return GPU spawn config for the new rectangle spawn path.
- Wired map-level configuration: added `MapVisualEffectsConfig` and `MapSnowfallEffectConfig` to `maps-db.types.ts`, exposed `visualEffects` through the run lifecycle (`map.run-lifecycle.ts` / `map.module.ts`), implemented creation/updating of a `snowfall` scene object in `MapVisualEffects` (computes `spawnRect` and `cullRect` from camera+padding), and registered the renderer in `ui/renderers/objects/index.ts`.
- Added a sample snowfall configuration to the `frozenForest` map to demonstrate emitter defaults, spawn area, and cull padding.
- Ensured CPU particle update (`updateSnowfallParticle`) also checks the `cullRect` so CPU-spawned particles are removed when outside the safe area.

### Testing
- Ran the test suite with `npm test` (which runs `tsc -p tsconfig.tests.json` and the test runner), and all tests completed successfully: `67 tests passed`.
- Type-check and compile issues encountered during integration were fixed so the project builds cleanly under the test command.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d095115dc832096445af3ce2d371d)