### PR TITLE
Enforce GPU-spawn-only emitters

### DIFF
--- a/src/ui/renderers/primitives/ParticleEmitterPrimitive.ts
+++ b/src/ui/renderers/primitives/ParticleEmitterPrimitive.ts
@@ -657,13 +657,29 @@ const advanceParticleEmitterStateGpu = <
 
   const origin = options.getOrigin(instance, config);
   
+  const hasGpuSpawnProvider = typeof options.getGpuSpawnConfig === "function";
   // Check if GPU spawn is available
-  const gpuSpawnConfig = options.getGpuSpawnConfig?.(instance, config);
+  const gpuSpawnConfig = hasGpuSpawnProvider
+    ? options.getGpuSpawnConfig(instance, config)
+    : null;
   const useGpuSpawn = gpuSpawnConfig !== null && gpuSpawnConfig !== undefined;
   
   let spawnParams: GpuSpawnParams | undefined;
   
-  if (useGpuSpawn) {
+  if (hasGpuSpawnProvider && !useGpuSpawn) {
+    if (!state.warnedCpuSpawnFallback) {
+      console.error(
+        "[ParticleEmitter] GPU spawn config missing in GPU mode. " +
+          "CPU fallback is disabled. " +
+          `shape=${config.shape}, particlesPerSecond=${config.particlesPerSecond}`
+      );
+      state.warnedCpuSpawnFallback = true;
+    }
+    state.spawnAccumulator = 0;
+    if (gpu.handle) {
+      gpu.handle.activeCount = 0;
+    }
+  } else if (useGpuSpawn) {
     // GPU SPAWN PATH: No CPU slot tracking needed!
     // GPU shader handles slot availability via isActive flag
     const dampingWindow = Math.max(0, config.emissionDampingInterval ?? 0);
@@ -716,14 +732,6 @@ const advanceParticleEmitterStateGpu = <
     state.spawnAccumulator = 0;
   } else {
     // CPU SPAWN PATH: Legacy - requires slot tracking
-    if (!state.warnedCpuSpawnFallback && options.getGpuSpawnConfig) {
-      console.warn(
-        "[ParticleEmitter] Falling back to CPU spawn in GPU mode: " +
-          `getGpuSpawnConfig returned null/undefined. ` +
-          `shape=${config.shape}, particlesPerSecond=${config.particlesPerSecond}`
-      );
-      state.warnedCpuSpawnFallback = true;
-    }
     const currentTimeMs = state.ageMs;
     const slots = gpu.slots;
     const freeSlots: number[] = [];

--- a/src/ui/renderers/primitives/ParticleEmitterPrimitive.ts
+++ b/src/ui/renderers/primitives/ParticleEmitterPrimitive.ts
@@ -657,11 +657,12 @@ const advanceParticleEmitterStateGpu = <
 
   const origin = options.getOrigin(instance, config);
   
+  let gpuSpawnConfig: GpuSpawnConfig | null = null;
   const hasGpuSpawnProvider = typeof options.getGpuSpawnConfig === "function";
   // Check if GPU spawn is available
-  const gpuSpawnConfig = hasGpuSpawnProvider
-    ? options.getGpuSpawnConfig(instance, config)
-    : null;
+  if (hasGpuSpawnProvider) {
+    gpuSpawnConfig = options.getGpuSpawnConfig!(instance, config);
+  }
   const useGpuSpawn = gpuSpawnConfig !== null && gpuSpawnConfig !== undefined;
   
   let spawnParams: GpuSpawnParams | undefined;
@@ -679,7 +680,7 @@ const advanceParticleEmitterStateGpu = <
     if (gpu.handle) {
       gpu.handle.activeCount = 0;
     }
-  } else if (useGpuSpawn) {
+  } else if (useGpuSpawn && gpuSpawnConfig) {
     // GPU SPAWN PATH: No CPU slot tracking needed!
     // GPU shader handles slot availability via isActive flag
     const dampingWindow = Math.max(0, config.emissionDampingInterval ?? 0);


### PR DESCRIPTION
### Motivation
- Ensure emitters that declare a GPU spawn provider use GPU spawning exclusively and never silently fall back to CPU spawning.
- Surface a clear error when a GPU-enabled emitter lacks a GPU spawn configuration to avoid hidden behavior and stale metrics.
- Prevent stale active counts when GPU spawn is expected but missing.

### Description
- Add a `hasGpuSpawnProvider` check and only call `getGpuSpawnConfig` when the provider function exists, using `null` otherwise.
- If a GPU spawn provider exists but returns `null`/`undefined`, log an error via `console.error`, zero `state.spawnAccumulator`, and clear `gpu.handle.activeCount` to avoid CPU fallback and stale stats.
- Preserve the GPU spawn path behavior when `getGpuSpawnConfig` returns a config, and remove the previous CPU-fallback warning path.

### Testing
- No automated tests were run for this change.
- The file `src/ui/renderers/primitives/ParticleEmitterPrimitive.ts` was updated and committed locally without executing test suites.
- Manual runtime validation is recommended to confirm render behavior for GPU-enabled emitters and to verify the new error path is hit when expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d153b88f0832089396f12e00e090c)