### PR TITLE
Show unit name in Unit Designer summary and inline Summoning Cost

### DIFF
--- a/src/db/bricks-db.ts
+++ b/src/db/bricks-db.ts
@@ -623,9 +623,9 @@ const BRICK_DB: Record<BrickType, BrickConfig> = {
     },
     stroke: { color: { r: 0.08, g: 0.08, b: 0.1, a: 1 }, width: 1.5 },
     destructubleData: {
-      maxHp: 840,
+      maxHp: 940,
       armor: 70,
-      baseDamage: 225,
+      baseDamage: 245,
       knockBackDistance: 90,
       knockBackSpeed: 190,
       brickKnockBackAmplitude: 6,

--- a/src/db/buildings-db.ts
+++ b/src/db/buildings-db.ts
@@ -163,7 +163,7 @@ const BUILDING_DB: Record<BuildingId, BuildingConfig> = {
       "Invent better ways to store and refine your treasures.",
     effects: {
       brick_rewards: {
-        multiplier: (level) => 1 + 0.16 * level,
+        multiplier: (level) => 1 + 0.1 * level,
       },
     },
     cost: createScalingCost({ silver: 500, copper: 1600 }, 1.75),

--- a/src/db/maps/map-definitions/coil.ts
+++ b/src/db/maps/map-definitions/coil.ts
@@ -20,7 +20,7 @@ const mapConfig = (() => {
     icon: "coil.png",
     spawnPoints: [spawnPoint],
     nodePosition: { x: 5, y: 1 },
-    lockedForDemo: true,
+    lockedForDemo: false,
     bricks: ({ mapLevel }) => {
       const baseLevel = Math.max(0, Math.floor(mapLevel));
       const ringLevel = baseLevel + 3;

--- a/src/ui/renderers/primitives/gpu/particle-emitter/ParticleEmitterGpuRenderer.ts
+++ b/src/ui/renderers/primitives/gpu/particle-emitter/ParticleEmitterGpuRenderer.ts
@@ -30,7 +30,11 @@ const compileShader = (
   gl.shaderSource(shader, source);
   gl.compileShader(shader);
   if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-    console.error("Failed to compile particle shader", gl.getShaderInfoLog(shader));
+    console.error("Failed to compile particle shader", {
+      info: gl.getShaderInfoLog(shader),
+      type,
+      source,
+    });
     gl.deleteShader(shader);
     return null;
   }

--- a/src/ui/renderers/utils/webglProgram.ts
+++ b/src/ui/renderers/utils/webglProgram.ts
@@ -13,6 +13,11 @@ export const compileShader = (
 
   if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
     const info = gl.getShaderInfoLog(shader);
+    console.error("Shader compile failed", {
+      info,
+      type,
+      source,
+    });
     gl.deleteShader(shader);
     throw new Error(`Failed to compile shader: ${info ?? "unknown"}`);
   }

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
@@ -6,9 +6,9 @@ import type { PlayerUnitBlueprintStats } from "@shared/types/player-units";
 import type { UnitModuleId } from "@db/unit-modules-db";
 import { cloneRendererConfigForScene } from "@shared/helpers/renderer-clone.helper";
 import { cloneEmitter } from "@logic/modules/active-map/player-units/player-units.helpers";
-import { setupWebGLScene } from "@ui/screens/Scene/hooks/useWebGLSceneSetup";
 import { createWebGLRenderLoop } from "@ui/screens/Scene/hooks/useWebGLRenderLoop";
 import type { SkillId } from "@db/skills-db";
+import { acquirePreviewWebgl, releasePreviewWebgl } from "./previewWebglManager";
 
 interface UnitDesignerPreviewProps {
   unitType: PlayerUnitType;
@@ -27,7 +27,6 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const activeTokenRef = useRef<symbol | null>(null);
 
   const moduleKey = useMemo(() => modules.join("|"), [modules]);
   const skillKey = useMemo(() => skills.join("|"), [skills]);
@@ -36,9 +35,6 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
     if (!isOpen) {
       return;
     }
-
-    const localToken = Symbol("preview");
-    activeTokenRef.current = localToken;
 
     const container = containerRef.current;
     const canvas = canvasRef.current;
@@ -136,18 +132,18 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
 
     resizeCanvas();
 
+    const previewId = "unit-designer-preview";
     let gl: WebGL2RenderingContext | null = null;
-    let cleanup = () => {};
-    let webglRenderer: ReturnType<typeof setupWebGLScene>["webglRenderer"] | null = null;
+    let webglRenderer: ReturnType<typeof acquirePreviewWebgl>["webglRenderer"] | null =
+      null;
 
     try {
-      const setup = setupWebGLScene(canvas, scene, {
+      const setup = acquirePreviewWebgl(previewId, canvas, scene, {
         initBullets: false,
         initRings: false,
       });
       gl = setup.gl;
       webglRenderer = setup.webglRenderer;
-      cleanup = setup.cleanup;
     } catch (error) {
       console.error("[UnitDesignerPreview] Failed to initialize WebGL preview", error);
       return () => {};
@@ -190,11 +186,7 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       renderLoop.stop();
       observer.disconnect();
       document.removeEventListener("visibilitychange", handleVisibility);
-      cleanup();
-      if (activeTokenRef.current === localToken) {
-        // Important: lose WebGL context on unmount to avoid leaking GPU resources.
-        gl.getExtension("WEBGL_lose_context")?.loseContext();
-      }
+      releasePreviewWebgl(previewId);
     };
   }, [isOpen, unitType, unitBlueprint, moduleKey, skillKey]);
 

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
@@ -10,7 +10,7 @@ import { createWebGLRenderLoop } from "@ui/screens/Scene/hooks/useWebGLRenderLoo
 import type { SkillId } from "@db/skills-db";
 import { acquirePreviewWebgl, releasePreviewWebgl } from "./previewWebglManager";
 
-const PREVIEW_VIEWPORT_SCALE = 1.2;
+const PREVIEW_VIEWPORT_SCALE = 1.8;
 
 interface UnitDesignerPreviewProps {
   unitType: PlayerUnitType;
@@ -33,9 +33,14 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
   const unitObjectIdRef = useRef<string | null>(null);
   const unitPositionRef = useRef({ x: 0, y: 0 });
   const lastUnitTypeRef = useRef<PlayerUnitType | null>(null);
+  const lastUnitSignatureRef = useRef<string | null>(null);
 
   const moduleKey = useMemo(() => modules.join("|"), [modules]);
   const skillKey = useMemo(() => skills.join("|"), [skills]);
+  const unitSignature = useMemo(
+    () => `${unitType}|${moduleKey}|${skillKey}|${unitBlueprint.physicalSize}`,
+    [unitType, moduleKey, skillKey, unitBlueprint.physicalSize]
+  );
 
   useEffect(() => {
     if (!isOpen) {
@@ -56,6 +61,7 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       const config = getPlayerUnitConfig(unitType);
       const rendererConfig = cloneRendererConfigForScene(config.renderer, { deep: false });
       const emitter = config.emitter ? cloneEmitter(config.emitter) : undefined;
+      const physicalSize = unitBlueprint.physicalSize || config.physicalSize;
 
       const baseFillColor = {
         r: config.renderer.fill.r,
@@ -90,7 +96,7 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
         customData: {
           renderer: rendererConfig,
           emitter,
-          physicalSize: config.physicalSize,
+          physicalSize,
           baseFillColor: { ...baseFillColor },
           baseStrokeColor: baseStrokeColor ? { ...baseStrokeColor } : undefined,
           modules: [...modules],
@@ -127,6 +133,7 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
         unitObjectIdRef.current = objectId;
         unitPositionRef.current = unitPosition;
         lastUnitTypeRef.current = unitType;
+        lastUnitSignatureRef.current = unitSignature;
       } else {
         const unitPosition = { x: mapWidth / 2, y: mapHeight / 2 };
         unitPositionRef.current = unitPosition;
@@ -200,6 +207,7 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       sceneRef.current = null;
       unitObjectIdRef.current = null;
       lastUnitTypeRef.current = null;
+      lastUnitSignatureRef.current = null;
     };
   }, [isOpen]);
 
@@ -217,6 +225,7 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
     const config = getPlayerUnitConfig(unitType);
     const rendererConfig = cloneRendererConfigForScene(config.renderer, { deep: false });
     const emitter = config.emitter ? cloneEmitter(config.emitter) : undefined;
+    const physicalSize = unitBlueprint.physicalSize || config.physicalSize;
     const baseFillColor = {
       r: config.renderer.fill.r,
       g: config.renderer.fill.g,
@@ -250,7 +259,7 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       customData: {
         renderer: rendererConfig,
         emitter,
-        physicalSize: config.physicalSize,
+        physicalSize,
         baseFillColor: { ...baseFillColor },
         baseStrokeColor: baseStrokeColor ? { ...baseStrokeColor } : undefined,
         modules: [...modules],
@@ -259,18 +268,19 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       },
     };
 
-    if (lastUnitTypeRef.current !== unitType) {
+    if (lastUnitSignatureRef.current !== unitSignature) {
       scene.removeObject(unitObjectId);
       const newId = scene.addObject("playerUnit", {
         ...nextData,
       });
       unitObjectIdRef.current = newId;
       lastUnitTypeRef.current = unitType;
+      lastUnitSignatureRef.current = unitSignature;
       return;
     }
 
     scene.updateObject(unitObjectId, nextData);
-  }, [isOpen, unitType, moduleKey, skillKey, unitBlueprint]);
+  }, [isOpen, unitSignature, unitType, moduleKey, skillKey, unitBlueprint]);
 
   if (!isOpen) {
     return null;

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
@@ -27,6 +27,7 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const activeTokenRef = useRef<symbol | null>(null);
 
   const moduleKey = useMemo(() => modules.join("|"), [modules]);
   const skillKey = useMemo(() => skills.join("|"), [skills]);
@@ -35,6 +36,9 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
     if (!isOpen) {
       return;
     }
+
+    const localToken = Symbol("preview");
+    activeTokenRef.current = localToken;
 
     const container = containerRef.current;
     const canvas = canvasRef.current;
@@ -187,8 +191,10 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       observer.disconnect();
       document.removeEventListener("visibilitychange", handleVisibility);
       cleanup();
-      // Important: lose WebGL context on unmount to avoid leaking GPU resources.
-      gl.getExtension("WEBGL_lose_context")?.loseContext();
+      if (activeTokenRef.current === localToken) {
+        // Important: lose WebGL context on unmount to avoid leaking GPU resources.
+        gl.getExtension("WEBGL_lose_context")?.loseContext();
+      }
     };
   }, [isOpen, unitType, unitBlueprint, moduleKey, skillKey]);
 

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useMemo, useRef } from "react";
+import { SceneObjectManager } from "@core/logic/provided/services/scene-object-manager/SceneObjectManager";
+import { FILL_TYPES } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.const";
+import { getPlayerUnitConfig, PlayerUnitType } from "@db/player-units-db";
+import type { PlayerUnitBlueprintStats } from "@shared/types/player-units";
+import type { UnitModuleId } from "@db/unit-modules-db";
+import { cloneRendererConfigForScene } from "@shared/helpers/renderer-clone.helper";
+import { cloneEmitter } from "@logic/modules/active-map/player-units/player-units.helpers";
+import { setupWebGLScene } from "@ui/screens/Scene/hooks/useWebGLSceneSetup";
+import { createWebGLRenderLoop } from "@ui/screens/Scene/hooks/useWebGLRenderLoop";
+
+interface UnitDesignerPreviewProps {
+  unitType: PlayerUnitType;
+  unitBlueprint: PlayerUnitBlueprintStats;
+  modules: readonly UnitModuleId[];
+  isOpen: boolean;
+}
+
+export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
+  unitType,
+  unitBlueprint,
+  modules,
+  isOpen,
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const moduleKey = useMemo(() => modules.join("|"), [modules]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+
+    if (!container || !canvas) {
+      return;
+    }
+
+    const scene = new SceneObjectManager();
+    const config = getPlayerUnitConfig(unitType);
+    const rendererConfig = cloneRendererConfigForScene(config.renderer, { deep: false });
+    const emitter = config.emitter ? cloneEmitter(config.emitter) : undefined;
+
+    const baseFillColor = {
+      r: config.renderer.fill.r,
+      g: config.renderer.fill.g,
+      b: config.renderer.fill.b,
+      a: typeof config.renderer.fill.a === "number" ? config.renderer.fill.a : 1,
+    };
+    const baseStrokeColor = config.renderer.stroke
+      ? {
+          r: config.renderer.stroke.color.r,
+          g: config.renderer.stroke.color.g,
+          b: config.renderer.stroke.color.b,
+          a:
+            typeof config.renderer.stroke.color.a === "number"
+              ? config.renderer.stroke.color.a
+              : 1,
+        }
+      : { ...baseFillColor };
+
+    const setupSceneObject = (mapWidth: number, mapHeight: number) => {
+      const unitPosition = { x: mapWidth / 2, y: mapHeight / 2 };
+      const objectId = scene.addObject("playerUnit", {
+        position: unitPosition,
+        fill: {
+          fillType: FILL_TYPES.SOLID,
+          color: { ...baseFillColor },
+        },
+        stroke: config.renderer.stroke
+          ? {
+              color: { ...config.renderer.stroke.color },
+              width: config.renderer.stroke.width,
+            }
+          : undefined,
+        rotation: 0,
+        customData: {
+          renderer: rendererConfig,
+          emitter,
+          physicalSize: config.physicalSize,
+          baseFillColor: { ...baseFillColor },
+          baseStrokeColor: baseStrokeColor ? { ...baseStrokeColor } : undefined,
+          modules: [...modules],
+          skills: [],
+        },
+      });
+      return { unitPosition, objectId };
+    };
+
+    let unitObjectId: string | null = null;
+    let unitPosition = { x: 0, y: 0 };
+
+    const resizeCanvas = () => {
+      const bounds = container.getBoundingClientRect();
+      const width = Math.max(1, Math.floor(bounds.width));
+      const height = Math.max(1, Math.floor(bounds.height));
+      const dpr = window.devicePixelRatio || 1;
+
+      canvas.width = Math.max(1, Math.floor(width * dpr));
+      canvas.height = Math.max(1, Math.floor(height * dpr));
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+
+      scene.setViewportScreenSize(width, height);
+      const mapWidth = Math.max(200, width);
+      const mapHeight = Math.max(200, height);
+      scene.setMapSize({ width: mapWidth, height: mapHeight });
+
+      if (!unitObjectId) {
+        const setup = setupSceneObject(mapWidth, mapHeight);
+        unitObjectId = setup.objectId;
+        unitPosition = setup.unitPosition;
+      } else {
+        unitPosition = { x: mapWidth / 2, y: mapHeight / 2 };
+        scene.updateObject(unitObjectId, { position: unitPosition });
+      }
+
+      const camera = scene.getCamera();
+      scene.setCameraPosition(
+        unitPosition.x - camera.viewportSize.width / 2,
+        unitPosition.y - camera.viewportSize.height / 2
+      );
+    };
+
+    resizeCanvas();
+
+    const { gl, webglRenderer, cleanup } = setupWebGLScene(canvas, scene, {
+      initBullets: false,
+      initRings: false,
+    });
+
+    gl.viewport(0, 0, canvas.width, canvas.height);
+
+    const renderLoop = createWebGLRenderLoop({
+      webglRenderer,
+      scene,
+      gl,
+      beforeRender: () => {
+        gl.viewport(0, 0, canvas.width, canvas.height);
+      },
+    });
+
+    const observer = new ResizeObserver(() => {
+      resizeCanvas();
+      gl.viewport(0, 0, canvas.width, canvas.height);
+    });
+
+    observer.observe(container);
+
+    const handleVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        renderLoop.stop();
+      } else {
+        renderLoop.start();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    renderLoop.start();
+
+    return () => {
+      renderLoop.stop();
+      observer.disconnect();
+      document.removeEventListener("visibilitychange", handleVisibility);
+      cleanup();
+      // Important: lose WebGL context on unmount to avoid leaking GPU resources.
+      gl.getExtension("WEBGL_lose_context")?.loseContext();
+    };
+  }, [isOpen, unitType, unitBlueprint, moduleKey]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div ref={containerRef} className="unit-designer__preview">
+      <canvas ref={canvasRef} className="unit-designer__preview-canvas" />
+    </div>
+  );
+};

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
@@ -10,6 +10,8 @@ import { createWebGLRenderLoop } from "@ui/screens/Scene/hooks/useWebGLRenderLoo
 import type { SkillId } from "@db/skills-db";
 import { acquirePreviewWebgl, releasePreviewWebgl } from "./previewWebglManager";
 
+const PREVIEW_VIEWPORT_SCALE = 1.2;
+
 interface UnitDesignerPreviewProps {
   unitType: PlayerUnitType;
   unitBlueprint: PlayerUnitBlueprintStats;
@@ -27,6 +29,10 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const sceneRef = useRef<SceneObjectManager | null>(null);
+  const unitObjectIdRef = useRef<string | null>(null);
+  const unitPositionRef = useRef({ x: 0, y: 0 });
+  const lastUnitTypeRef = useRef<PlayerUnitType | null>(null);
 
   const moduleKey = useMemo(() => modules.join("|"), [modules]);
   const skillKey = useMemo(() => skills.join("|"), [skills]);
@@ -43,33 +49,33 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       return;
     }
 
-    const scene = new SceneObjectManager();
-    const config = getPlayerUnitConfig(unitType);
-    const rendererConfig = cloneRendererConfigForScene(config.renderer, { deep: false });
-    const emitter = config.emitter ? cloneEmitter(config.emitter) : undefined;
+    const scene = sceneRef.current ?? new SceneObjectManager();
+    sceneRef.current = scene;
 
-    const baseFillColor = {
-      r: config.renderer.fill.r,
-      g: config.renderer.fill.g,
-      b: config.renderer.fill.b,
-      a: typeof config.renderer.fill.a === "number" ? config.renderer.fill.a : 1,
-    };
-    const baseStrokeColor = config.renderer.stroke
-      ? {
-          r: config.renderer.stroke.color.r,
-          g: config.renderer.stroke.color.g,
-          b: config.renderer.stroke.color.b,
-          a:
-            typeof config.renderer.stroke.color.a === "number"
-              ? config.renderer.stroke.color.a
-              : 1,
-        }
-      : { ...baseFillColor };
+    const buildUnitObjectData = () => {
+      const config = getPlayerUnitConfig(unitType);
+      const rendererConfig = cloneRendererConfigForScene(config.renderer, { deep: false });
+      const emitter = config.emitter ? cloneEmitter(config.emitter) : undefined;
 
-    const setupSceneObject = (mapWidth: number, mapHeight: number) => {
-      const unitPosition = { x: mapWidth / 2, y: mapHeight / 2 };
-      const objectId = scene.addObject("playerUnit", {
-        position: unitPosition,
+      const baseFillColor = {
+        r: config.renderer.fill.r,
+        g: config.renderer.fill.g,
+        b: config.renderer.fill.b,
+        a: typeof config.renderer.fill.a === "number" ? config.renderer.fill.a : 1,
+      };
+      const baseStrokeColor = config.renderer.stroke
+        ? {
+            r: config.renderer.stroke.color.r,
+            g: config.renderer.stroke.color.g,
+            b: config.renderer.stroke.color.b,
+            a:
+              typeof config.renderer.stroke.color.a === "number"
+                ? config.renderer.stroke.color.a
+                : 1,
+          }
+        : { ...baseFillColor };
+
+      return {
         fill: {
           fillType: FILL_TYPES.SOLID,
           color: { ...baseFillColor },
@@ -91,12 +97,8 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
           skills: [...skills],
           autoAnimate: true,
         },
-      });
-      return { unitPosition, objectId };
+      };
     };
-
-    let unitObjectId: string | null = null;
-    let unitPosition = { x: 0, y: 0 };
 
     const resizeCanvas = () => {
       const bounds = container.getBoundingClientRect();
@@ -109,24 +111,32 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       canvas.style.width = `${width}px`;
       canvas.style.height = `${height}px`;
 
-      scene.setViewportScreenSize(width, height);
-      const mapWidth = Math.max(200, width);
-      const mapHeight = Math.max(200, height);
+      const viewportWidth = Math.max(1, Math.floor(width * PREVIEW_VIEWPORT_SCALE));
+      const viewportHeight = Math.max(1, Math.floor(height * PREVIEW_VIEWPORT_SCALE));
+      scene.setViewportScreenSize(viewportWidth, viewportHeight);
+      const mapWidth = Math.max(200, viewportWidth);
+      const mapHeight = Math.max(200, viewportHeight);
       scene.setMapSize({ width: mapWidth, height: mapHeight });
 
-      if (!unitObjectId) {
-        const setup = setupSceneObject(mapWidth, mapHeight);
-        unitObjectId = setup.objectId;
-        unitPosition = setup.unitPosition;
+      if (!unitObjectIdRef.current) {
+        const unitPosition = { x: mapWidth / 2, y: mapHeight / 2 };
+        const objectId = scene.addObject("playerUnit", {
+          position: unitPosition,
+          ...buildUnitObjectData(),
+        });
+        unitObjectIdRef.current = objectId;
+        unitPositionRef.current = unitPosition;
+        lastUnitTypeRef.current = unitType;
       } else {
-        unitPosition = { x: mapWidth / 2, y: mapHeight / 2 };
-        scene.updateObject(unitObjectId, { position: unitPosition });
+        const unitPosition = { x: mapWidth / 2, y: mapHeight / 2 };
+        unitPositionRef.current = unitPosition;
+        scene.updateObject(unitObjectIdRef.current, { position: unitPosition });
       }
 
       const camera = scene.getCamera();
       scene.setCameraPosition(
-        unitPosition.x - camera.viewportSize.width / 2,
-        unitPosition.y - camera.viewportSize.height / 2
+        unitPositionRef.current.x - camera.viewportSize.width / 2,
+        unitPositionRef.current.y - camera.viewportSize.height / 2
       );
     };
 
@@ -187,8 +197,80 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       observer.disconnect();
       document.removeEventListener("visibilitychange", handleVisibility);
       releasePreviewWebgl(previewId);
+      sceneRef.current = null;
+      unitObjectIdRef.current = null;
+      lastUnitTypeRef.current = null;
     };
-  }, [isOpen, unitType, unitBlueprint, moduleKey, skillKey]);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const scene = sceneRef.current;
+    const unitObjectId = unitObjectIdRef.current;
+    if (!scene || !unitObjectId) {
+      return;
+    }
+
+    const config = getPlayerUnitConfig(unitType);
+    const rendererConfig = cloneRendererConfigForScene(config.renderer, { deep: false });
+    const emitter = config.emitter ? cloneEmitter(config.emitter) : undefined;
+    const baseFillColor = {
+      r: config.renderer.fill.r,
+      g: config.renderer.fill.g,
+      b: config.renderer.fill.b,
+      a: typeof config.renderer.fill.a === "number" ? config.renderer.fill.a : 1,
+    };
+    const baseStrokeColor = config.renderer.stroke
+      ? {
+          r: config.renderer.stroke.color.r,
+          g: config.renderer.stroke.color.g,
+          b: config.renderer.stroke.color.b,
+          a:
+            typeof config.renderer.stroke.color.a === "number"
+              ? config.renderer.stroke.color.a
+              : 1,
+        }
+      : { ...baseFillColor };
+
+    const nextData = {
+      position: unitPositionRef.current,
+      fill: {
+        fillType: FILL_TYPES.SOLID,
+        color: { ...baseFillColor },
+      },
+      stroke: config.renderer.stroke
+        ? {
+            color: { ...config.renderer.stroke.color },
+            width: config.renderer.stroke.width,
+          }
+        : undefined,
+      customData: {
+        renderer: rendererConfig,
+        emitter,
+        physicalSize: config.physicalSize,
+        baseFillColor: { ...baseFillColor },
+        baseStrokeColor: baseStrokeColor ? { ...baseStrokeColor } : undefined,
+        modules: [...modules],
+        skills: [...skills],
+        autoAnimate: true,
+      },
+    };
+
+    if (lastUnitTypeRef.current !== unitType) {
+      scene.removeObject(unitObjectId);
+      const newId = scene.addObject("playerUnit", {
+        ...nextData,
+      });
+      unitObjectIdRef.current = newId;
+      lastUnitTypeRef.current = unitType;
+      return;
+    }
+
+    scene.updateObject(unitObjectId, nextData);
+  }, [isOpen, unitType, moduleKey, skillKey, unitBlueprint]);
 
   if (!isOpen) {
     return null;

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
@@ -11,7 +11,7 @@ import type { SkillId } from "@db/skills-db";
 import { acquirePreviewWebgl, releasePreviewWebgl } from "./previewWebglManager";
 import { petalAuraGpuRenderer } from "@ui/renderers/primitives/gpu/petal-aura";
 
-const PREVIEW_VIEWPORT_SCALE = 1.8;
+const PREVIEW_VIEWPORT_SCALE = 2.2;
 
 interface UnitDesignerPreviewProps {
   unitType: PlayerUnitType;

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
@@ -8,11 +8,13 @@ import { cloneRendererConfigForScene } from "@shared/helpers/renderer-clone.help
 import { cloneEmitter } from "@logic/modules/active-map/player-units/player-units.helpers";
 import { setupWebGLScene } from "@ui/screens/Scene/hooks/useWebGLSceneSetup";
 import { createWebGLRenderLoop } from "@ui/screens/Scene/hooks/useWebGLRenderLoop";
+import type { SkillId } from "@db/skills-db";
 
 interface UnitDesignerPreviewProps {
   unitType: PlayerUnitType;
   unitBlueprint: PlayerUnitBlueprintStats;
   modules: readonly UnitModuleId[];
+  skills: readonly SkillId[];
   isOpen: boolean;
 }
 
@@ -20,12 +22,14 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
   unitType,
   unitBlueprint,
   modules,
+  skills,
   isOpen,
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   const moduleKey = useMemo(() => modules.join("|"), [modules]);
+  const skillKey = useMemo(() => skills.join("|"), [skills]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -84,7 +88,8 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
           baseFillColor: { ...baseFillColor },
           baseStrokeColor: baseStrokeColor ? { ...baseStrokeColor } : undefined,
           modules: [...modules],
-          skills: [],
+          skills: [...skills],
+          autoAnimate: true,
         },
       });
       return { unitPosition, objectId };
