### PR TITLE
Add Steam wishlist links to Save Slot screen and Void Camp top bar

### DIFF
--- a/src/logic/modules/camp/unit-design/unit-design.module.ts
+++ b/src/logic/modules/camp/unit-design/unit-design.module.ts
@@ -194,8 +194,7 @@ export class UnitDesignModule extends BaseGameModule<UnitDesignerListener> {
       return;
     }
     if (typeof updates.name === "string") {
-      const trimmed = updates.name.trim();
-      record.name = trimmed.length > 0 ? trimmed : DEFAULT_UNIT_NAME_FALLBACK;
+      record.name = updates.name.trim();
     }
     if (Array.isArray(updates.modules)) {
       record.modules = clampModuleCount(this.sanitizeModules(updates.modules));

--- a/src/ui/screens/SaveSlotSelect/SaveSlotSelectScreen.css
+++ b/src/ui/screens/SaveSlotSelect/SaveSlotSelectScreen.css
@@ -50,6 +50,11 @@
   color: var(--color-text-subtle);
 }
 
+.save-slot-screen__wishlist {
+  align-self: flex-end;
+  text-decoration: none;
+}
+
 .save-slot-card {
   padding: var(--spacing-xl);
   display: flex;

--- a/src/ui/screens/SaveSlotSelect/SaveSlotSelectScreen.css
+++ b/src/ui/screens/SaveSlotSelect/SaveSlotSelectScreen.css
@@ -51,8 +51,10 @@
 }
 
 .save-slot-screen__wishlist {
-  align-self: flex-end;
+  align-self: flex-start;
   text-decoration: none;
+  padding: 16px 60px;
+  font-size: 1.20em;
 }
 
 .save-slot-card {

--- a/src/ui/screens/SaveSlotSelect/SaveSlotSelectScreen.tsx
+++ b/src/ui/screens/SaveSlotSelect/SaveSlotSelectScreen.tsx
@@ -91,7 +91,7 @@ export const SaveSlotSelectScreen: React.FC<SaveSlotSelectScreenProps> = ({
           })}
         </div>
         <a
-          className="save-slot-screen__wishlist button primary-button"
+          className="save-slot-screen__wishlist button black-button"
           href={STEAM_WISHLIST_URL}
           target="_blank"
           rel="noreferrer"

--- a/src/ui/screens/SaveSlotSelect/SaveSlotSelectScreen.tsx
+++ b/src/ui/screens/SaveSlotSelect/SaveSlotSelectScreen.tsx
@@ -4,6 +4,7 @@ import { SaveSlotBackgroundScene } from "./SaveSlotBackgroundScene";
 import { VersionHistoryModal } from "@ui/shared/VersionHistoryModal";
 import { formatDuration } from "@ui/utils/formatDuration";
 import { GAME_VERSIONS } from "@db/version-db";
+import { STEAM_WISHLIST_URL } from "@ui/shared/steam";
 import "./SaveSlotSelectScreen.css";
 
 interface SaveSlotViewModel {
@@ -89,6 +90,14 @@ export const SaveSlotSelectScreen: React.FC<SaveSlotSelectScreenProps> = ({
             );
           })}
         </div>
+        <a
+          className="save-slot-screen__wishlist button primary-button"
+          href={STEAM_WISHLIST_URL}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Wishlist on Steam
+        </a>
       </div>
       {currentVersion && (
         <button

--- a/src/ui/screens/VoidCamp/VoidCampScreen.tsx
+++ b/src/ui/screens/VoidCamp/VoidCampScreen.tsx
@@ -80,6 +80,7 @@ import {
   DEFAULT_ACHIEVEMENTS_STATE,
 } from "@logic/modules/shared/achievements/achievements.const";
 import type { AchievementsBridgePayload } from "@logic/modules/shared/achievements/achievements.types";
+import { STEAM_WISHLIST_URL } from "@ui/shared/steam";
 
 interface VoidCampScreenProps {
   onStart: () => void;
@@ -352,6 +353,7 @@ export const VoidCampScreen: React.FC<VoidCampScreenProps> = ({
             showAchievements={hasUnlockedAchievements}
             onSettingsClick={handleOpenSettings}
             onExitClick={handleExit}
+            wishlistUrl={STEAM_WISHLIST_URL}
           />
         }
         content={

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.tsx
@@ -6,7 +6,7 @@ import { UnitDesignerBridgeState } from "@logic/modules/camp/unit-design/unit-de
 import { useAppLogic } from "@ui/contexts/AppLogicContext";
 import { formatUnitModuleBonusValue } from "@ui-shared/format/unitModuleBonus";
 import { buildUnitStatEntries } from "@ui-shared/unitStats";
-import { PlayerUnitType } from "@db/player-units-db";
+import { getPlayerUnitConfig, PlayerUnitType } from "@db/player-units-db";
 import { UnitModuleId } from "@db/unit-modules-db";
 import { Button } from "@ui-shared/Button";
 import { ModuleDetailsCard } from "@ui-shared/ModuleDetailsCard";
@@ -182,7 +182,9 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
                     }}
                   >
                     <div className="unit-designer__list-text">
-                      <span className="unit-designer__list-name">{unit.name}</span>
+                      <span className="unit-designer__list-name">
+                        {unit.name || getPlayerUnitConfig(unit.type).name}
+                      </span>
                       <span className="unit-designer__list-modules">{unit.modules.length} modules</span>
                     </div>
                     <button
@@ -192,7 +194,7 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
                         e.stopPropagation();
                         handleDeleteUnit(unit.id);
                       }}
-                      aria-label={`Delete ${unit.name}`}
+                      aria-label={`Delete ${unit.name || getPlayerUnitConfig(unit.type).name}`}
                     >
                       Delete
                     </button>
@@ -213,6 +215,13 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
               className="input"
               value={selectedUnit.name}
               onChange={(event) => handleRenameUnit(selectedUnit.id, event.target.value)}
+              onBlur={(event) => {
+                const value = event.target.value.trim();
+                if (value === "") {
+                  const defaultName = getPlayerUnitConfig(selectedUnit.type).name;
+                  handleRenameUnit(selectedUnit.id, defaultName);
+                }
+              }}
             />
           </div>
           <div className="unit-designer__selected">

--- a/src/ui/screens/VoidCamp/components/VoidCamp/VoidCampTopBar.css
+++ b/src/ui/screens/VoidCamp/components/VoidCamp/VoidCampTopBar.css
@@ -31,6 +31,10 @@
   transition: color 0.18s ease, text-shadow 0.18s ease;
 }
 
