### PR TITLE
Add Coal Convoy map (wagon with coal pile and tractor)

### DIFF
--- a/src/db/maps/map-definitions/coalConvoy.ts
+++ b/src/db/maps/map-definitions/coalConvoy.ts
@@ -1,0 +1,225 @@
+import type { SceneSize, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import {
+  bezierPolygonWithBricks,
+  circleWithBricks,
+  polygonWithBricks,
+} from "../../../logic/services/brick-layout/BrickLayoutService";
+import type { MapConfig } from "../maps-db.types";
+
+const mapConfig = (() => {
+  const size: SceneSize = { width: 1500, height: 900 };
+  const center: SceneVector2 = { x: size.width / 2, y: size.height / 2 };
+  const spawnPoint: SceneVector2 = { x: 100, y: 100 };
+
+  const createRectangle = (
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ): SceneVector2[] => [
+    { x, y },
+    { x: x + width, y },
+    { x: x + width, y: y + height },
+    { x, y: y + height },
+  ];
+
+  return {
+    name: "Coal Convoy",
+    size,
+    spawnPoints: [spawnPoint],
+    nodePosition: { x: 5, y: 6 },
+    icon: "mine.png",
+    lockedForDemo: true,
+    bricks: ({ mapLevel }) => {
+      const baseLevel = Math.max(0, Math.floor(mapLevel));
+      const ironLevel = baseLevel;
+
+      const wagonStartX = 100;
+      const wagonEndX = center.x + 100;
+      const wagonWidth = wagonEndX - wagonStartX;
+      const wagonTopY = center.y - 70;
+      const wagonBottomY = center.y + 70;
+      const wagonHeight = wagonBottomY - wagonTopY;
+      const frameThickness = 30;
+
+      const coalBaseY = wagonBottomY - frameThickness;
+      const coalPeakY = wagonTopY - 90;
+      const coalPeakX = wagonStartX + wagonWidth * 0.62;
+
+      const coalOutline = [
+        {
+          start: { x: wagonStartX, y: coalBaseY },
+          control1: { x: wagonStartX + wagonWidth * 0.33, y: coalBaseY },
+          control2: { x: wagonStartX + wagonWidth * 0.66, y: coalBaseY },
+          end: { x: wagonEndX, y: coalBaseY },
+        },
+        {
+          start: { x: wagonEndX, y: coalBaseY },
+          control1: { x: wagonEndX + 40, y: coalBaseY - 80 },
+          control2: { x: coalPeakX + 120, y: coalPeakY + 40 },
+          end: { x: coalPeakX, y: coalPeakY },
+        },
+        {
+          start: { x: coalPeakX, y: coalPeakY },
+          control1: { x: coalPeakX - 180, y: coalPeakY + 30 },
+          control2: { x: wagonStartX - 40, y: coalBaseY - 70 },
+          end: { x: wagonStartX, y: coalBaseY },
+        },
+      ] as const;
+
+      const coalPile = bezierPolygonWithBricks(
+        "smallCoal",
+        {
+          outline: coalOutline,
+          spacing: 24,
+          sampleStep: 12,
+          alignToEdge: true,
+        },
+        { level: baseLevel },
+      );
+
+      const wagonFrame = polygonWithBricks(
+        "compactIron",
+        {
+          vertices: createRectangle(
+            wagonStartX,
+            wagonTopY,
+            wagonWidth,
+            wagonHeight,
+          ),
+          holes: [
+            createRectangle(
+              wagonStartX + frameThickness,
+              wagonTopY + frameThickness,
+              wagonWidth - frameThickness * 2,
+              wagonHeight - frameThickness * 2,
+            ),
+          ],
+        },
+        { level: ironLevel },
+      );
+
+      const wagonGridBars = [1, 2, 3].map((index) => {
+        const barWidth = 18;
+        const barX = wagonStartX + (wagonWidth * index) / 4 - barWidth / 2;
+        return polygonWithBricks(
+          "compactIron",
+          {
+            vertices: createRectangle(
+              barX,
+              wagonTopY + frameThickness / 2,
+              barWidth,
+              wagonHeight - frameThickness,
+            ),
+          },
+          { level: ironLevel },
+        );
+      });
+
+      const wagonWheelY = wagonBottomY + 65;
+      const wagonWheelRadius = 45;
+      const wagonWheels = [
+        circleWithBricks(
+          "smallIron",
+          {
+            center: { x: wagonStartX + 180, y: wagonWheelY },
+            outerRadius: wagonWheelRadius,
+          },
+          { level: baseLevel },
+        ),
+        circleWithBricks(
+          "smallIron",
+          {
+            center: { x: wagonEndX - 180, y: wagonWheelY },
+            outerRadius: wagonWheelRadius,
+          },
+          { level: baseLevel },
+        ),
+      ];
+
+      const tractorStartX = center.x + 220;
+      const tractorEndX = center.x + 680;
+      const tractorRearWheelX = tractorStartX + 90;
+      const tractorFrontWheelX = tractorEndX - 90;
+      const tractorWheelY = wagonWheelY;
+
+      const tractorWheels = [
+        circleWithBricks(
+          "smallIron",
+          {
+            center: { x: tractorRearWheelX, y: tractorWheelY },
+            outerRadius: 52,
+          },
+          { level: baseLevel },
+        ),
+        circleWithBricks(
+          "smallIron",
+          {
+            center: { x: tractorFrontWheelX, y: tractorWheelY },
+            outerRadius: 40,
+          },
+          { level: baseLevel },
+        ),
+      ];
+
+      const cabWidth = 170;
+      const cabHeight = 120;
+      const cabBottomY = wagonBottomY - 5;
+      const cabTopY = cabBottomY - cabHeight;
+      const cabX = tractorRearWheelX - cabWidth / 2;
+
+      const tractorCab = polygonWithBricks(
+        "compactIron",
+        {
+          vertices: createRectangle(cabX, cabTopY, cabWidth, cabHeight),
+        },
+        { level: ironLevel },
+      );
+
+      const hoodBackX = cabX + cabWidth;
+      const hoodFrontX = tractorEndX - 20;
+      const hoodBottomY = cabBottomY + 8;
+      const hoodTopY = cabBottomY - 45;
+
+      const tractorHood = polygonWithBricks(
+        "compactIron",
+        {
+          vertices: [
+            { x: hoodBackX, y: hoodBottomY },
+            { x: hoodFrontX, y: hoodBottomY },
+            { x: hoodFrontX - 30, y: hoodTopY },
+            { x: hoodBackX, y: hoodTopY },
+          ],
+        },
+        { level: ironLevel },
+      );
+
+      return [
+        coalPile,
+        wagonFrame,
+        ...wagonGridBars,
+        ...wagonWheels,
+        tractorCab,
+        tractorHood,
+        ...tractorWheels,
+      ];
+    },
+    playerUnits: [
+      {
+        type: "bluePentagon",
+        position: { ...spawnPoint },
+      },
+    ],
+    unlockedBy: [
+      {
+        type: "map",
+        id: "mine",
+        level: 1,
+      },
+    ],
+    mapsRequired: { mine: 1 },
+    maxLevel: 1,
+  } satisfies MapConfig;
+})();
+
+export default mapConfig;

--- a/src/db/maps/map-definitions/coalConvoy.ts
+++ b/src/db/maps/map-definitions/coalConvoy.ts
@@ -32,10 +32,10 @@ const mapConfig = (() => {
     lockedForDemo: true,
     bricks: ({ mapLevel }) => {
       const baseLevel = Math.max(0, Math.floor(mapLevel));
-      const ironLevel = baseLevel;
+      const ironLevel = baseLevel + 1;
 
       const wagonStartX = 100;
-      const wagonEndX = center.x + 100;
+      const wagonEndX = center.x + 150;
       const wagonWidth = wagonEndX - wagonStartX;
       const wagonTopY = center.y - 70;
       const wagonBottomY = center.y + 70;
@@ -43,7 +43,7 @@ const mapConfig = (() => {
       const frameThickness = 30;
 
       const coalBaseY = wagonBottomY - frameThickness;
-      const coalPeakY = wagonTopY - 90;
+      const coalPeakY = wagonTopY - 190;
       const coalPeakX = wagonStartX + wagonWidth * 0.62;
 
       const coalOutline = [
@@ -75,7 +75,7 @@ const mapConfig = (() => {
           sampleStep: 12,
           alignToEdge: true,
         },
-        { level: baseLevel },
+        { level: baseLevel + 1 },
       );
 
       const wagonFrame = polygonWithBricks(
@@ -163,7 +163,7 @@ const mapConfig = (() => {
       ];
 
       const cabWidth = 170;
-      const cabHeight = 120;
+      const cabHeight = 220;
       const cabBottomY = wagonBottomY - 5;
       const cabTopY = cabBottomY - cabHeight;
       const cabX = tractorRearWheelX - cabWidth / 2;
@@ -172,6 +172,14 @@ const mapConfig = (() => {
         "compactIron",
         {
           vertices: createRectangle(cabX, cabTopY, cabWidth, cabHeight),
+          holes: [
+            createRectangle(
+              cabX + 30,
+              cabTopY + 30,
+              cabWidth - 40,
+              cabHeight - 120,
+            ),
+          ],
         },
         { level: ironLevel },
       );
@@ -179,7 +187,7 @@ const mapConfig = (() => {
       const hoodBackX = cabX + cabWidth;
       const hoodFrontX = tractorEndX - 20;
       const hoodBottomY = cabBottomY + 8;
-      const hoodTopY = cabBottomY - 45;
+      const hoodTopY = cabBottomY - 75;
 
       const tractorHood = polygonWithBricks(
         "compactIron",

--- a/src/db/maps/map-definitions/coalConvoy.ts
+++ b/src/db/maps/map-definitions/coalConvoy.ts
@@ -79,7 +79,7 @@ const mapConfig = (() => {
       );
 
       const wagonFrame = polygonWithBricks(
-        "compactIron",
+        "smallIron",
         {
           vertices: createRectangle(
             wagonStartX,
@@ -103,7 +103,7 @@ const mapConfig = (() => {
         const barWidth = 18;
         const barX = wagonStartX + (wagonWidth * index) / 4 - barWidth / 2;
         return polygonWithBricks(
-          "compactIron",
+          "smallIron",
           {
             vertices: createRectangle(
               barX,
@@ -116,11 +116,11 @@ const mapConfig = (() => {
         );
       });
 
-      const wagonWheelY = wagonBottomY + 65;
+      const wagonWheelY = wagonBottomY + 25;
       const wagonWheelRadius = 45;
       const wagonWheels = [
         circleWithBricks(
-          "smallIron",
+          "compactIron",
           {
             center: { x: wagonStartX + 180, y: wagonWheelY },
             outerRadius: wagonWheelRadius,
@@ -128,7 +128,7 @@ const mapConfig = (() => {
           { level: baseLevel },
         ),
         circleWithBricks(
-          "smallIron",
+          "compactIron",
           {
             center: { x: wagonEndX - 180, y: wagonWheelY },
             outerRadius: wagonWheelRadius,
@@ -145,7 +145,7 @@ const mapConfig = (() => {
 
       const tractorWheels = [
         circleWithBricks(
-          "smallIron",
+          "compactIron",
           {
             center: { x: tractorRearWheelX, y: tractorWheelY },
             outerRadius: 52,
@@ -153,7 +153,7 @@ const mapConfig = (() => {
           { level: baseLevel },
         ),
         circleWithBricks(
-          "smallIron",
+          "compactIron",
           {
             center: { x: tractorFrontWheelX, y: tractorWheelY },
             outerRadius: 40,
@@ -169,28 +169,28 @@ const mapConfig = (() => {
       const cabX = tractorRearWheelX - cabWidth / 2;
 
       const tractorCab = polygonWithBricks(
-        "compactIron",
+        "smallIron",
         {
           vertices: createRectangle(cabX, cabTopY, cabWidth, cabHeight),
           holes: [
             createRectangle(
               cabX + 30,
               cabTopY + 30,
-              cabWidth - 40,
+              cabWidth - 60,
               cabHeight - 120,
             ),
           ],
         },
-        { level: ironLevel },
+        { level: ironLevel+1 },
       );
 
       const hoodBackX = cabX + cabWidth;
       const hoodFrontX = tractorEndX - 20;
-      const hoodBottomY = cabBottomY + 8;
-      const hoodTopY = cabBottomY - 75;
+      const hoodBottomY = cabBottomY + 18;
+      const hoodTopY = cabBottomY - 95;
 
       const tractorHood = polygonWithBricks(
-        "compactIron",
+        "smallIron",
         {
           vertices: [
             { x: hoodBackX, y: hoodBottomY },
@@ -199,7 +199,7 @@ const mapConfig = (() => {
             { x: hoodBackX, y: hoodTopY },
           ],
         },
-        { level: ironLevel },
+        { level: ironLevel+1 },
       );
 
       return [

--- a/src/db/maps/maps-db.ts
+++ b/src/db/maps/maps-db.ts
@@ -3,6 +3,7 @@ import adit from "./map-definitions/adit";
 import ancientPyramids from "./map-definitions/ancientPyramids";
 import bezierGrove from "./map-definitions/bezierGrove";
 import coil from "./map-definitions/coil";
+import coalConvoy from "./map-definitions/coalConvoy";
 import deadOak from "./map-definitions/deadOak";
 import deadlyTunnels from "./map-definitions/deadlyTunnels";
 import deathfulGuns from "./map-definitions/deathfulGuns";
@@ -64,6 +65,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
   deathfulGuns,
   deadlyTunnels,
   encagedBeast,
+  coalConvoy,
   uranium_fields: uraniumFields,
 };
 

--- a/src/db/maps/maps-db.types.ts
+++ b/src/db/maps/maps-db.types.ts
@@ -34,6 +34,7 @@ export type MapId =
   | "deathfulGuns"
   | "deadlyTunnels"
   | "encagedBeast"
+  | "coalConvoy"
   | "uranium_fields";
 
 export interface MapBrickGeneratorOptions {


### PR DESCRIPTION
### Motivation
- Provide a new map depicting a coal wagon and tractor placed to the right of the existing map node graph, matching the layout and visual style of other map definitions.
- The map should use existing brick primitives and bezier outlines so the wagon is full of coal that noticeably protrudes above the frame.

### Description
- Added new map definition `coalConvoy` at `src/db/maps/map-definitions/coalConvoy.ts` which defines a 1500x900 scene with a bezier coal pile (`bezierPolygonWithBricks` using `smallCoal`), wagon frame and grid bars (`polygonWithBricks` using `compactIron`), wagon wheels and tractor wheels (`circleWithBricks` using `smallIron`), tractor cab and hood (`polygonWithBricks` using `compactIron`), and spawn point and metadata (icon, lockedForDemo, node position).
- The coal pile outline is crafted with bezier segments so the pile fills the wagon base and has a visible peak above the wagon frame.
- Registered the new map in the maps database by importing `coalConvoy` and inserting it into `MAPS_DB` at `src/db/maps/maps-db.ts` and added the new id to the `MapId` union in `src/db/maps/maps-db.types.ts` (positioned next to `uranium_fields` in the node grid by using `nodePosition: { x: 5, y: 6 }`).
- All brick generators used are existing helpers: `bezierPolygonWithBricks`, `polygonWithBricks`, and `circleWithBricks`, and generation levels respect `mapLevel`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d1c0d5f5c8320bb12c47e8f241afb)