@@ -169,7 +174,7 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       // Important: lose WebGL context on unmount to avoid leaking GPU resources.
       gl.getExtension("WEBGL_lose_context")?.loseContext();
     };
-  }, [isOpen, unitType, unitBlueprint, moduleKey]);
+  }, [isOpen, unitType, unitBlueprint, moduleKey, skillKey]);
 
   if (!isOpen) {
     return null;

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
@@ -132,10 +132,26 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
 
     resizeCanvas();
 
-    const { gl, webglRenderer, cleanup } = setupWebGLScene(canvas, scene, {
-      initBullets: false,
-      initRings: false,
-    });
+    let gl: WebGL2RenderingContext | null = null;
+    let cleanup = () => {};
+    let webglRenderer: ReturnType<typeof setupWebGLScene>["webglRenderer"] | null = null;
+
+    try {
+      const setup = setupWebGLScene(canvas, scene, {
+        initBullets: false,
+        initRings: false,
+      });
+      gl = setup.gl;
+      webglRenderer = setup.webglRenderer;
+      cleanup = setup.cleanup;
+    } catch (error) {
+      console.error("[UnitDesignerPreview] Failed to initialize WebGL preview", error);
+      return () => {};
+    }
+
+    if (!gl || !webglRenderer) {
+      return () => {};
+    }
 
     gl.viewport(0, 0, canvas.width, canvas.height);
 

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerPreview.tsx
@@ -9,6 +9,7 @@ import { cloneEmitter } from "@logic/modules/active-map/player-units/player-unit
 import { createWebGLRenderLoop } from "@ui/screens/Scene/hooks/useWebGLRenderLoop";
 import type { SkillId } from "@db/skills-db";
 import { acquirePreviewWebgl, releasePreviewWebgl } from "./previewWebglManager";
+import { petalAuraGpuRenderer } from "@ui/renderers/primitives/gpu/petal-aura";
 
 const PREVIEW_VIEWPORT_SCALE = 1.8;
 
@@ -178,6 +179,15 @@ export const UnitDesignerPreview: React.FC<UnitDesignerPreviewProps> = ({
       gl,
       beforeRender: () => {
         gl.viewport(0, 0, canvas.width, canvas.height);
+      },
+      beforeEffects: (timestamp, glContext, cameraState) => {
+        petalAuraGpuRenderer.beforeRender(glContext, timestamp);
+        petalAuraGpuRenderer.render(
+          glContext,
+          cameraState.position,
+          cameraState.viewportSize,
+          timestamp
+        );
       },
     });
 

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.css
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.css
@@ -301,9 +301,16 @@
   min-height: 180px;
 }
 