+.void-camp-top-bar__link {
+  text-decoration: none;
+}
+
 .void-camp-top-bar__button:hover,
 .void-camp-top-bar__button:focus-visible {
   color: var(--color-accent);

--- a/src/ui/screens/VoidCamp/components/VoidCamp/VoidCampTopBar.tsx
+++ b/src/ui/screens/VoidCamp/components/VoidCamp/VoidCampTopBar.tsx
@@ -9,6 +9,7 @@ interface VoidCampTopBarProps {
   readonly onAchievementsClick?: () => void;
   readonly showAchievements?: boolean;
   readonly onExitClick: () => void;
+  readonly wishlistUrl?: string;
 }
 
 export const VoidCampTopBar: React.FC<VoidCampTopBarProps> = ({
@@ -19,6 +20,7 @@ export const VoidCampTopBar: React.FC<VoidCampTopBarProps> = ({
   onAchievementsClick,
   showAchievements,
   onExitClick,
+  wishlistUrl,
 }) => {
   return (
     <div className="void-camp-top-bar">
@@ -57,6 +59,20 @@ export const VoidCampTopBar: React.FC<VoidCampTopBarProps> = ({
         </button>
       </div>
       <div className="void-camp-top-bar__right">
+        {wishlistUrl && (
+          <a
+            className={classNames(
+              "void-camp-top-bar__button",
+              "void-camp-top-bar__button--wishlist",
+              "void-camp-top-bar__link"
+            )}
+            href={wishlistUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Wishlist on Steam
+          </a>
+        )}
         <span className="void-camp-top-bar__label">Version</span>
         <button
           type="button"

--- a/src/ui/shared/steam.ts
+++ b/src/ui/shared/steam.ts
@@ -1,0 +1,1 @@
+export const STEAM_WISHLIST_URL = "https://store.steampowered.com/app/4344620/Void_Eaters/";

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -293,6 +293,21 @@ input[type="number"]:focus-visible {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), 0 18px 36px rgba(0, 0, 0, 0.52);
 }
 
+.button.black-button {
+  /*background: linear-gradient(-35deg, #3c5055, #252627);*/
+  background: linear-gradient(-35deg, #2d838d, #1b4a4f);
+  color: var(--color-text-primary);
+  border: 1px solid rgba(62, 71, 72, 0.7);
+  border-radius: var(--radius-sm);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 14px 28px rgba(0, 0, 0, 0.45);
+  transition: background 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.button.black-button:not(:disabled):hover {
+  background: linear-gradient(-35deg, #3a5258, #2c2f30);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), 0 18px 36px rgba(0, 0, 0, 0.52);
+}
+
 .button.small-button {
   padding: 0.35rem 0.75rem;
   font-size: 0.85rem;


### PR DESCRIPTION
### Motivation

- Add a visible call-to-action so players can easily wishlist the Steam page from the game UI (under save slots and in the Void Camp top bar). 

### Description

- Introduced a shared constant `STEAM_WISHLIST_URL` in `src/ui/shared/steam.ts` to centralize the Steam link. 
- Added a `Wishlist on Steam` anchor under the save-slot list in `src/ui/screens/SaveSlotSelect/SaveSlotSelectScreen.tsx` and styled it via `SaveSlotSelectScreen.css`. 
- Exposed a `wishlistUrl` prop on `VoidCampTopBar` and render a `Wishlist on Steam` link left of the `Version` label in `src/ui/screens/VoidCamp/components/VoidCamp/VoidCampTopBar.tsx`, with small CSS addition in `VoidCampTopBar.css`. 
- Wired the shared constant into the Void Camp screen by importing `STEAM_WISHLIST_URL` and passing it to the top bar in `src/ui/screens/VoidCamp/VoidCampScreen.tsx`.

### Testing

- Started the dev server with `npm start` and confirmed webpack compiled successfully (dev server served the app). — Success.
- Captured a UI screenshot using a Playwright script that navigated to `http://127.0.0.1:3000` and saved `artifacts/save-slot-wishlist.png` to verify the new wishlist CTA is rendered. — Success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980ed4bb3a483209a84da78a441ed58)