### PR TITLE
Add Plasma Beam Turret to Coil map

### DIFF
--- a/src/db/arcs-db.ts
+++ b/src/db/arcs-db.ts
@@ -1,7 +1,13 @@
 import type { SceneColor } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import { getAssetUrl } from "@shared/helpers/assets.helper";
 
-export type ArcType = "heal" | "frenzy" | "freeze" | "laser" | "chainLightning";
+export type ArcType =
+  | "heal"
+  | "frenzy"
+  | "freeze"
+  | "laser"
+  | "plasmaBeam"
+  | "chainLightning";
 
 export interface ArcConfig {
   readonly coreColor: SceneColor;
@@ -28,6 +34,8 @@ const FREEZE_ARC_COLOR: SceneColor = { r: 0.6, g: 0.85, b: 1.0, a: 0.9 };
 const FREEZE_ARC_BLUR: SceneColor = { r: 0.4, g: 0.7, b: 1.0, a: 0.5 };
 const LASER_ARC_COLOR: SceneColor = { r: 1.0, g: 0.65, b: 0.7, a: 0.99 };
 const LASER_ARC_BLUR: SceneColor = { r: 1.0, g: 0.65, b: 0.7, a: 0.25 };
+const PLASMA_BEAM_ARC_COLOR: SceneColor = { r: 0.45, g: 0.7, b: 1.0, a: 0.98 };
+const PLASMA_BEAM_ARC_BLUR: SceneColor = { r: 0.3, g: 0.6, b: 1.0, a: 0.4 };
 const CHAIN_ARC_COLOR: SceneColor = { r: 0.85, g: 0.95, b: 1.0, a: 0.95 };
 const CHAIN_ARC_BLUR: SceneColor = { r: 0.3, g: 0.7, b: 1.0, a: 0.35 };
 
@@ -78,6 +86,19 @@ const ARC_DB: Record<ArcType, ArcConfig> = {
     soundEffectUrl: getAssetUrl("audio/sounds/unit_effects/laser_02.mp3"),
     lifetimeMs: 1000,
     fadeStartMs: 450,
+    bendsPer100Px: 0,
+    noiseAmplitude: 0,
+    oscillationPeriodMs: 0,
+    oscillationAmplitude: 0.0,
+  },
+  plasmaBeam: {
+    coreColor: PLASMA_BEAM_ARC_COLOR,
+    blurColor: PLASMA_BEAM_ARC_BLUR,
+    coreWidth: 3,
+    blurWidth: 12,
+    soundEffectUrl: getAssetUrl("audio/sounds/unit_effects/laser_02.mp3"),
+    lifetimeMs: 950,
+    fadeStartMs: 350,
     bendsPer100Px: 0,
     noiseAmplitude: 0,
     oscillationPeriodMs: 0,

--- a/src/db/enemies-db.ts
+++ b/src/db/enemies-db.ts
@@ -30,7 +30,8 @@ export type EnemyType =
   | "encagedBeastEnemy"
   | "freezeTurretEnemy"
   | "bigGun"
-  | "laserTurretEnemy";
+  | "laserTurretEnemy"
+  | "plasmaBeamTurretEnemy";
 
 export interface EnemyAuraConfig {
   petalCount: number;
@@ -1384,6 +1385,74 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
       explosionType: "smallLaser",
       explosionRadius: 21,
       spawnOffset: { x: 1, y: 0 },
+    },
+  },
+  plasmaBeamTurretEnemy: {
+    knockBackDistance: 180,
+    knockBackSpeed: 180,
+    name: "Plasma Beam Turret",
+    renderer: {
+      kind: "composite",
+      fill: { r: 0.1, g: 0.15, b: 0.35, a: 1 },
+      layers: [
+        {
+          shape: "polygon",
+          vertices: [
+            { x: 16, y: -3 },
+            { x: 0, y: -4 },
+            { x: 0, y: 4 },
+            { x: 16, y: 3 },
+          ],
+          fill: { type: "base", brightness: -0.15 },
+        },
+        {
+          shape: "polygon",
+          vertices: [
+            { x: 0, y: -6 },
+            { x: -10, y: -9 },
+            { x: -10, y: 9 },
+            { x: 0, y: 6 },
+          ],
+          fill: { type: "base", brightness: 0.85 },
+        },
+        {
+          shape: "polygon",
+          vertices: [
+            { x: -4, y: -7 },
+            { x: -7, y: -18 },
+            { x: -9, y: -18 },
+            { x: -9, y: -7 },
+          ],
+          fill: { type: "base", brightness: 0.55 },
+        },
+        {
+          shape: "polygon",
+          vertices: [
+            { x: -4, y: 7 },
+            { x: -7, y: 18 },
+            { x: -9, y: 18 },
+            { x: -9, y: 7 },
+          ],
+          fill: { type: "base", brightness: 0.55 },
+        },
+      ],
+    },
+    maxHp: 16500,
+    armor: 165,
+    baseDamage: 480,
+    attackInterval: 2.1,
+    attackRange: 650,
+    moveSpeed: 0,
+    physicalSize: 28,
+    reward: normalizeResourceAmount({
+      iron: 42,
+      coal: 8,
+    }),
+    arcAttack: {
+      arcType: "plasmaBeam",
+      explosionType: "plasmaBeam",
+      explosionRadius: 36,
+      spawnOffset: { x: 2, y: 0 },
     },
   },
 };