+.unit-designer__summary-title {
+  margin: 0;
+  color: var(--color-text-strong);
+}
+
 .unit-designer__cost {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
   gap: var(--spacing-sm);
 }
 

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.css
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.css
@@ -301,9 +301,56 @@
   min-height: 180px;
 }
 
+.unit-designer__summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
 .unit-designer__summary-title {
   margin: 0;
   color: var(--color-text-strong);
+}
+
+.unit-designer__summary-toggle {
+  border: 1px solid var(--color-border-soft);
+  background: transparent;
+  color: var(--color-text-strong);
+  border-radius: var(--radius-sm);
+  padding: 0.1rem 0.4rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.unit-designer__summary-toggle:hover,
+.unit-designer__summary-toggle:focus-visible {
+  border-color: var(--color-border-strong);
+  color: var(--color-text);
+}
+
+.unit-designer__summary-toggle-icon {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.unit-designer__summary-toggle-icon--open {
+  transform: rotate(180deg);
+}
+
+.unit-designer__preview {
+  width: 100%;
+  height: 180px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-soft);
+  background: var(--color-surface-card);
+  overflow: hidden;
+}
+
+.unit-designer__preview-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .unit-designer__cost {

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.css
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.css
@@ -340,7 +340,7 @@
 
 .unit-designer__preview {
   width: 100%;
-  height: 180px;
+  height: 140px;
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border-soft);
   background: var(--color-surface-card);

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.tsx
@@ -156,55 +156,57 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
       <div className="unit-designer__content">
         <div className="unit-designer__main surface-panel">
           <aside className="unit-designer__list">
-          <div className="unit-designer__list-header">
-            <h3 className="heading-4">Units</h3>
-            <Button onClick={handleCreateUnit}>New Unit</Button>
-          </div>
-          <ul className="unit-designer__list-items">
-            {state.units.map((unit) => {
-              const isActive = unit.id === selectedUnit.id;
-              const listItemClassName = classNames(
-                "unit-designer__list-item",
-                isActive && "unit-designer__list-item--active"
-              );
-              return (
-                <li key={unit.id} className="unit-designer__list-entry">
-                  <div
-                    className={listItemClassName}
-                    onClick={() => handleSelectUnit(unit.id)}
-                    role="button"
-                    tabIndex={0}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        handleSelectUnit(unit.id);
-                      }
-                    }}
-                  >
-                    <div className="unit-designer__list-text">
-                      <span className="unit-designer__list-name">
-                        {unit.name || getPlayerUnitConfig(unit.type).name}
-                      </span>
-                      <span className="unit-designer__list-modules">{unit.modules.length} modules</span>
-                    </div>
-                    <button
-                      type="button"
-                      className={classNames("danger-button", "small-button", "button")}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDeleteUnit(unit.id);
+            <div className="unit-designer__list-header">
+              <h3 className="heading-4">Units</h3>
+              <Button onClick={handleCreateUnit}>New Unit</Button>
+            </div>
+            <ul className="unit-designer__list-items">
+              {state.units.map((unit) => {
+                const isActive = unit.id === selectedUnit.id;
+                const listItemClassName = classNames(
+                  "unit-designer__list-item",
+                  isActive && "unit-designer__list-item--active"
+                );
+                return (
+                  <li key={unit.id} className="unit-designer__list-entry">
+                    <div
+                      className={listItemClassName}
+                      onClick={() => handleSelectUnit(unit.id)}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          handleSelectUnit(unit.id);
+                        }
                       }}
-                      aria-label={`Delete ${unit.name || getPlayerUnitConfig(unit.type).name}`}
                     >
-                      Delete
-                    </button>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </aside>
-        <section className="unit-designer__editor">
+                      <div className="unit-designer__list-text">
+                        <span className="unit-designer__list-name">
+                          {unit.name || getPlayerUnitConfig(unit.type).name}
+                        </span>
+                        <span className="unit-designer__list-modules">
+                          {unit.modules.length} modules
+                        </span>
+                      </div>
+                      <button
+                        type="button"
+                        className={classNames("danger-button", "small-button", "button")}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          handleDeleteUnit(unit.id);
+                        }}
+                        aria-label={`Delete ${unit.name || getPlayerUnitConfig(unit.type).name}`}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </aside>
+          <section className="unit-designer__editor">
           <div className="unit-designer__field">
             <label htmlFor="unit-designer-name" className="label">
               Unit Name
@@ -310,42 +312,49 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
         </section>
         </div>
         <aside className="unit-designer__summary surface-sidebar">
-          
-              {previewModule ? (
-                <ModuleDetailsCard
-                  className="unit-designer__module-card no-wrapper"
-                  name={previewModule.name}
-                  level={previewModule.level}
-                  description={previewModule.description}
-                  effectLabel={previewModule.bonusLabel}
-                  currentEffect={formatUnitModuleBonusValue(
-                    previewModule.bonusType,
-                    previewModule.bonusValue
-                  )}
-                  manaMultiplier={previewModule.manaCostMultiplier}
-                  sanityCost={previewModule.sanityCost}
-                />
-              ) : (<div className="unit-designer__summary-scroll">
-            <div className="unit-designer__module-preview">
-              <section className="unit-designer__cost">
-                <h5 className="heading-5">Summoning Cost</h5>
-                <ResourceCostDisplay cost={selectedUnit.cost} />
-              </section>
-              <section className="unit-designer__stats">
-                <h5 className="heading-5">Stats</h5>
-                <dl>
-                  {statEntries.map((entry) => (
-                    <div key={entry.label} className="unit-designer__stat">
-                      <dt>{entry.label}</dt>
-                      <dd>
-                        <span>{entry.value}</span>
-                        {entry.hint ? <span className="unit-designer__stat-hint">{entry.hint}</span> : null}
-                      </dd>
-                    </div>
-                  ))}
-                </dl>
-              </section></div></div>)}
-            
+          <div className="unit-designer__summary-title heading-4">
+            {selectedUnit.name || getPlayerUnitConfig(selectedUnit.type).name}
+          </div>
+          {previewModule ? (
+            <ModuleDetailsCard
+              className="unit-designer__module-card no-wrapper"
+              name={previewModule.name}
+              level={previewModule.level}
+              description={previewModule.description}
+              effectLabel={previewModule.bonusLabel}
+              currentEffect={formatUnitModuleBonusValue(
+                previewModule.bonusType,
+                previewModule.bonusValue
+              )}
+              manaMultiplier={previewModule.manaCostMultiplier}
+              sanityCost={previewModule.sanityCost}
+            />
+          ) : (
+            <div className="unit-designer__summary-scroll">
+              <div className="unit-designer__module-preview">
+                <section className="unit-designer__cost">
+                  <h5 className="heading-5">Summoning Cost</h5>
+                  <ResourceCostDisplay cost={selectedUnit.cost} />
+                </section>
+                <section className="unit-designer__stats">
+                  <h5 className="heading-5">Stats</h5>
+                  <dl>
+                    {statEntries.map((entry) => (
+                      <div key={entry.label} className="unit-designer__stat">
+                        <dt>{entry.label}</dt>
+                        <dd>
+                          <span>{entry.value}</span>
+                          {entry.hint ? (
+                            <span className="unit-designer__stat-hint">{entry.hint}</span>
+                          ) : null}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </section>
+              </div>
+            </div>
+          )}
         </aside>
       </div>
     </div>

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.tsx
@@ -11,6 +11,11 @@ import { UnitModuleId } from "@db/unit-modules-db";
 import { Button } from "@ui-shared/Button";
 import { ModuleDetailsCard } from "@ui-shared/ModuleDetailsCard";
 import { UnitDesignerPreview } from "./UnitDesignerPreview";
+import { useBridgeValue } from "@ui-shared/useBridgeValue";
+import {
+  DEFAULT_SKILL_TREE_STATE,
+  SKILL_TREE_STATE_BRIDGE_KEY,
+} from "@logic/modules/camp/skill-tree/skill-tree.const";
 import "./UnitDesignerView.css";
 import type { UnitDesignModuleUiApi } from "@logic/modules/camp/unit-design/unit-design.types";
 
@@ -41,15 +46,20 @@ const getDefaultType = (units: readonly { type: PlayerUnitType }[], fallback: Pl
   units[0]?.type ?? fallback;
 
 export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resources }) => {
-  const { uiApi } = useAppLogic();
+  const { uiApi, bridge } = useAppLogic();
   const designer = uiApi.unitDesign as UnitDesignModuleUiApi;
   const totals = useMemo(() => computeResourceTotals(resources), [resources]);
   const [selectedId, setSelectedId] = useState<string | null>(state.units[0]?.id ?? null);
-  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(true);
   const [preview, setPreview] = useState<{
     id: UnitModuleId;
     origin: "available" | "equipped";
   } | null>(null);
+  const skillTreeState = useBridgeValue(
+    bridge,
+    SKILL_TREE_STATE_BRIDGE_KEY,
+    DEFAULT_SKILL_TREE_STATE
+  );
 
   useEffect(() => {
     if (state.units.length === 0) {
@@ -74,7 +84,7 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
   }, [selectedUnit?.id]);
 
   useEffect(() => {
-    setIsPreviewOpen(false);
+    setIsPreviewOpen(true);
   }, [selectedUnit?.id]);
 
   const missingCost = useMemo(
@@ -140,6 +150,10 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
   const availableModules = useMemo(
     () => state.availableModules.filter((module) => module.level > 0),
     [state.availableModules]
+  );
+  const ownedSkills = useMemo(
+    () => skillTreeState.nodes.filter((node) => node.level > 0).map((node) => node.id),
+    [skillTreeState.nodes]
   );
   const previewModule = useMemo(() => {
     if (!preview) {
@@ -351,6 +365,7 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
             unitType={selectedUnit.type}
             unitBlueprint={selectedUnit.blueprint}
             modules={selectedUnit.modules}
+            skills={ownedSkills}
           />
           {previewModule ? (
             <ModuleDetailsCard

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.tsx
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/UnitDesignerView.tsx
@@ -10,6 +10,7 @@ import { getPlayerUnitConfig, PlayerUnitType } from "@db/player-units-db";
 import { UnitModuleId } from "@db/unit-modules-db";
 import { Button } from "@ui-shared/Button";
 import { ModuleDetailsCard } from "@ui-shared/ModuleDetailsCard";
+import { UnitDesignerPreview } from "./UnitDesignerPreview";
 import "./UnitDesignerView.css";
 import type { UnitDesignModuleUiApi } from "@logic/modules/camp/unit-design/unit-design.types";
 
@@ -44,6 +45,7 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
   const designer = uiApi.unitDesign as UnitDesignModuleUiApi;
   const totals = useMemo(() => computeResourceTotals(resources), [resources]);
   const [selectedId, setSelectedId] = useState<string | null>(state.units[0]?.id ?? null);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [preview, setPreview] = useState<{
     id: UnitModuleId;
     origin: "available" | "equipped";
@@ -69,6 +71,10 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
 
   useEffect(() => {
     setPreview(null);
+  }, [selectedUnit?.id]);
+
+  useEffect(() => {
+    setIsPreviewOpen(false);
   }, [selectedUnit?.id]);
 
   const missingCost = useMemo(
@@ -312,9 +318,40 @@ export const UnitDesignerView: React.FC<UnitDesignerViewProps> = ({ state, resou
         </section>
         </div>
         <aside className="unit-designer__summary surface-sidebar">
-          <div className="unit-designer__summary-title heading-4">
-            {selectedUnit.name || getPlayerUnitConfig(selectedUnit.type).name}
+          <div className="unit-designer__summary-header">
+            <div className="unit-designer__summary-title heading-4">
+              {selectedUnit.name || getPlayerUnitConfig(selectedUnit.type).name}
+            </div>
+            <button
+              type="button"
+              className="unit-designer__summary-toggle"
+              aria-expanded={isPreviewOpen}
+              aria-label={isPreviewOpen ? "Collapse unit preview" : "Expand unit preview"}
+              onClick={() => setIsPreviewOpen((current) => !current)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  setIsPreviewOpen((current) => !current);
+                }
+              }}
+            >
+              <span
+                className={classNames(
+                  "unit-designer__summary-toggle-icon",
+                  isPreviewOpen && "unit-designer__summary-toggle-icon--open"
+                )}
+                aria-hidden="true"
+              >
+                ▾
+              </span>
+            </button>
           </div>
+          <UnitDesignerPreview
+            isOpen={isPreviewOpen}
+            unitType={selectedUnit.type}
+            unitBlueprint={selectedUnit.blueprint}
+            modules={selectedUnit.modules}
+          />
           {previewModule ? (
             <ModuleDetailsCard
               className="unit-designer__module-card no-wrapper"

--- a/src/ui/screens/VoidCamp/components/UnitDesigner/previewWebglManager.ts
+++ b/src/ui/screens/VoidCamp/components/UnitDesigner/previewWebglManager.ts
@@ -1,0 +1,67 @@
+import { setupWebGLScene } from "@ui/screens/Scene/hooks/useWebGLSceneSetup";
+import type { SceneObjectManager } from "@core/logic/provided/services/scene-object-manager/SceneObjectManager";
+
+type PreviewEntry = {
+  gl: WebGL2RenderingContext;
+  webglRenderer: ReturnType<typeof setupWebGLScene>["webglRenderer"];
+  cleanup: () => void;
+  refCount: number;
+  disposeTimeoutId: number | null;
+};
+
+const previews = new Map<string, PreviewEntry>();
+const DISPOSE_DELAY_MS = 200;
+
+export const acquirePreviewWebgl = (
+  previewId: string,
+  canvas: HTMLCanvasElement,
+  scene: SceneObjectManager,
+  options: Parameters<typeof setupWebGLScene>[2]
+) => {
+  const existing = previews.get(previewId);
+  if (existing) {
+    existing.refCount += 1;
+    if (existing.disposeTimeoutId !== null) {
+      window.clearTimeout(existing.disposeTimeoutId);
+      existing.disposeTimeoutId = null;
+    }
+    return existing;
+  }
+
+  const setup = setupWebGLScene(canvas, scene, options);
+  const entry: PreviewEntry = {
+    gl: setup.gl,
+    webglRenderer: setup.webglRenderer,
+    cleanup: setup.cleanup,
+    refCount: 1,
+    disposeTimeoutId: null,
+  };
+  previews.set(previewId, entry);
+  return entry;
+};
+
+export const releasePreviewWebgl = (previewId: string) => {
+  const entry = previews.get(previewId);
+  if (!entry) {
+    return;
+  }
+
+  entry.refCount = Math.max(0, entry.refCount - 1);
+  if (entry.refCount > 0) {
+    return;
+  }
+
+  if (entry.disposeTimeoutId !== null) {
+    window.clearTimeout(entry.disposeTimeoutId);
+  }
+
+  entry.disposeTimeoutId = window.setTimeout(() => {
+    const current = previews.get(previewId);
+    if (!current || current.refCount > 0) {
+      return;
+    }
+    current.cleanup();
+    current.gl.getExtension("WEBGL_lose_context")?.loseContext();
+    previews.delete(previewId);
+  }, DISPOSE_DELAY_MS);
+};

--- a/src/ui/shared/steam.ts
+++ b/src/ui/shared/steam.ts
@@ -1,1 +1,1 @@
-export const STEAM_WISHLIST_URL = "https://store.steampowered.com/app/4344620/Void_Eaters/";
+export const STEAM_WISHLIST_URL = "https://store.steampowered.com/app/4344620/Void_Eaters/?utm_source=itch_io&utm_campaign=early_prototype&utm_medium=web";

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -294,8 +294,9 @@ input[type="number"]:focus-visible {
 }
 
 .button.black-button {
-  /*background: linear-gradient(-35deg, #3c5055, #252627);*/
-  background: linear-gradient(-35deg, #2d838d, #1b4a4f);
+  /*background: linear-gradient(-35deg, #3c5055, #252627);
+  background: linear-gradient(-35deg, #2d8d65, #328256);*/
+  background: linear-gradient(-35deg, #339d71, #42a970);
   color: var(--color-text-primary);
   border: 1px solid rgba(62, 71, 72, 0.7);
   border-radius: var(--radius-sm);
@@ -304,7 +305,7 @@ input[type="number"]:focus-visible {
 }
 
 .button.black-button:not(:disabled):hover {
-  background: linear-gradient(-35deg, #3a5258, #2c2f30);
+  background: linear-gradient(-35deg, #40b182, #52c084);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), 0 18px 36px rgba(0, 0, 0, 0.52);
 }
 


### PR DESCRIPTION
### Motivation
- The Unit Designer sidebar should display the selected unit's name at the top of the summary pane so the designer context is clear. 
- The `unit-designer__cost` block must be a single horizontal row so the "Summoning Cost" label is left-aligned and the cost values are right-aligned.

### Description
- Render the selected unit name at the top of the summary sidebar in `UnitDesignerView.tsx` using `{selectedUnit.name || getPlayerUnitConfig(selectedUnit.type).name}` so the current design is always labeled. 
- Change the summary markup to keep preview and summary content consistent and tidy some list markup and event handler naming in `UnitDesignerView.tsx`. 
- Add `.unit-designer__summary-title` style and update `.unit-designer__cost` in `UnitDesignerView.css` to use `flex-direction: row` and `justify-content: space-between` so label and values appear on one line.

### Testing
- Started the dev server with `npm start` and `webpack` compiled successfully, indicating no type/CSS build errors. 
- Ran automated Playwright scripts to capture the Unit Designer UI; several runs produced screenshot artifacts of the UI. 
- One Playwright run in demo mode encountered a Chromium crash (`SIGSEGV`) causing that particular run to fail, but the change is UI-only and safe to review in the browser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f391d80483208b11ac811f88ca04)