--- a/src/db/explosions/explosions.colors.const.ts
+++ b/src/db/explosions/explosions.colors.const.ts
@@ -145,3 +145,9 @@ export const SMALL_ENERGETIC_WAVE_GRADIENT_STOPS: readonly SceneGradientStop[] =
   { offset: 0.75, color: { r: 0.4, g: 0.7, b: 0.6, a: 0.9 } },
   { offset: 1, color: { r: 0.4, g: 0.7, b: 0.6, a: 0 } },
 ] as const;
+
+export const PLASMA_BEAM_WAVE_GRADIENT_STOPS: readonly SceneGradientStop[] = [
+  { offset: 0, color: { r: 0.55, g: 0.8, b: 1, a: 0.7 } },
+  { offset: 0.5, color: { r: 0.35, g: 0.65, b: 1, a: 0.5 } },
+  { offset: 1, color: { r: 0.2, g: 0.4, b: 0.85, a: 0 } },
+] as const;

--- a/src/db/explosions/explosions.emitters.const.ts
+++ b/src/db/explosions/explosions.emitters.const.ts
@@ -38,6 +38,16 @@ export const SMALL_LASER_EMITTER_FILL: SceneFill = {
   ],
 };
 
+export const PLASMA_BEAM_EMITTER_FILL: SceneFill = {
+  fillType: FILL_TYPES.RADIAL_GRADIENT,
+  start: { x: 0, y: 0 },
+  stops: [
+    { offset: 0, color: { r: 0.6, g: 0.9, b: 1.0, a: 1.0 } },
+    { offset: 0.4, color: { r: 0.35, g: 0.7, b: 1.0, a: 0.55 } },
+    { offset: 1, color: { r: 0.15, g: 0.45, b: 0.9, a: 0.2 } },
+  ],
+};
+
 export const SMALL_ENERGETIC_EMITTER_FILL: SceneFill = {
   fillType: FILL_TYPES.RADIAL_GRADIENT,
   start: { x: 0, y: 0 },

--- a/src/db/explosions/explosions.emitters.const.ts
+++ b/src/db/explosions/explosions.emitters.const.ts
@@ -42,9 +42,9 @@ export const PLASMA_BEAM_EMITTER_FILL: SceneFill = {
   fillType: FILL_TYPES.RADIAL_GRADIENT,
   start: { x: 0, y: 0 },
   stops: [
-    { offset: 0, color: { r: 0.6, g: 0.9, b: 1.0, a: 1.0 } },
-    { offset: 0.4, color: { r: 0.35, g: 0.7, b: 1.0, a: 0.55 } },
-    { offset: 1, color: { r: 0.15, g: 0.45, b: 0.9, a: 0.2 } },
+    { offset: 0, color: { r: 0.8, g: 0.9, b: 1.0, a: 1.0 } },
+    { offset: 0.4, color: { r: 0.8, g: 0.9, b: 1.0, a: 0.55 } },
+    { offset: 1, color: { r: 0.8, g: 0.9, b: 1, a: 0.2 } },
   ],
 };
 

--- a/src/db/explosions/explosions.projectiles.ts
+++ b/src/db/explosions/explosions.projectiles.ts
@@ -305,7 +305,7 @@ export const PROJECTILE_EXPLOSIONS: Partial<Record<ExplosionType, ExplosionConfi
       fadeStartMs: 450,
       particleLifetimeMs: 1_100,
       particlesPerSecond: 2400,
-      sizeRange: { min: 0.4, max: 2.6 },
+      sizeRange: { min: 0.9, max: 3.6 },
       emissionDurationMs: 450,
       spawnRadius: { min: 0, max: 0.2 },
       spawnRadiusMultiplier: undefined,

--- a/src/db/explosions/explosions.projectiles.ts
+++ b/src/db/explosions/explosions.projectiles.ts
@@ -7,6 +7,7 @@ import {
   GREY_WAVE_GRADIENT_STOPS,
   HEAL_WAVE_GRADIENT_STOPS,
   MAGNETIC_WAVE_GRADIENT_STOPS,
+  PLASMA_BEAM_WAVE_GRADIENT_STOPS,
   PLASMOID_WAVE_GRADIENT_STOPS,
   SMALL_ENERGETIC_WAVE_GRADIENT_STOPS,
   WEAKEN_CURSE_WAVE_GRADIENT_STOPS,
@@ -16,6 +17,7 @@ import {
   DEFAULT_EMITTER,
   GRAY_BRICK_EMITTER_FILL,
   MAGNETIC_EMITTER_FILL,
+  PLASMA_BEAM_EMITTER_FILL,
   SMALL_CANNON_EMITTER_FILL,
   SMALL_ENERGETIC_EMITTER_FILL,
   SMALL_GREY_CANNON_EMITTER_FILL,
@@ -284,6 +286,32 @@ export const PROJECTILE_EXPLOSIONS: Partial<Record<ExplosionType, ExplosionConfi
       spawnRadiusMultiplier: undefined, // Override DEFAULT_EMITTER to use explicit spawnRadius
       fill: SMALL_LASER_EMITTER_FILL,
       radialVelocity: true, // Частинки рухаються від центру вибуху
+    },
+  },
+  plasmaBeam: {
+    lifetimeMs: 1_600,
+    defaultInitialRadius: 4,
+    waves: createSimpleWave({
+      defaultInitialRadius: 3,
+      radiusExtension: 18,
+      startAlpha: 0.85,
+      endAlpha: 0,
+      gradientStops: PLASMA_BEAM_WAVE_GRADIENT_STOPS,
+    }),
+    emitter: {
+      ...DEFAULT_EMITTER,
+      baseSpeed: 0.08,
+      speedVariation: 0.03,
+      fadeStartMs: 450,
+      particleLifetimeMs: 1_100,
+      particlesPerSecond: 2400,
+      sizeRange: { min: 0.4, max: 2.6 },
+      emissionDurationMs: 450,
+      spawnRadius: { min: 0, max: 0.2 },
+      spawnRadiusMultiplier: undefined,
+      fill: PLASMA_BEAM_EMITTER_FILL,
+      radialVelocity: true,
+      maxParticles: 2600,
     },
   },
   smallEnergetic: {

--- a/src/db/explosions/explosions.types.ts
+++ b/src/db/explosions/explosions.types.ts
@@ -37,6 +37,7 @@ export type ExplosionType =
   | "bigCannon"
   | "smallCannonGrey"
   | "smallLaser"
+  | "plasmaBeam"
   | "smallEnergetic"
   | "chainLightning"
   | "magicArrow";

--- a/src/db/maps/map-definitions/coil.ts
+++ b/src/db/maps/map-definitions/coil.ts
@@ -1,4 +1,5 @@
 import type { SceneSize, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { EnemySpawnData } from "../../../logic/modules/active-map/enemies/enemies.types";
 import {
   bezierCurveWithBricks,
   circleWithBricks,
@@ -87,23 +88,16 @@ const mapConfig = (() => {
       }
       return [base, ...wires];
     },
-    /* enemies: ({ mapLevel }) => {
-      const level = Math.max(1, Math.floor(mapLevel));
-      const offsets: SceneVector2[] = [
-        { x: -100, y: -100 },
-        { x: 100, y: -100 },
-        { x: 100, y: 100 },
-        { x: -100, y: 100 },
+    enemies: ({ mapLevel }) => {
+      const baseLevel = Math.max(0, Math.floor(mapLevel));
+      return [
+        {
+          type: "plasmaBeamTurretEnemy",
+          level: baseLevel,
+          position: { x: center.x, y: center.y },
+        } satisfies EnemySpawnData,
       ];
-      return offsets.map((offset) => ({
-        type: "burstTurretEnemy",
-        level,
-        position: {
-          x: center.x + offset.x,
-          y: center.y + offset.y,
-        },
-      }));
-    },*/
+    },
     playerUnits: [
       {
         type: "bluePentagon",


### PR DESCRIPTION
### Motivation
- Introduce a new enemy turret for the Coil map that fires a wider bluish laser and produces a stronger bluish impact effect.
- Reuse existing arc/explosion systems to provide a distinct visual/audio identity for the new weapon while keeping gameplay consistent with turret mechanics.

### Description
- Added a new `ArcType` `plasmaBeam` and its visual config in `src/db/arcs-db.ts` with wider core/blur widths and blue tint.
- Extended explosion types to include `plasmaBeam` in `src/db/explosions/explosions.types.ts` and added matching gradient stops and emitter fill in `src/db/explosions/explosions.colors.const.ts` and `src/db/explosions/explosions.emitters.const.ts` respectively.
- Implemented the projectile/explosion config for `plasmaBeam` in `src/db/explosions/explosions.projectiles.ts` (waves, emitter, particle counts and sizes) to create the stronger bluish blast and particles.
- Added a new enemy config `plasmaBeamTurretEnemy` in `src/db/enemies-db.ts` with increased stats and an `arcAttack` that uses `plasmaBeam` and a larger explosion radius, and placed a single spawn of this enemy at the center of the Coil map by updating `src/db/maps/map-definitions/coil.ts`.

### Testing
- No automated tests were executed as part of this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d286a521c8320b00d1dafe49d1b3a)