### PR TITLE
Add animation executionMode, anchor types/registry and shared samplers with CPU fallback warnings

### DIFF
--- a/src/shared/types/renderer.types.ts
+++ b/src/shared/types/renderer.types.ts
@@ -17,6 +17,16 @@ export interface RendererLayerAnimationConfig {
   phase?: number;
   falloff?: "tip" | "root" | "none";
   axis?: "normal" | "tangent" | "movement-normal" | "movement-tangent";
+  executionMode?: "gpu" | "cpu" | "auto";
+}
+
+export type RendererLayerAnchorMode = "vertex" | "spine";
+
+export interface RendererLayerAnchorConfig {
+  id: string;
+  mode: RendererLayerAnchorMode;
+  index?: number;
+  t?: number;
 }
 
 /**
@@ -31,6 +41,7 @@ export interface BaseRendererLayerFields {
   requiresEffect?: string;
   anim?: RendererLayerAnimationConfig;
   groupId?: string;
+  anchors?: RendererLayerAnchorConfig[];
 }
 
 /**

--- a/src/ui/renderers/objects/implementations/enemy/composite-helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-helpers.ts
@@ -57,6 +57,8 @@ export const sanitizeCompositeLayer = (
     spine?: { x: number; y: number; width: number }[];
     segmentIndex?: number;
     buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
+    groupId?: string;
+    anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
   }
 ): {
   shape: "polygon" | "circle" | "sprite";
@@ -73,6 +75,8 @@ export const sanitizeCompositeLayer = (
   spine?: { x: number; y: number; width: number }[];
   segmentIndex?: number;
   buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
+  groupId?: string;
+  anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
 } | null => {
   return sanitizeEnemyCompositeLayer(layer);
 };
@@ -83,6 +87,8 @@ type EnemyLayerExtras = {
   spine?: { x: number; y: number; width: number }[];
   segmentIndex?: number;
   buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
+  groupId?: string;
+  anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
 };
 
 const sanitizeEnemyCompositeLayer = createCompositeLayerSanitizer<
@@ -101,6 +107,8 @@ const sanitizeEnemyCompositeLayer = createCompositeLayerSanitizer<
     spine?: { x: number; y: number; width: number }[];
     segmentIndex?: number;
     buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
+    groupId?: string;
+    anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
   },
   EnemyLayerExtras
 >({
@@ -134,5 +142,7 @@ const sanitizeEnemyCompositeLayer = createCompositeLayerSanitizer<
     spine: layer.spine,
     segmentIndex: layer.segmentIndex,
     buildOpts: layer.buildOpts,
+    groupId: layer.groupId,
+    anchors: layer.anchors,
   }),
 });

--- a/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
@@ -1,6 +1,5 @@
 import type {
   SceneObjectInstance,
-  SceneVector2,
   SceneFill,
   SceneStroke,
 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
@@ -19,8 +18,13 @@ import {
   sanitizeCompositeLayer,
 } from "./composite-helpers";
 import { getNowMs } from "@shared/helpers/time.helper";
+import { resolveLayerAnchors, writeAnchorsForLayer } from "../../shared/anchors";
+import {
+  createPolygonAnimSampler,
+  createSpineSwaySampler,
+  resolveAnimationExecutionMode,
+} from "../../shared/animation-pipeline";
 
-const TAU = Math.PI * 2;
 const POLYGON_SWAY_PHASE_STEP = 0.3; // Phase difference between vertices for wave-like animation
 
 /**
@@ -37,7 +41,7 @@ export const createCompositePrimitives = (
   dynamicPrimitives: DynamicPrimitive[]
 ): void => {
   // Process each layer
-  renderer.layers.forEach((layerConfig) => {
+  renderer.layers.forEach((layerConfig, layerIndex) => {
     const layer = sanitizeCompositeLayer(layerConfig);
     if (!layer) {
       return; // Skip invalid layers
@@ -51,151 +55,33 @@ export const createCompositePrimitives = (
 
       // Sway animation for tentacle segments built from a line spine (like player units)
       if (Array.isArray(layer.spine) && layer.anim?.type === "sway") {
-        const rawSpine = layer.spine;
-        const baseSpine = rawSpine.map((p) => ({ x: p.x, y: p.y, width: p.width }));
-        const segIndex = typeof layer.segmentIndex === "number" ? layer.segmentIndex : 0;
-        const build = layer.buildOpts || {};
-        const winding = build.winding === "CW" ? "CW" : "CCW";
-        const epsilon =
-          typeof build.epsilon === "number" && isFinite(build.epsilon) ? build.epsilon : 0.2;
-        const anim = layer.anim;
-        const period = Math.max(anim?.periodMs ?? 1400, 1);
-        const amplitude = anim?.amplitude ?? 1.0;
-        const phase = anim?.phase ?? 0;
-        const falloffKind = anim?.falloff ?? "tip";
-        const axis = anim?.axis ?? "normal";
-
-        const segmentCount = Math.max(baseSpine.length - 1, 0);
-        const deformed = baseSpine.map((p) => ({ x: p.x, y: p.y, width: p.width }));
-        const quadVerts: SceneVector2[] = [
-          { x: 0, y: 0 },
-          { x: 0, y: 0 },
-          { x: 0, y: 0 },
-          { x: 0, y: 0 },
-        ];
-
-        const falloffFactors = new Float32Array(baseSpine.length);
-        if (baseSpine.length > 1) {
-          for (let i = 1; i < baseSpine.length; i += 1) {
-            const ratio = i / (baseSpine.length - 1);
-            falloffFactors[i] =
-              falloffKind === "tip"
-                ? ratio
-                : falloffKind === "root"
-                ? 1 - ratio
-                : 1;
+        const executionMode = resolveAnimationExecutionMode({
+          requested: layer.anim.executionMode,
+          gpuAvailable: false,
+          warnKey: `enemy:${instance.id}:spine:${layer.groupId ?? layerIndex}`,
+        });
+        void executionMode;
+        const sampler = createSpineSwaySampler({
+          spine: layer.spine,
+          segmentIndex: typeof layer.segmentIndex === "number" ? layer.segmentIndex : 0,
+          buildOpts: layer.buildOpts,
+          anim: layer.anim,
+          timeSource: getAnimationTimeMs,
+        });
+        const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
+        const sampleVertices = () => {
+          const quadVerts = sampler.getVertices();
+          if (hasAnchors) {
+            const resolved = resolveLayerAnchors(
+              layer.anchors,
+              quadVerts,
+              sampler.getDeformedSpine(),
+              layer.offset
+            );
+            writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
-        }
-
-        const axisX = new Float32Array(segmentCount);
-        const axisY = new Float32Array(segmentCount);
-        for (let i = 0; i < segmentCount; i += 1) {
-          const a = baseSpine[i]!;
-          const b = baseSpine[i + 1]!;
-          const dx = b.x - a.x;
-          const dy = b.y - a.y;
-          const length = Math.hypot(dx, dy) || 1;
-          const tangentX = dx / length;
-          const tangentY = dy / length;
-          const normalX = -tangentY;
-          const normalY = tangentX;
-          axisX[i] = axis === "tangent" ? tangentX : normalX;
-          axisY[i] = axis === "tangent" ? tangentY : normalY;
-        }
-
-        const omega = (2 * Math.PI) / period;
-
-        const deformSpine = (timeMs: number) => {
-          if (baseSpine.length === 0) {
-            return;
-          }
-          deformed[0]!.x = baseSpine[0]!.x;
-          deformed[0]!.y = baseSpine[0]!.y;
-          if (baseSpine.length === 1 || amplitude === 0 || segmentCount === 0) {
-            for (let i = 1; i < baseSpine.length; i += 1) {
-              deformed[i]!.x = baseSpine[i]!.x;
-              deformed[i]!.y = baseSpine[i]!.y;
-            }
-            return;
-          }
-
-          const baseAngle = omega * timeMs + phase;
-
-          for (let i = 1; i < baseSpine.length; i += 1) {
-            const segmentPhase = i * 0.5;
-            const sinAngle = Math.sin(baseAngle + segmentPhase);
-            const displacement = amplitude * falloffFactors[i]! * sinAngle;
-            const axisXValue = axisX[i - 1] ?? 0;
-            const axisYValue = axisY[i - 1] ?? 0;
-            deformed[i]!.x = baseSpine[i]!.x + axisXValue * displacement;
-            deformed[i]!.y = baseSpine[i]!.y + axisYValue * displacement;
-          }
+          return quadVerts;
         };
-
-        const buildQuad = (k: number) => {
-          const a = deformed[k]!;
-          const b = deformed[k + 1]!;
-          const ax = a?.x ?? 0;
-          const ay = a?.y ?? 0;
-          const bx = b?.x ?? ax;
-          const by = b?.y ?? ay;
-          const tx = bx - ax;
-          const ty = by - ay;
-          const len = Math.hypot(tx, ty) || 1;
-          const ux = tx / len;
-          const uy = ty / len;
-          const nx = -uy;
-          const ny = ux;
-          const aCapX = ax - ux * epsilon;
-          const aCapY = ay - uy * epsilon;
-          const bCapX = bx + ux * epsilon;
-          const bCapY = by + uy * epsilon;
-          const wa = (a?.width ?? 0) * 0.5;
-          const wb = (b?.width ?? 0) * 0.5;
-          const aLx = aCapX + nx * wa;
-          const aLy = aCapY + ny * wa;
-          const aRx = aCapX - nx * wa;
-          const aRy = aCapY - ny * wa;
-          const bLx = bCapX + nx * wb;
-          const bLy = bCapY + ny * wb;
-          const bRx = bCapX - nx * wb;
-          const bRy = bCapY - ny * wb;
-          if (winding === "CW") {
-            quadVerts[0]!.x = aRx;
-            quadVerts[0]!.y = aRy;
-            quadVerts[1]!.x = bRx;
-            quadVerts[1]!.y = bRy;
-            quadVerts[2]!.x = bLx;
-            quadVerts[2]!.y = bLy;
-            quadVerts[3]!.x = aLx;
-            quadVerts[3]!.y = aLy;
-          } else {
-            quadVerts[0]!.x = aLx;
-            quadVerts[0]!.y = aLy;
-            quadVerts[1]!.x = bLx;
-            quadVerts[1]!.y = bLy;
-            quadVerts[2]!.x = bRx;
-            quadVerts[2]!.y = bRy;
-            quadVerts[3]!.x = aRx;
-            quadVerts[3]!.y = aRy;
-          }
-        };
-
-        const sampleVertices = (() => {
-          let lastSampleTime = -1;
-          const UPDATE_INTERVAL_MS = 32;
-
-          return () => {
-            const now = getAnimationTimeMs();
-            if (now - lastSampleTime < UPDATE_INTERVAL_MS) {
-              return quadVerts;
-            }
-            lastSampleTime = now;
-            deformSpine(now);
-            buildQuad(segIndex);
-            return quadVerts;
-          };
-        })();
 
         if (layer.stroke) {
           const strokeColor =
@@ -229,137 +115,27 @@ export const createCompositePrimitives = (
       const animCfg = layer.anim;
       if (animCfg && (animCfg.type === "sway" || animCfg.type === "pulse")) {
         // Animated polygon layer
-        const baseVertices = layer.vertices.map((v) => ({ x: v.x, y: v.y }));
-        const center = baseVertices.reduce(
-          (acc, v) => ({ x: acc.x + v.x, y: acc.y + v.y }),
-          { x: 0, y: 0 }
-        );
-        const invCount = baseVertices.length > 0 ? 1 / baseVertices.length : 0;
-        center.x *= invCount;
-        center.y *= invCount;
-
-        const period = Math.max(1, Math.floor(animCfg.periodMs ?? 1500));
-        const amplitude = animCfg.amplitude ?? 6;
-        const phase = animCfg.phase ?? 0;
-        const axis = animCfg.axis ?? "normal";
-        const amplitudePercentage =
-          typeof animCfg.amplitudePercentage === "number" &&
-          Number.isFinite(animCfg.amplitudePercentage)
-            ? animCfg.amplitudePercentage
-            : undefined;
-
-        const vertexMeta = baseVertices.map((v) => {
-          const dx = v.x - center.x;
-          const dy = v.y - center.y;
-          const radius = Math.hypot(dx, dy);
-          const invRadius = radius > 1e-6 ? 1 / radius : 0;
-          const normalX = dx * invRadius;
-          const normalY = dy * invRadius;
-          const tangentX = -normalY;
-          const tangentY = normalX;
-          const normalMagnitude =
-            amplitudePercentage !== undefined ? radius * amplitudePercentage : amplitude;
-          return {
-            baseX: v.x,
-            baseY: v.y,
-            normalX,
-            normalY,
-            tangentX,
-            tangentY,
-            normalMagnitude,
-            tangentMagnitude: amplitude,
-          };
+        const executionMode = resolveAnimationExecutionMode({
+          requested: animCfg.executionMode,
+          gpuAvailable: false,
+          warnKey: `enemy:${instance.id}:polygon:${layer.groupId ?? layerIndex}`,
         });
-
-        // Add phase step for vertex-by-vertex animation (like player units)
-        const POLYGON_SWAY_PHASE_STEP = 0.3; // Phase difference between vertices
-        const sinPhaseStep = Math.sin(POLYGON_SWAY_PHASE_STEP);
-        const cosPhaseStep = Math.cos(POLYGON_SWAY_PHASE_STEP);
-
-        const sampleSway = (timeMs: number): SceneVector2[] => {
-          if (vertexMeta.length === 0) {
-            return [];
-          }
-          const omega = TAU / period;
-          const baseAngle = omega * timeMs + phase;
-          let sinValue = Math.sin(baseAngle);
-          let cosValue = Math.cos(baseAngle);
-          const deformed = new Array<SceneVector2>(vertexMeta.length);
-          for (let i = 0; i < vertexMeta.length; i += 1) {
-            const meta = vertexMeta[i]!;
-            if (!meta) {
-              deformed[i] = { x: 0, y: 0 };
-              continue;
-            }
-            // Use per-vertex phase for wave-like animation
-            const sinForVertex = sinValue;
-            if (axis === "tangent") {
-              const magnitude = meta.tangentMagnitude * sinForVertex;
-              deformed[i] = {
-                x: meta.baseX + meta.tangentX * magnitude,
-                y: meta.baseY + meta.tangentY * magnitude,
-              };
-            } else {
-              const magnitude = meta.normalMagnitude * sinForVertex;
-              deformed[i] = {
-                x: meta.baseX + meta.normalX * magnitude,
-                y: meta.baseY + meta.normalY * magnitude,
-              };
-            }
-            // Rotate phase for next vertex
-            const prevSin = sinValue;
-            const prevCos = cosValue;
-            sinValue = prevSin * cosPhaseStep + prevCos * sinPhaseStep;
-            cosValue = prevCos * cosPhaseStep - prevSin * sinPhaseStep;
+        void executionMode;
+        const sampler = createPolygonAnimSampler({
+          vertices: layer.vertices,
+          anim: animCfg,
+          timeSource: getAnimationTimeMs,
+          phaseStep: POLYGON_SWAY_PHASE_STEP,
+        });
+        const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
+        const getDeformedVertices = () => {
+          const deformed = sampler.getVertices();
+          if (hasAnchors) {
+            const resolved = resolveLayerAnchors(layer.anchors, deformed, undefined, layer.offset);
+            writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return deformed;
         };
-
-        const samplePulse = (timeMs: number): SceneVector2[] => {
-          if (vertexMeta.length === 0) {
-            return [];
-          }
-          const omega = TAU / period;
-          const angle = omega * timeMs + phase;
-          const s = Math.sin(angle);
-          const deformed = new Array<SceneVector2>(vertexMeta.length);
-          for (let i = 0; i < vertexMeta.length; i += 1) {
-            const meta = vertexMeta[i]!;
-            if (!meta) {
-              deformed[i] = { x: 0, y: 0 };
-              continue;
-            }
-            if (axis === "tangent") {
-              const magnitude = amplitude * s;
-              deformed[i] = {
-                x: meta.baseX + meta.tangentX * magnitude,
-                y: meta.baseY + meta.tangentY * magnitude,
-              };
-            } else {
-              const magnitude = amplitude * s;
-              deformed[i] = {
-                x: meta.baseX + meta.normalX * magnitude,
-                y: meta.baseY + meta.normalY * magnitude,
-              };
-            }
-          }
-          return deformed;
-        };
-
-        const getDeformedVertices = (() => {
-          const UPDATE_INTERVAL_MS = 32; // Update animation every 32ms (~30 FPS)
-          let lastUpdateTime = -1;
-          let lastSample = baseVertices.map((v) => ({ x: v.x, y: v.y }));
-          return () => {
-            const now = getAnimationTimeMs();
-            if (now - lastUpdateTime < UPDATE_INTERVAL_MS) {
-              return lastSample; // Return cached vertices
-            }
-            lastUpdateTime = now;
-            lastSample = animCfg.type === "sway" ? sampleSway(now) : samplePulse(now);
-            return lastSample;
-          };
-        })();
 
         if (layer.stroke) {
           const strokeColor =
@@ -403,6 +179,10 @@ export const createCompositePrimitives = (
           );
         }
         const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
+        if (Array.isArray(layer.anchors) && layer.anchors.length > 0) {
+          const resolved = resolveLayerAnchors(layer.anchors, layer.vertices, layer.spine, layer.offset);
+          writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+        }
         dynamicPrimitives.push(
           createDynamicPolygonPrimitive(instance, {
             vertices: layer.vertices,

--- a/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
@@ -24,6 +24,7 @@ import {
   createSpineSwaySampler,
   resolveAnimationExecutionMode,
 } from "../../shared/animation-pipeline";
+import { isAnimationGpuAvailable } from "../../shared/animation-gpu";
 
 const POLYGON_SWAY_PHASE_STEP = 0.3; // Phase difference between vertices for wave-like animation
 
@@ -57,16 +58,16 @@ export const createCompositePrimitives = (
       if (Array.isArray(layer.spine) && layer.anim?.type === "sway") {
         const executionMode = resolveAnimationExecutionMode({
           requested: layer.anim.executionMode,
-          gpuAvailable: false,
+          gpuAvailable: isAnimationGpuAvailable(),
           warnKey: `enemy:${instance.id}:spine:${layer.groupId ?? layerIndex}`,
         });
-        void executionMode;
         const sampler = createSpineSwaySampler({
           spine: layer.spine,
           segmentIndex: typeof layer.segmentIndex === "number" ? layer.segmentIndex : 0,
           buildOpts: layer.buildOpts,
           anim: layer.anim,
           timeSource: getAnimationTimeMs,
+          executionMode,
         });
         const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
         const sampleVertices = () => {
@@ -117,15 +118,15 @@ export const createCompositePrimitives = (
         // Animated polygon layer
         const executionMode = resolveAnimationExecutionMode({
           requested: animCfg.executionMode,
-          gpuAvailable: false,
+          gpuAvailable: isAnimationGpuAvailable(),
           warnKey: `enemy:${instance.id}:polygon:${layer.groupId ?? layerIndex}`,
         });
-        void executionMode;
         const sampler = createPolygonAnimSampler({
           vertices: layer.vertices,
           anim: animCfg,
           timeSource: getAnimationTimeMs,
           phaseStep: POLYGON_SWAY_PHASE_STEP,
+          executionMode,
         });
         const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
         const getDeformedVertices = () => {

--- a/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
@@ -30,6 +30,7 @@ import {
   createSpineSwaySampler,
   resolveAnimationExecutionMode,
 } from "../../shared/animation-pipeline";
+import { isAnimationGpuAvailable } from "../../shared/animation-gpu";
 
 /**
  * Creates composite primitives for player unit renderer
@@ -129,16 +130,16 @@ export const createCompositePrimitives = (
       if (Array.isArray(layer.spine) && layer.anim?.type === "sway") {
         const executionMode = resolveAnimationExecutionMode({
           requested: layer.anim.executionMode,
-          gpuAvailable: false,
+          gpuAvailable: isAnimationGpuAvailable(),
           warnKey: `player-unit:${instance.id}:spine:${layer.groupId ?? layerIndex}`,
         });
-        void executionMode;
         const sampler = createSpineSwaySampler({
           spine: layer.spine,
           segmentIndex: typeof layer.segmentIndex === "number" ? layer.segmentIndex : 0,
           buildOpts: layer.buildOpts,
           anim: layer.anim,
           timeSource: getTentacleTimeMs,
+          executionMode,
         });
         const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
         const sampleVertices = () => {
@@ -200,16 +201,16 @@ export const createCompositePrimitives = (
       if (animCfg && (animCfg.type === "sway" || animCfg.type === "pulse")) {
         const executionMode = resolveAnimationExecutionMode({
           requested: animCfg.executionMode,
-          gpuAvailable: false,
+          gpuAvailable: isAnimationGpuAvailable(),
           warnKey: `player-unit:${instance.id}:polygon:${layer.groupId ?? layerIndex}`,
         });
-        void executionMode;
         const sampler = createPolygonAnimSampler({
           vertices: layer.vertices,
           anim: animCfg,
           timeSource: getTentacleTimeMs,
           enableMovementAxis: true,
           phaseStep: POLYGON_SWAY_PHASE_STEP,
+          executionMode,
         });
         const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
         const getDeformedVertices = () => {

--- a/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
@@ -1,6 +1,5 @@
 import type {
   SceneObjectInstance,
-  SceneVector2,
   SceneFill,
   SceneStroke,
 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
@@ -18,13 +17,19 @@ import {
   resolveLayerStrokeFill,
   resolveStrokeColor,
 } from "./helpers";
+import { resolveLayerAnchors, writeAnchorsForLayer } from "../../shared/anchors";
 import {
   getAuraInstanceMap,
   acquireAuraSlotForInstance,
   writeAuraInstance,
 } from "./aura.helpers";
-import { TAU, POLYGON_SWAY_PHASE_STEP } from "./constants";
+import { POLYGON_SWAY_PHASE_STEP } from "./constants";
 import { getTentacleTimeMs } from "./helpers";
+import {
+  createPolygonAnimSampler,
+  createSpineSwaySampler,
+  resolveAnimationExecutionMode,
+} from "../../shared/animation-pipeline";
 
 /**
  * Creates composite primitives for player unit renderer
@@ -95,7 +100,7 @@ export const createCompositePrimitives = (
   }
 
   // Group tentacle segments by groupId for potential future use (not required to animate basic sway)
-  renderer.layers.forEach((layer) => {
+  renderer.layers.forEach((layer, layerIndex) => {
     // If a layer requires a module, render it only when present
     const payload = instance.data.customData as PlayerUnitCustomData | undefined;
     const required = layer.requiresModule;
@@ -122,153 +127,33 @@ export const createCompositePrimitives = (
     if (layer.shape === "polygon") {
       // Sway animation for tentacle segments built from a line spine
       if (Array.isArray(layer.spine) && layer.anim?.type === "sway") {
-        const rawSpine = layer.spine;
-        const baseSpine = rawSpine.map((p) => ({ x: p.x, y: p.y, width: p.width }));
-        const segIndex = typeof layer.segmentIndex === "number" ? layer.segmentIndex : 0;
-        const build = layer.buildOpts || {};
-        const winding = build.winding === "CW" ? "CW" : "CCW";
-        const epsilon =
-          typeof build.epsilon === "number" && isFinite(build.epsilon) ? build.epsilon : 0.2;
-        const anim = layer.anim;
-        const period = Math.max(anim?.periodMs ?? 1400, 1);
-        const amplitude = anim?.amplitude ?? 1.0;
-        const phase = anim?.phase ?? 0;
-        const falloffKind = anim?.falloff ?? "tip";
-        const axis = anim?.axis ?? "normal";
-
-        const segmentCount = Math.max(baseSpine.length - 1, 0);
-        const deformed = baseSpine.map((p) => ({ x: p.x, y: p.y, width: p.width }));
-        const quadVerts: SceneVector2[] = [
-          { x: 0, y: 0 },
-          { x: 0, y: 0 },
-          { x: 0, y: 0 },
-          { x: 0, y: 0 },
-        ];
-
-        const falloffFactors = new Float32Array(baseSpine.length);
-        if (baseSpine.length > 1) {
-          for (let i = 1; i < baseSpine.length; i += 1) {
-            const ratio = i / (baseSpine.length - 1);
-            falloffFactors[i] =
-              falloffKind === "tip"
-                ? ratio
-                : falloffKind === "root"
-                ? 1 - ratio
-                : 1;
+        const executionMode = resolveAnimationExecutionMode({
+          requested: layer.anim.executionMode,
+          gpuAvailable: false,
+          warnKey: `player-unit:${instance.id}:spine:${layer.groupId ?? layerIndex}`,
+        });
+        void executionMode;
+        const sampler = createSpineSwaySampler({
+          spine: layer.spine,
+          segmentIndex: typeof layer.segmentIndex === "number" ? layer.segmentIndex : 0,
+          buildOpts: layer.buildOpts,
+          anim: layer.anim,
+          timeSource: getTentacleTimeMs,
+        });
+        const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
+        const sampleVertices = () => {
+          const quadVerts = sampler.getVertices();
+          if (hasAnchors) {
+            const resolved = resolveLayerAnchors(
+              layer.anchors,
+              quadVerts,
+              sampler.getDeformedSpine(),
+              layer.offset
+            );
+            writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
-        }
-
-        const axisX = new Float32Array(segmentCount);
-        const axisY = new Float32Array(segmentCount);
-        for (let i = 0; i < segmentCount; i += 1) {
-          const a = baseSpine[i]!;
-          const b = baseSpine[i + 1]!;
-          const dx = b.x - a.x;
-          const dy = b.y - a.y;
-          const length = Math.hypot(dx, dy) || 1;
-          const tangentX = dx / length;
-          const tangentY = dy / length;
-          const normalX = -tangentY;
-          const normalY = tangentX;
-          axisX[i] = axis === "tangent" ? tangentX : normalX;
-          axisY[i] = axis === "tangent" ? tangentY : normalY;
-        }
-
-        const omega = (2 * Math.PI) / period;
-
-        const deformSpine = (timeMs: number) => {
-          if (baseSpine.length === 0) {
-            return;
-          }
-          deformed[0]!.x = baseSpine[0]!.x;
-          deformed[0]!.y = baseSpine[0]!.y;
-          if (baseSpine.length === 1 || amplitude === 0 || segmentCount === 0) {
-            for (let i = 1; i < baseSpine.length; i += 1) {
-              deformed[i]!.x = baseSpine[i]!.x;
-              deformed[i]!.y = baseSpine[i]!.y;
-            }
-            return;
-          }
-
-          // Спростимо анімацію - використовуємо один sin для всіх сегментів з різними фазами
-          const baseAngle = omega * timeMs + phase;
-
-          for (let i = 1; i < baseSpine.length; i += 1) {
-            // Фазовий зсув базується на позиції сегмента (простіша версія)
-            const segmentPhase = i * 0.5; // Фіксований зсув замість складного розрахунку
-            const sinAngle = Math.sin(baseAngle + segmentPhase);
-            const displacement = amplitude * falloffFactors[i]! * sinAngle;
-            const axisXValue = axisX[i - 1] ?? 0;
-            const axisYValue = axisY[i - 1] ?? 0;
-            deformed[i]!.x = baseSpine[i]!.x + axisXValue * displacement;
-            deformed[i]!.y = baseSpine[i]!.y + axisYValue * displacement;
-          }
+          return quadVerts;
         };
-
-        const buildQuad = (k: number) => {
-          const a = deformed[k]!;
-          const b = deformed[k + 1]!;
-          const ax = a?.x ?? 0;
-          const ay = a?.y ?? 0;
-          const bx = b?.x ?? ax;
-          const by = b?.y ?? ay;
-          const tx = bx - ax;
-          const ty = by - ay;
-          const len = Math.hypot(tx, ty) || 1;
-          const ux = tx / len;
-          const uy = ty / len;
-          const nx = -uy;
-          const ny = ux;
-          const aCapX = ax - ux * epsilon;
-          const aCapY = ay - uy * epsilon;
-          const bCapX = bx + ux * epsilon;
-          const bCapY = by + uy * epsilon;
-          const wa = (a?.width ?? 0) * 0.5;
-          const wb = (b?.width ?? 0) * 0.5;
-          const aLx = aCapX + nx * wa;
-          const aLy = aCapY + ny * wa;
-          const aRx = aCapX - nx * wa;
-          const aRy = aCapY - ny * wa;
-          const bLx = bCapX + nx * wb;
-          const bLy = bCapY + ny * wb;
-          const bRx = bCapX - nx * wb;
-          const bRy = bCapY - ny * wb;
-          if (winding === "CW") {
-            quadVerts[0]!.x = aRx;
-            quadVerts[0]!.y = aRy;
-            quadVerts[1]!.x = bRx;
-            quadVerts[1]!.y = bRy;
-            quadVerts[2]!.x = bLx;
-            quadVerts[2]!.y = bLy;
-            quadVerts[3]!.x = aLx;
-            quadVerts[3]!.y = aLy;
-          } else {
-            quadVerts[0]!.x = aLx;
-            quadVerts[0]!.y = aLy;
-            quadVerts[1]!.x = bLx;
-            quadVerts[1]!.y = bLy;
-            quadVerts[2]!.x = bRx;
-            quadVerts[2]!.y = bRy;
-            quadVerts[3]!.x = aRx;
-            quadVerts[3]!.y = aRy;
-          }
-        };
-
-        const sampleVertices = (() => {
-          let lastSampleTime = -1;
-          const UPDATE_INTERVAL_MS = 32; // Оновлюємо анімацію кожні 32ms (~30 FPS)
-
-          return () => {
-            const now = getTentacleTimeMs();
-            if (now - lastSampleTime < UPDATE_INTERVAL_MS) {
-              return quadVerts; // Повертаємо ті самі вершини без перерахунку
-            }
-            lastSampleTime = now;
-            deformSpine(now);
-            buildQuad(segIndex);
-            return quadVerts;
-          };
-        })();
 
         if (layer.stroke) {
           const layerStrokeForTentacle = layer.stroke;
@@ -313,162 +198,28 @@ export const createCompositePrimitives = (
       const animCfg = layer.anim;
 
       if (animCfg && (animCfg.type === "sway" || animCfg.type === "pulse")) {
-        const baseVertices = layer.vertices.map((v) => ({ x: v.x, y: v.y }));
-        const center = baseVertices.reduce(
-          (acc, v) => ({ x: acc.x + v.x, y: acc.y + v.y }),
-          { x: 0, y: 0 }
-        );
-        const invCount = baseVertices.length > 0 ? 1 / baseVertices.length : 0;
-        center.x *= invCount;
-        center.y *= invCount;
-        const period = Math.max(1, Math.floor(animCfg.periodMs ?? 1500));
-        const amplitude = animCfg.amplitude ?? 6;
-        const phase = animCfg.phase ?? 0;
-        const axis = animCfg.axis ?? "normal";
-        const amplitudePercentage =
-          typeof animCfg.amplitudePercentage === "number" &&
-          Number.isFinite(animCfg.amplitudePercentage)
-            ? animCfg.amplitudePercentage
-            : undefined;
-        const movementPerp =
-          axis === "movement-tangent"
-            ? { x: 0, y: 1 }
-            : axis === "movement-normal"
-            ? { x: -1, y: 0 }
-            : null;
-
-        const vertexCount = baseVertices.length;
-        const baseX = new Float32Array(vertexCount);
-        const baseY = new Float32Array(vertexCount);
-        const normalX = new Float32Array(vertexCount);
-        const normalY = new Float32Array(vertexCount);
-        const tangentX = new Float32Array(vertexCount);
-        const tangentY = new Float32Array(vertexCount);
-        const normalMagnitude = new Float32Array(vertexCount);
-        const tangentMagnitude = new Float32Array(vertexCount);
-        for (let i = 0; i < vertexCount; i += 1) {
-          const v = baseVertices[i]!;
-          const dx = v.x - center.x;
-          const dy = v.y - center.y;
-          const radius = Math.hypot(dx, dy);
-          const invRadius = radius > 1e-6 ? 1 / radius : 0;
-          baseX[i] = v.x;
-          baseY[i] = v.y;
-          normalX[i] = dx * invRadius;
-          normalY[i] = dy * invRadius;
-          tangentX[i] = -normalY[i]!;
-          tangentY[i] = normalX[i]!;
-          normalMagnitude[i] =
-            amplitudePercentage !== undefined ? radius * amplitudePercentage : amplitude;
-          tangentMagnitude[i] = amplitude;
-        }
-        const deformed = baseVertices.map((v) => ({ x: v.x, y: v.y }));
-        const moveToward = movementPerp ? new Float32Array(vertexCount) : null;
-        const moveMagnitude = movementPerp ? new Float32Array(vertexCount) : null;
-        if (movementPerp && moveToward && moveMagnitude) {
-          for (let i = 0; i < vertexCount; i += 1) {
-            const signedDist =
-              baseX[i]! * movementPerp.x + baseY[i]! * movementPerp.y;
-            moveToward[i] = -Math.sign(signedDist) || 0;
-            moveMagnitude[i] =
-              amplitudePercentage !== undefined
-                ? Math.abs(signedDist) * amplitudePercentage
-                : amplitude;
-          }
-        }
-        const hasMovement = Boolean(movementPerp && moveToward && moveMagnitude);
-        const sinPhaseStep = Math.sin(POLYGON_SWAY_PHASE_STEP);
-        const cosPhaseStep = Math.cos(POLYGON_SWAY_PHASE_STEP);
-
-        const sampleSway = (timeMs: number): SceneVector2[] => {
-          if (vertexCount === 0) {
-            return deformed;
-          }
-          const omega = TAU / period;
-          const baseAngle = omega * timeMs + phase;
-          const globalSin = Math.sin(baseAngle);
-          const usesVertexPhase = !hasMovement;
-          const sinStep = usesVertexPhase ? sinPhaseStep : 0;
-          const cosStep = usesVertexPhase ? cosPhaseStep : 1;
-          let sinValue = globalSin;
-          let cosValue = Math.cos(baseAngle);
-          for (let i = 0; i < vertexCount; i += 1) {
-            const sinForVertex = usesVertexPhase ? sinValue : globalSin;
-            if (movementPerp && moveToward && moveMagnitude && hasMovement) {
-              const magnitude = moveMagnitude[i]! * sinForVertex * moveToward[i]!;
-              deformed[i]!.x = baseX[i]! + movementPerp.x * magnitude;
-              deformed[i]!.y = baseY[i]! + movementPerp.y * magnitude;
-            } else if (axis === "tangent") {
-              const magnitude = tangentMagnitude[i]! * sinForVertex;
-              deformed[i]!.x = baseX[i]! + tangentX[i]! * magnitude;
-              deformed[i]!.y = baseY[i]! + tangentY[i]! * magnitude;
-            } else {
-              const magnitude = normalMagnitude[i]! * sinForVertex;
-              deformed[i]!.x = baseX[i]! + normalX[i]! * magnitude;
-              deformed[i]!.y = baseY[i]! + normalY[i]! * magnitude;
-            }
-            if (usesVertexPhase) {
-              const prevSin = sinValue;
-              const prevCos = cosValue;
-              sinValue = prevSin * cosStep + prevCos * sinStep;
-              cosValue = prevCos * cosStep - prevSin * sinStep;
-            }
+        const executionMode = resolveAnimationExecutionMode({
+          requested: animCfg.executionMode,
+          gpuAvailable: false,
+          warnKey: `player-unit:${instance.id}:polygon:${layer.groupId ?? layerIndex}`,
+        });
+        void executionMode;
+        const sampler = createPolygonAnimSampler({
+          vertices: layer.vertices,
+          anim: animCfg,
+          timeSource: getTentacleTimeMs,
+          enableMovementAxis: true,
+          phaseStep: POLYGON_SWAY_PHASE_STEP,
+        });
+        const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
+        const getDeformedVertices = () => {
+          const deformed = sampler.getVertices();
+          if (hasAnchors) {
+            const resolved = resolveLayerAnchors(layer.anchors, deformed, undefined, layer.offset);
+            writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return deformed;
         };
-
-        const samplePulse = (timeMs: number): SceneVector2[] => {
-          if (vertexCount === 0) {
-            return deformed;
-          }
-          const omega = TAU / period;
-          const baseAngle = omega * timeMs + phase;
-          const sinStep = 0;
-          const cosStep = 1;
-          let sinValue = Math.sin(baseAngle);
-          let cosValue = Math.cos(baseAngle);
-          for (let i = 0; i < vertexCount; i += 1) {
-            const s = sinValue;
-            if (movementPerp && moveToward && moveMagnitude) {
-              const magnitude = moveMagnitude[i]! * s * moveToward[i]!;
-              deformed[i]!.x = baseX[i]! + movementPerp.x * magnitude;
-              deformed[i]!.y = baseY[i]! + movementPerp.y * magnitude;
-            } else if (axis === "tangent") {
-              const magnitude = amplitude * s;
-              deformed[i]!.x = baseX[i]! + tangentX[i]! * magnitude;
-              deformed[i]!.y = baseY[i]! + tangentY[i]! * magnitude;
-            } else {
-              const magnitude = amplitude * s;
-              deformed[i]!.x = baseX[i]! + normalX[i]! * magnitude;
-              deformed[i]!.y = baseY[i]! + normalY[i]! * magnitude;
-            }
-            if (sinStep !== 0) {
-              const prevSin = sinValue;
-              const prevCos = cosValue;
-              sinValue = prevSin * cosStep + prevCos * sinStep;
-              cosValue = prevCos * cosStep - prevSin * sinStep;
-            }
-          }
-          return deformed;
-        };
-
-        const getDeformedVertices = (() => {
-          const UPDATE_INTERVAL_MS = 32; // Оновлюємо анімацію кожні 32ms (~30 FPS)
-          let lastUpdateTime = -1;
-          return () => {
-            const now = getTentacleTimeMs();
-            if (now - lastUpdateTime < UPDATE_INTERVAL_MS) {
-              return deformed; // Повертаємо закешовані вершини
-            }
-            lastUpdateTime = now;
-            if (animCfg.type === "sway") {
-              sampleSway(now);
-            } else {
-              samplePulse(now);
-            }
-            return deformed;
-          };
-        })();
 
         if (layer.stroke) {
           const layerStrokeForAnimated = layer.stroke;
@@ -532,6 +283,10 @@ export const createCompositePrimitives = (
         // Always add refreshFill to track visual effect changes
         const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
         const layerFillForStatic = layer.fill;
+        if (Array.isArray(layer.anchors) && layer.anchors.length > 0) {
+          const resolved = resolveLayerAnchors(layer.anchors, layer.vertices, layer.spine, layer.offset);
+          writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+        }
         dynamicPrimitives.push(
           createDynamicPolygonPrimitive(instance, {
             vertices: layer.vertices,

--- a/src/ui/renderers/objects/implementations/player-unit/helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/helpers.ts
@@ -148,6 +148,7 @@ type PlayerLayerExtraFields = {
   segmentIndex?: RendererLayer["segmentIndex"];
   buildOpts?: RendererLayer["buildOpts"];
   groupId?: RendererLayer["groupId"];
+  anchors?: RendererLayer["anchors"];
 };
 
 const sanitizePlayerCompositeLayer = createCompositeLayerSanitizer<
@@ -185,6 +186,7 @@ const sanitizePlayerCompositeLayer = createCompositeLayerSanitizer<
     segmentIndex: layer.segmentIndex,
     buildOpts: layer.buildOpts,
     groupId: layer.groupId,
+    anchors: layer.anchors,
   }),
 });
 

--- a/src/ui/renderers/objects/shared/anchors.ts
+++ b/src/ui/renderers/objects/shared/anchors.ts
@@ -1,0 +1,134 @@
+import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { RendererLayerAnchorConfig } from "@shared/types/renderer.types";
+
+export type RendererAnchorRecord = {
+  id: string;
+  position: SceneVector2;
+};
+
+const anchorRegistry = new Map<string, Map<string, SceneVector2>>();
+
+const normalizeGroupId = (groupId: string | undefined): string => groupId ?? "default";
+
+const buildRegistryKey = (instanceId: string, groupId: string | undefined): string => {
+  return `${instanceId}::${normalizeGroupId(groupId)}`;
+};
+
+export const writeAnchorsForLayer = (
+  instanceId: string,
+  groupId: string | undefined,
+  anchors: RendererAnchorRecord[]
+): void => {
+  if (anchors.length === 0) {
+    return;
+  }
+  const key = buildRegistryKey(instanceId, groupId);
+  const record = new Map<string, SceneVector2>();
+  anchors.forEach((anchor) => {
+    record.set(anchor.id, anchor.position);
+  });
+  anchorRegistry.set(key, record);
+};
+
+export const readAnchor = (
+  instanceId: string,
+  groupId: string | undefined,
+  anchorId: string
+): SceneVector2 | undefined => {
+  return anchorRegistry.get(buildRegistryKey(instanceId, groupId))?.get(anchorId);
+};
+
+export const readAnchorsForLayer = (
+  instanceId: string,
+  groupId: string | undefined
+): RendererAnchorRecord[] => {
+  const record = anchorRegistry.get(buildRegistryKey(instanceId, groupId));
+  if (!record) {
+    return [];
+  }
+  return Array.from(record.entries()).map(([id, position]) => ({ id, position }));
+};
+
+const sampleSpineByT = (spine: SceneVector2[], t: number): SceneVector2 | null => {
+  if (spine.length === 0) {
+    return null;
+  }
+  if (spine.length === 1) {
+    return spine[0] ?? null;
+  }
+  const clampedT = Math.max(0, Math.min(1, t));
+  let totalLength = 0;
+  const lengths = new Array<number>(spine.length - 1);
+  for (let i = 0; i < spine.length - 1; i += 1) {
+    const a = spine[i]!;
+    const b = spine[i + 1]!;
+    const length = Math.hypot(b.x - a.x, b.y - a.y);
+    lengths[i] = length;
+    totalLength += length;
+  }
+  if (totalLength <= 0) {
+    return spine[0] ?? null;
+  }
+  let distance = clampedT * totalLength;
+  for (let i = 0; i < lengths.length; i += 1) {
+    const segmentLength = lengths[i] ?? 0;
+    if (distance <= segmentLength || i === lengths.length - 1) {
+      const a = spine[i]!;
+      const b = spine[i + 1]!;
+      const segmentT = segmentLength > 0 ? distance / segmentLength : 0;
+      return {
+        x: a.x + (b.x - a.x) * segmentT,
+        y: a.y + (b.y - a.y) * segmentT,
+      };
+    }
+    distance -= segmentLength;
+  }
+  return spine[spine.length - 1] ?? null;
+};
+
+export const resolveLayerAnchors = (
+  anchors: RendererLayerAnchorConfig[] | undefined,
+  vertices: SceneVector2[] | undefined,
+  spine: SceneVector2[] | undefined,
+  offset: SceneVector2 | undefined
+): RendererAnchorRecord[] => {
+  if (!anchors || anchors.length === 0) {
+    return [];
+  }
+  const resolved: RendererAnchorRecord[] = [];
+  const offsetX = offset?.x ?? 0;
+  const offsetY = offset?.y ?? 0;
+  anchors.forEach((anchor) => {
+    if (anchor.mode === "vertex") {
+      if (!vertices || vertices.length === 0 || typeof anchor.index !== "number") {
+        return;
+      }
+      const vertex = vertices[anchor.index];
+      if (!vertex) {
+        return;
+      }
+      resolved.push({
+        id: anchor.id,
+        position: { x: vertex.x + offsetX, y: vertex.y + offsetY },
+      });
+      return;
+    }
+    if (!spine || spine.length === 0) {
+      return;
+    }
+    let point: SceneVector2 | null = null;
+    if (typeof anchor.index === "number") {
+      point = spine[Math.max(0, Math.min(spine.length - 1, anchor.index))] ?? null;
+    } else if (typeof anchor.t === "number") {
+      point = sampleSpineByT(spine, anchor.t);
+    }
+    if (!point) {
+      return;
+    }
+    resolved.push({
+      id: anchor.id,
+      position: { x: point.x + offsetX, y: point.y + offsetY },
+    });
+  });
+  return resolved;
+};

--- a/src/ui/renderers/objects/shared/animation-gpu.ts
+++ b/src/ui/renderers/objects/shared/animation-gpu.ts
@@ -1,0 +1,454 @@
+import { compileShader } from "@ui/renderers/utils/webglProgram";
+import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { RendererLayerAnimationConfig } from "@shared/types/renderer.types";
+
+const TF_VERTEX_HEADER = `#version 300 es
+precision highp float;
+`;
+
+const TF_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+out vec4 outColor;
+void main() {
+  outColor = vec4(0.0);
+}
+`;
+
+const POLYGON_TF_VERTEX_SHADER = `${TF_VERTEX_HEADER}
+layout(location = 0) in vec2 a_position;
+
+uniform float u_timeMs;
+uniform float u_periodMs;
+uniform float u_phase;
+uniform float u_amplitude;
+uniform float u_amplitudePercent;
+uniform float u_phaseStep;
+uniform int u_animType; // 0 sway, 1 pulse
+uniform int u_axisType; // 0 normal, 1 tangent, 2 movement
+uniform int u_useVertexPhase;
+uniform vec2 u_center;
+uniform vec2 u_movementPerp;
+
+out vec2 v_position;
+
+vec2 resolveNormal(vec2 pos) {
+  vec2 d = pos - u_center;
+  float len = length(d);
+  if (len < 1e-6) {
+    return vec2(0.0, 0.0);
+  }
+  return d / len;
+}
+
+void main() {
+  vec2 basePos = a_position;
+  float omega = 6.28318530718 / max(u_periodMs, 1.0);
+  float baseAngle = omega * u_timeMs + u_phase;
+  float phaseOffset = (u_useVertexPhase == 1) ? (u_phaseStep * float(gl_VertexID)) : 0.0;
+  float angle = baseAngle + phaseOffset;
+  float s = sin(angle);
+
+  vec2 normal = resolveNormal(basePos);
+  vec2 tangent = vec2(-normal.y, normal.x);
+  vec2 axis;
+  if (u_axisType == 1) {
+    axis = tangent;
+  } else if (u_axisType == 2) {
+    axis = u_movementPerp;
+  } else {
+    axis = normal;
+  }
+
+  float magnitude = u_amplitude;
+  if (u_axisType == 2) {
+    float signedDist = dot(basePos, u_movementPerp);
+    float moveToward = -sign(signedDist);
+    float moveMagnitude = (u_amplitudePercent >= 0.0) ? abs(signedDist) * u_amplitudePercent : u_amplitude;
+    magnitude = moveMagnitude * moveToward;
+  } else if (u_amplitudePercent >= 0.0 && u_axisType == 0) {
+    float radius = length(basePos - u_center);
+    magnitude = radius * u_amplitudePercent;
+  }
+
+  vec2 offset = axis * (magnitude * s);
+  v_position = basePos + offset;
+}
+`;
+
+const SPINE_TF_VERTEX_SHADER = `${TF_VERTEX_HEADER}
+layout(location = 0) in vec2 a_position;
+layout(location = 1) in vec2 a_axis;
+layout(location = 2) in float a_falloff;
+
+uniform float u_timeMs;
+uniform float u_periodMs;
+uniform float u_phase;
+uniform float u_amplitude;
+
+out vec2 v_position;
+
+void main() {
+  float omega = 6.28318530718 / max(u_periodMs, 1.0);
+  float baseAngle = omega * u_timeMs + u_phase;
+  float segmentPhase = float(gl_VertexID) * 0.5;
+  float s = sin(baseAngle + segmentPhase);
+  float displacement = u_amplitude * a_falloff * s;
+  v_position = a_position + a_axis * displacement;
+}
+`;
+
+const TF_VARYINGS = ["v_position"] as const;
+
+type PolygonGpuResources = {
+  program: WebGLProgram;
+  vertexShader: WebGLShader;
+  fragmentShader: WebGLShader;
+  vao: WebGLVertexArrayObject;
+  inputBuffer: WebGLBuffer;
+  outputBuffer: WebGLBuffer;
+  transformFeedback: WebGLTransformFeedback;
+  capacity: number;
+  uniforms: {
+    timeMs: WebGLUniformLocation | null;
+    periodMs: WebGLUniformLocation | null;
+    phase: WebGLUniformLocation | null;
+    amplitude: WebGLUniformLocation | null;
+    amplitudePercent: WebGLUniformLocation | null;
+    phaseStep: WebGLUniformLocation | null;
+    animType: WebGLUniformLocation | null;
+    axisType: WebGLUniformLocation | null;
+    useVertexPhase: WebGLUniformLocation | null;
+    center: WebGLUniformLocation | null;
+    movementPerp: WebGLUniformLocation | null;
+  };
+};
+
+type SpineGpuResources = {
+  program: WebGLProgram;
+  vertexShader: WebGLShader;
+  fragmentShader: WebGLShader;
+  vao: WebGLVertexArrayObject;
+  inputBuffer: WebGLBuffer;
+  outputBuffer: WebGLBuffer;
+  transformFeedback: WebGLTransformFeedback;
+  capacity: number;
+  uniforms: {
+    timeMs: WebGLUniformLocation | null;
+    periodMs: WebGLUniformLocation | null;
+    phase: WebGLUniformLocation | null;
+    amplitude: WebGLUniformLocation | null;
+  };
+};
+
+type GpuAnimResources = {
+  polygon: PolygonGpuResources;
+  spine: SpineGpuResources;
+};
+
+const rendererContexts = new WeakMap<WebGL2RenderingContext, GpuAnimResources>();
+const failedContexts = new WeakSet<WebGL2RenderingContext>();
+let activeContext: WebGL2RenderingContext | null = null;
+
+export const setAnimationGpuContext = (
+  context: WebGL2RenderingContext | null
+): void => {
+  activeContext = context;
+};
+
+export const getAnimationGpuContext = (): WebGL2RenderingContext | null => activeContext;
+
+const createTransformFeedbackProgram = (
+  gl: WebGL2RenderingContext,
+  vertexSource: string,
+  varyings: readonly string[]
+): { program: WebGLProgram; vertexShader: WebGLShader; fragmentShader: WebGLShader } => {
+  const vertexShader = compileShader(gl, gl.VERTEX_SHADER, vertexSource);
+  const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, TF_FRAGMENT_SHADER);
+  const program = gl.createProgram();
+  if (!program) {
+    throw new Error("Unable to create program");
+  }
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.transformFeedbackVaryings(program, varyings, gl.SEPARATE_ATTRIBS);
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const info = gl.getProgramInfoLog(program);
+    gl.deleteProgram(program);
+    throw new Error(`Failed to link program: ${info ?? "unknown"}`);
+  }
+  return { program, vertexShader, fragmentShader };
+};
+
+const ensurePolygonResources = (
+  gl: WebGL2RenderingContext,
+  vertexCount: number
+): PolygonGpuResources | null => {
+  const resources = ensureResources(gl);
+  if (!resources) {
+    return null;
+  }
+  const polygon = resources.polygon;
+  if (vertexCount > polygon.capacity) {
+    polygon.capacity = Math.max(vertexCount, polygon.capacity * 2, 16);
+    gl.bindBuffer(gl.ARRAY_BUFFER, polygon.inputBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, polygon.capacity * 2 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, polygon.outputBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, polygon.capacity * 2 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  }
+  return polygon;
+};
+
+const ensureSpineResources = (
+  gl: WebGL2RenderingContext,
+  vertexCount: number
+): SpineGpuResources | null => {
+  const resources = ensureResources(gl);
+  if (!resources) {
+    return null;
+  }
+  const spine = resources.spine;
+  if (vertexCount > spine.capacity) {
+    spine.capacity = Math.max(vertexCount, spine.capacity * 2, 8);
+    gl.bindBuffer(gl.ARRAY_BUFFER, spine.inputBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, spine.capacity * 5 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, spine.outputBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, spine.capacity * 2 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  }
+  return spine;
+};
+
+const ensureResources = (gl: WebGL2RenderingContext): GpuAnimResources | null => {
+  const existing = rendererContexts.get(gl);
+  if (existing) {
+    return existing;
+  }
+  if (failedContexts.has(gl)) {
+    return null;
+  }
+
+  try {
+    const polygonProgram = createTransformFeedbackProgram(gl, POLYGON_TF_VERTEX_SHADER, TF_VARYINGS);
+    const spineProgram = createTransformFeedbackProgram(gl, SPINE_TF_VERTEX_SHADER, TF_VARYINGS);
+
+    const polygonVao = gl.createVertexArray();
+    const spineVao = gl.createVertexArray();
+    const polygonInputBuffer = gl.createBuffer();
+    const polygonOutputBuffer = gl.createBuffer();
+    const spineInputBuffer = gl.createBuffer();
+    const spineOutputBuffer = gl.createBuffer();
+    const polygonTf = gl.createTransformFeedback();
+    const spineTf = gl.createTransformFeedback();
+
+    if (!polygonVao || !spineVao || !polygonInputBuffer || !polygonOutputBuffer || !spineInputBuffer || !spineOutputBuffer || !polygonTf || !spineTf) {
+      return null;
+    }
+
+    gl.bindVertexArray(polygonVao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, polygonInputBuffer);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 2 * Float32Array.BYTES_PER_ELEMENT, 0);
+    gl.bindVertexArray(null);
+
+    gl.bindVertexArray(spineVao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, spineInputBuffer);
+    const stride = 5 * Float32Array.BYTES_PER_ELEMENT;
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, stride, 0);
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 2, gl.FLOAT, false, stride, 2 * Float32Array.BYTES_PER_ELEMENT);
+    gl.enableVertexAttribArray(2);
+    gl.vertexAttribPointer(2, 1, gl.FLOAT, false, stride, 4 * Float32Array.BYTES_PER_ELEMENT);
+    gl.bindVertexArray(null);
+
+    const polygonResources: PolygonGpuResources = {
+      program: polygonProgram.program,
+      vertexShader: polygonProgram.vertexShader,
+      fragmentShader: polygonProgram.fragmentShader,
+      vao: polygonVao,
+      inputBuffer: polygonInputBuffer,
+      outputBuffer: polygonOutputBuffer,
+      transformFeedback: polygonTf,
+      capacity: 0,
+      uniforms: {
+        timeMs: gl.getUniformLocation(polygonProgram.program, "u_timeMs"),
+        periodMs: gl.getUniformLocation(polygonProgram.program, "u_periodMs"),
+        phase: gl.getUniformLocation(polygonProgram.program, "u_phase"),
+        amplitude: gl.getUniformLocation(polygonProgram.program, "u_amplitude"),
+        amplitudePercent: gl.getUniformLocation(polygonProgram.program, "u_amplitudePercent"),
+        phaseStep: gl.getUniformLocation(polygonProgram.program, "u_phaseStep"),
+        animType: gl.getUniformLocation(polygonProgram.program, "u_animType"),
+        axisType: gl.getUniformLocation(polygonProgram.program, "u_axisType"),
+        useVertexPhase: gl.getUniformLocation(polygonProgram.program, "u_useVertexPhase"),
+        center: gl.getUniformLocation(polygonProgram.program, "u_center"),
+        movementPerp: gl.getUniformLocation(polygonProgram.program, "u_movementPerp"),
+      },
+    };
+
+    const spineResources: SpineGpuResources = {
+      program: spineProgram.program,
+      vertexShader: spineProgram.vertexShader,
+      fragmentShader: spineProgram.fragmentShader,
+      vao: spineVao,
+      inputBuffer: spineInputBuffer,
+      outputBuffer: spineOutputBuffer,
+      transformFeedback: spineTf,
+      capacity: 0,
+      uniforms: {
+        timeMs: gl.getUniformLocation(spineProgram.program, "u_timeMs"),
+        periodMs: gl.getUniformLocation(spineProgram.program, "u_periodMs"),
+        phase: gl.getUniformLocation(spineProgram.program, "u_phase"),
+        amplitude: gl.getUniformLocation(spineProgram.program, "u_amplitude"),
+      },
+    };
+
+    const resources = { polygon: polygonResources, spine: spineResources };
+    rendererContexts.set(gl, resources);
+    return resources;
+  } catch (error) {
+    console.warn("[AnimationGpu] Failed to initialize GPU animation resources", error);
+    failedContexts.add(gl);
+    return null;
+  }
+};
+
+export const isAnimationGpuAvailable = (): boolean => {
+  if (!activeContext) {
+    return false;
+  }
+  return Boolean(ensureResources(activeContext));
+};
+
+export const samplePolygonGpu = (options: {
+  vertices: Float32Array;
+  vertexCount: number;
+  anim: RendererLayerAnimationConfig;
+  timeMs: number;
+  center: SceneVector2;
+  phaseStep: number;
+  enableMovementAxis: boolean;
+  output: Float32Array;
+}): boolean => {
+  const gl = activeContext;
+  if (!gl) {
+    return false;
+  }
+  const polygon = ensurePolygonResources(gl, options.vertexCount);
+  if (!polygon) {
+    return false;
+  }
+
+  const anim = options.anim;
+  const axis = anim.axis ?? "normal";
+  const useMovementAxis = options.enableMovementAxis && (axis === "movement-tangent" || axis === "movement-normal");
+  const axisType = useMovementAxis ? 2 : axis === "tangent" ? 1 : 0;
+  const movementPerp = axis === "movement-normal" ? { x: -1, y: 0 } : { x: 0, y: 1 };
+  const amplitudePercent =
+    typeof anim.amplitudePercentage === "number" && Number.isFinite(anim.amplitudePercentage)
+      ? anim.amplitudePercentage
+      : -1;
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, polygon.inputBuffer);
+  gl.bufferSubData(gl.ARRAY_BUFFER, 0, options.vertices);
+
+  gl.useProgram(polygon.program);
+  gl.uniform1f(polygon.uniforms.timeMs, options.timeMs);
+  gl.uniform1f(polygon.uniforms.periodMs, Math.max(anim.periodMs ?? 1500, 1));
+  gl.uniform1f(polygon.uniforms.phase, anim.phase ?? 0);
+  gl.uniform1f(polygon.uniforms.amplitude, anim.amplitude ?? 6);
+  gl.uniform1f(polygon.uniforms.amplitudePercent, amplitudePercent);
+  gl.uniform1f(polygon.uniforms.phaseStep, options.phaseStep);
+  gl.uniform1i(polygon.uniforms.animType, anim.type === "pulse" ? 1 : 0);
+  gl.uniform1i(polygon.uniforms.axisType, axisType);
+  const useVertexPhase = anim.type === "sway" && !useMovementAxis ? 1 : 0;
+  gl.uniform1i(polygon.uniforms.useVertexPhase, useVertexPhase);
+  gl.uniform2f(polygon.uniforms.center, options.center.x, options.center.y);
+  gl.uniform2f(polygon.uniforms.movementPerp, movementPerp.x, movementPerp.y);
+
+  gl.bindVertexArray(polygon.vao);
+  gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, polygon.transformFeedback);
+  gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, polygon.outputBuffer);
+  gl.enable(gl.RASTERIZER_DISCARD);
+  gl.beginTransformFeedback(gl.POINTS);
+  gl.drawArrays(gl.POINTS, 0, options.vertexCount);
+  gl.endTransformFeedback();
+  gl.disable(gl.RASTERIZER_DISCARD);
+  gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+  gl.bindVertexArray(null);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, polygon.outputBuffer);
+  gl.getBufferSubData(gl.ARRAY_BUFFER, 0, options.output);
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  return true;
+};
+
+export const sampleSpineGpu = (options: {
+  packedInput: Float32Array;
+  vertexCount: number;
+  anim: RendererLayerAnimationConfig;
+  timeMs: number;
+  output: Float32Array;
+}): boolean => {
+  const gl = activeContext;
+  if (!gl) {
+    return false;
+  }
+  const spine = ensureSpineResources(gl, options.vertexCount);
+  if (!spine) {
+    return false;
+  }
+
+  const anim = options.anim;
+  gl.bindBuffer(gl.ARRAY_BUFFER, spine.inputBuffer);
+  gl.bufferSubData(gl.ARRAY_BUFFER, 0, options.packedInput);
+
+  gl.useProgram(spine.program);
+  gl.uniform1f(spine.uniforms.timeMs, options.timeMs);
+  gl.uniform1f(spine.uniforms.periodMs, Math.max(anim.periodMs ?? 1400, 1));
+  gl.uniform1f(spine.uniforms.phase, anim.phase ?? 0);
+  gl.uniform1f(spine.uniforms.amplitude, anim.amplitude ?? 1.0);
+
+  gl.bindVertexArray(spine.vao);
+  gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, spine.transformFeedback);
+  gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, spine.outputBuffer);
+  gl.enable(gl.RASTERIZER_DISCARD);
+  gl.beginTransformFeedback(gl.POINTS);
+  gl.drawArrays(gl.POINTS, 0, options.vertexCount);
+  gl.endTransformFeedback();
+  gl.disable(gl.RASTERIZER_DISCARD);
+  gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+  gl.bindVertexArray(null);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, spine.outputBuffer);
+  gl.getBufferSubData(gl.ARRAY_BUFFER, 0, options.output);
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  return true;
+};
+
+export const disposeAnimationGpuResources = (gl: WebGL2RenderingContext): void => {
+  const resources = rendererContexts.get(gl);
+  if (!resources) {
+    failedContexts.delete(gl);
+    return;
+  }
+  gl.deleteProgram(resources.polygon.program);
+  gl.deleteShader(resources.polygon.vertexShader);
+  gl.deleteShader(resources.polygon.fragmentShader);
+  gl.deleteVertexArray(resources.polygon.vao);
+  gl.deleteBuffer(resources.polygon.inputBuffer);
+  gl.deleteBuffer(resources.polygon.outputBuffer);
+  gl.deleteTransformFeedback(resources.polygon.transformFeedback);
+
+  gl.deleteProgram(resources.spine.program);
+  gl.deleteShader(resources.spine.vertexShader);
+  gl.deleteShader(resources.spine.fragmentShader);
+  gl.deleteVertexArray(resources.spine.vao);
+  gl.deleteBuffer(resources.spine.inputBuffer);
+  gl.deleteBuffer(resources.spine.outputBuffer);
+  gl.deleteTransformFeedback(resources.spine.transformFeedback);
+
+  rendererContexts.delete(gl);
+  failedContexts.delete(gl);
+};

--- a/src/ui/renderers/objects/shared/animation-pipeline.ts
+++ b/src/ui/renderers/objects/shared/animation-pipeline.ts
@@ -1,5 +1,6 @@
 import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import type { RendererLayerAnimationConfig } from "@shared/types/renderer.types";
+import { isAnimationGpuAvailable, samplePolygonGpu, sampleSpineGpu } from "./animation-gpu";
 
 const TAU = Math.PI * 2;
 
@@ -50,6 +51,7 @@ export const createSpineSwaySampler = (options: {
   buildOpts: SpineBuildOptions | undefined;
   anim: RendererLayerAnimationConfig;
   timeSource: AnimationTimeSource;
+  executionMode?: AnimationExecutionMode;
 }): SpineSwaySampler => {
   const baseSpine = options.spine.map((p) => ({ x: p.x, y: p.y, width: p.width }));
   const segIndex = options.segmentIndex;
@@ -179,6 +181,22 @@ export const createSpineSwaySampler = (options: {
     }
   };
 
+  const useGpu = options.executionMode === "gpu" && isAnimationGpuAvailable();
+  const gpuOutput = useGpu ? new Float32Array(baseSpine.length * 2) : null;
+  const gpuInput = useGpu ? new Float32Array(baseSpine.length * 5) : null;
+  if (useGpu && gpuInput) {
+    for (let i = 0; i < baseSpine.length; i += 1) {
+      const base = baseSpine[i]!;
+      const axisIndex = Math.max(i - 1, 0);
+      const writeOffset = i * 5;
+      gpuInput[writeOffset + 0] = base.x;
+      gpuInput[writeOffset + 1] = base.y;
+      gpuInput[writeOffset + 2] = axisX[axisIndex] ?? 0;
+      gpuInput[writeOffset + 3] = axisY[axisIndex] ?? 0;
+      gpuInput[writeOffset + 4] = falloffFactors[i] ?? 0;
+    }
+  }
+
   const sampleVertices = (() => {
     let lastSampleTime = -1;
     const UPDATE_INTERVAL_MS = 32;
@@ -188,7 +206,27 @@ export const createSpineSwaySampler = (options: {
         return quadVerts;
       }
       lastSampleTime = now;
-      deformSpine(now);
+      if (useGpu && gpuInput && gpuOutput) {
+        const ok = sampleSpineGpu({
+          packedInput: gpuInput,
+          vertexCount: baseSpine.length,
+          anim,
+          timeMs: now,
+          output: gpuOutput,
+        });
+        if (ok) {
+          for (let i = 0; i < baseSpine.length; i += 1) {
+            const readOffset = i * 2;
+            deformed[i]!.x = gpuOutput[readOffset] ?? deformed[i]!.x;
+            deformed[i]!.y = gpuOutput[readOffset + 1] ?? deformed[i]!.y;
+            deformed[i]!.width = baseSpine[i]!.width;
+          }
+        } else {
+          deformSpine(now);
+        }
+      } else {
+        deformSpine(now);
+      }
       buildQuad(segIndex);
       return quadVerts;
     };
@@ -211,6 +249,7 @@ export const createPolygonAnimSampler = (options: {
   timeSource: AnimationTimeSource;
   enableMovementAxis?: boolean;
   phaseStep?: number;
+  executionMode?: AnimationExecutionMode;
 }): PolygonAnimSampler => {
   const baseVertices = options.vertices.map((v) => ({ x: v.x, y: v.y }));
   const center = baseVertices.reduce(
@@ -340,6 +379,17 @@ export const createPolygonAnimSampler = (options: {
     return deformed;
   };
 
+  const useGpu = options.executionMode === "gpu" && isAnimationGpuAvailable();
+  const basePacked = useGpu ? new Float32Array(vertexCount * 2) : null;
+  if (basePacked) {
+    for (let i = 0; i < vertexCount; i += 1) {
+      const offset = i * 2;
+      basePacked[offset] = baseX[i] ?? 0;
+      basePacked[offset + 1] = baseY[i] ?? 0;
+    }
+  }
+  const gpuOutput = useGpu ? new Float32Array(vertexCount * 2) : null;
+
   const getDeformedVertices = (() => {
     const UPDATE_INTERVAL_MS = 32;
     let lastUpdateTime = -1;
@@ -349,6 +399,26 @@ export const createPolygonAnimSampler = (options: {
         return deformed;
       }
       lastUpdateTime = now;
+      if (useGpu && basePacked && gpuOutput) {
+        const ok = samplePolygonGpu({
+          vertices: basePacked,
+          vertexCount,
+          anim: animCfg,
+          timeMs: now,
+          center,
+          phaseStep,
+          enableMovementAxis: Boolean(options.enableMovementAxis),
+          output: gpuOutput,
+        });
+        if (ok) {
+          for (let i = 0; i < vertexCount; i += 1) {
+            const readOffset = i * 2;
+            deformed[i]!.x = gpuOutput[readOffset] ?? deformed[i]!.x;
+            deformed[i]!.y = gpuOutput[readOffset + 1] ?? deformed[i]!.y;
+          }
+          return deformed;
+        }
+      }
       if (animCfg.type === "sway") {
         sampleSway(now);
       } else {

--- a/src/ui/renderers/objects/shared/animation-pipeline.ts
+++ b/src/ui/renderers/objects/shared/animation-pipeline.ts
@@ -1,0 +1,365 @@
+import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { RendererLayerAnimationConfig } from "@shared/types/renderer.types";
+
+const TAU = Math.PI * 2;
+
+export type AnimationTimeSource = () => number;
+
+export type AnimationExecutionMode = "gpu" | "cpu";
+
+const warnedFallbacks = new Set<string>();
+
+export const resolveAnimationExecutionMode = (options: {
+  requested?: RendererLayerAnimationConfig["executionMode"];
+  gpuAvailable: boolean;
+  warnKey?: string;
+}): AnimationExecutionMode => {
+  const requested = options.requested ?? "gpu";
+  if (requested === "cpu") {
+    return "cpu";
+  }
+  if (options.gpuAvailable) {
+    return "gpu";
+  }
+  const warnKey = options.warnKey ?? "default";
+  if (!warnedFallbacks.has(warnKey)) {
+    warnedFallbacks.add(warnKey);
+    console.warn(
+      `[AnimationPipeline] GPU mode requested but unavailable; falling back to CPU for ${warnKey}.`
+    );
+  }
+  return "cpu";
+};
+
+export type SpinePoint = { x: number; y: number; width: number };
+
+export type SpineBuildOptions = {
+  epsilon?: number;
+  minSegmentLength?: number;
+  winding?: "CW" | "CCW";
+};
+
+export type SpineSwaySampler = {
+  getVertices: () => SceneVector2[];
+  getDeformedSpine: () => SpinePoint[];
+};
+
+export const createSpineSwaySampler = (options: {
+  spine: SpinePoint[];
+  segmentIndex: number;
+  buildOpts: SpineBuildOptions | undefined;
+  anim: RendererLayerAnimationConfig;
+  timeSource: AnimationTimeSource;
+}): SpineSwaySampler => {
+  const baseSpine = options.spine.map((p) => ({ x: p.x, y: p.y, width: p.width }));
+  const segIndex = options.segmentIndex;
+  const build = options.buildOpts ?? {};
+  const winding = build.winding === "CW" ? "CW" : "CCW";
+  const epsilon = typeof build.epsilon === "number" && isFinite(build.epsilon) ? build.epsilon : 0.2;
+  const anim = options.anim;
+  const period = Math.max(anim.periodMs ?? 1400, 1);
+  const amplitude = anim.amplitude ?? 1.0;
+  const phase = anim.phase ?? 0;
+  const falloffKind = anim.falloff ?? "tip";
+  const axis = anim.axis ?? "normal";
+
+  const segmentCount = Math.max(baseSpine.length - 1, 0);
+  const deformed = baseSpine.map((p) => ({ x: p.x, y: p.y, width: p.width }));
+  const quadVerts: SceneVector2[] = [
+    { x: 0, y: 0 },
+    { x: 0, y: 0 },
+    { x: 0, y: 0 },
+    { x: 0, y: 0 },
+  ];
+
+  const falloffFactors = new Float32Array(baseSpine.length);
+  if (baseSpine.length > 1) {
+    for (let i = 1; i < baseSpine.length; i += 1) {
+      const ratio = i / (baseSpine.length - 1);
+      falloffFactors[i] =
+        falloffKind === "tip"
+          ? ratio
+          : falloffKind === "root"
+          ? 1 - ratio
+          : 1;
+    }
+  }
+
+  const axisX = new Float32Array(segmentCount);
+  const axisY = new Float32Array(segmentCount);
+  for (let i = 0; i < segmentCount; i += 1) {
+    const a = baseSpine[i]!;
+    const b = baseSpine[i + 1]!;
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const length = Math.hypot(dx, dy) || 1;
+    const tangentX = dx / length;
+    const tangentY = dy / length;
+    const normalX = -tangentY;
+    const normalY = tangentX;
+    axisX[i] = axis === "tangent" ? tangentX : normalX;
+    axisY[i] = axis === "tangent" ? tangentY : normalY;
+  }
+
+  const omega = (2 * Math.PI) / period;
+
+  const deformSpine = (timeMs: number) => {
+    if (baseSpine.length === 0) {
+      return;
+    }
+    deformed[0]!.x = baseSpine[0]!.x;
+    deformed[0]!.y = baseSpine[0]!.y;
+    if (baseSpine.length === 1 || amplitude === 0 || segmentCount === 0) {
+      for (let i = 1; i < baseSpine.length; i += 1) {
+        deformed[i]!.x = baseSpine[i]!.x;
+        deformed[i]!.y = baseSpine[i]!.y;
+      }
+      return;
+    }
+
+    const baseAngle = omega * timeMs + phase;
+
+    for (let i = 1; i < baseSpine.length; i += 1) {
+      const segmentPhase = i * 0.5;
+      const sinAngle = Math.sin(baseAngle + segmentPhase);
+      const displacement = amplitude * falloffFactors[i]! * sinAngle;
+      const axisXValue = axisX[i - 1] ?? 0;
+      const axisYValue = axisY[i - 1] ?? 0;
+      deformed[i]!.x = baseSpine[i]!.x + axisXValue * displacement;
+      deformed[i]!.y = baseSpine[i]!.y + axisYValue * displacement;
+    }
+  };
+
+  const buildQuad = (k: number) => {
+    const a = deformed[k]!;
+    const b = deformed[k + 1]!;
+    const ax = a?.x ?? 0;
+    const ay = a?.y ?? 0;
+    const bx = b?.x ?? ax;
+    const by = b?.y ?? ay;
+    const tx = bx - ax;
+    const ty = by - ay;
+    const len = Math.hypot(tx, ty) || 1;
+    const ux = tx / len;
+    const uy = ty / len;
+    const nx = -uy;
+    const ny = ux;
+    const aCapX = ax - ux * epsilon;
+    const aCapY = ay - uy * epsilon;
+    const bCapX = bx + ux * epsilon;
+    const bCapY = by + uy * epsilon;
+    const wa = (a?.width ?? 0) * 0.5;
+    const wb = (b?.width ?? 0) * 0.5;
+    const aLx = aCapX + nx * wa;
+    const aLy = aCapY + ny * wa;
+    const aRx = aCapX - nx * wa;
+    const aRy = aCapY - ny * wa;
+    const bLx = bCapX + nx * wb;
+    const bLy = bCapY + ny * wb;
+    const bRx = bCapX - nx * wb;
+    const bRy = bCapY - ny * wb;
+    if (winding === "CW") {
+      quadVerts[0]!.x = aRx;
+      quadVerts[0]!.y = aRy;
+      quadVerts[1]!.x = bRx;
+      quadVerts[1]!.y = bRy;
+      quadVerts[2]!.x = bLx;
+      quadVerts[2]!.y = bLy;
+      quadVerts[3]!.x = aLx;
+      quadVerts[3]!.y = aLy;
+    } else {
+      quadVerts[0]!.x = aLx;
+      quadVerts[0]!.y = aLy;
+      quadVerts[1]!.x = bLx;
+      quadVerts[1]!.y = bLy;
+      quadVerts[2]!.x = bRx;
+      quadVerts[2]!.y = bRy;
+      quadVerts[3]!.x = aRx;
+      quadVerts[3]!.y = aRy;
+    }
+  };
+
+  const sampleVertices = (() => {
+    let lastSampleTime = -1;
+    const UPDATE_INTERVAL_MS = 32;
+    return () => {
+      const now = options.timeSource();
+      if (now - lastSampleTime < UPDATE_INTERVAL_MS) {
+        return quadVerts;
+      }
+      lastSampleTime = now;
+      deformSpine(now);
+      buildQuad(segIndex);
+      return quadVerts;
+    };
+  })();
+
+  return {
+    getVertices: sampleVertices,
+    getDeformedSpine: () => deformed,
+  };
+};
+
+export type PolygonAnimSampler = {
+  getVertices: () => SceneVector2[];
+  getDeformedVertices: () => SceneVector2[];
+};
+
+export const createPolygonAnimSampler = (options: {
+  vertices: SceneVector2[];
+  anim: RendererLayerAnimationConfig;
+  timeSource: AnimationTimeSource;
+  enableMovementAxis?: boolean;
+  phaseStep?: number;
+}): PolygonAnimSampler => {
+  const baseVertices = options.vertices.map((v) => ({ x: v.x, y: v.y }));
+  const center = baseVertices.reduce(
+    (acc, v) => ({ x: acc.x + v.x, y: acc.y + v.y }),
+    { x: 0, y: 0 }
+  );
+  const invCount = baseVertices.length > 0 ? 1 / baseVertices.length : 0;
+  center.x *= invCount;
+  center.y *= invCount;
+
+  const animCfg = options.anim;
+  const period = Math.max(1, Math.floor(animCfg.periodMs ?? 1500));
+  const amplitude = animCfg.amplitude ?? 6;
+  const phase = animCfg.phase ?? 0;
+  const axis = animCfg.axis ?? "normal";
+  const amplitudePercentage =
+    typeof animCfg.amplitudePercentage === "number" && Number.isFinite(animCfg.amplitudePercentage)
+      ? animCfg.amplitudePercentage
+      : undefined;
+  const movementPerp =
+    options.enableMovementAxis && axis === "movement-tangent"
+      ? { x: 0, y: 1 }
+      : options.enableMovementAxis && axis === "movement-normal"
+      ? { x: -1, y: 0 }
+      : null;
+
+  const vertexCount = baseVertices.length;
+  const baseX = new Float32Array(vertexCount);
+  const baseY = new Float32Array(vertexCount);
+  const normalX = new Float32Array(vertexCount);
+  const normalY = new Float32Array(vertexCount);
+  const tangentX = new Float32Array(vertexCount);
+  const tangentY = new Float32Array(vertexCount);
+  const normalMagnitude = new Float32Array(vertexCount);
+  const tangentMagnitude = new Float32Array(vertexCount);
+  for (let i = 0; i < vertexCount; i += 1) {
+    const v = baseVertices[i]!;
+    const dx = v.x - center.x;
+    const dy = v.y - center.y;
+    const radius = Math.hypot(dx, dy);
+    const invRadius = radius > 1e-6 ? 1 / radius : 0;
+    baseX[i] = v.x;
+    baseY[i] = v.y;
+    normalX[i] = dx * invRadius;
+    normalY[i] = dy * invRadius;
+    tangentX[i] = -normalY[i]!;
+    tangentY[i] = normalX[i]!;
+    normalMagnitude[i] = amplitudePercentage !== undefined ? radius * amplitudePercentage : amplitude;
+    tangentMagnitude[i] = amplitude;
+  }
+  const deformed = baseVertices.map((v) => ({ x: v.x, y: v.y }));
+  const moveToward = movementPerp ? new Float32Array(vertexCount) : null;
+  const moveMagnitude = movementPerp ? new Float32Array(vertexCount) : null;
+  if (movementPerp && moveToward && moveMagnitude) {
+    for (let i = 0; i < vertexCount; i += 1) {
+      const signedDist = baseX[i]! * movementPerp.x + baseY[i]! * movementPerp.y;
+      moveToward[i] = -Math.sign(signedDist) || 0;
+      moveMagnitude[i] =
+        amplitudePercentage !== undefined ? Math.abs(signedDist) * amplitudePercentage : amplitude;
+    }
+  }
+  const hasMovement = Boolean(movementPerp && moveToward && moveMagnitude);
+  const phaseStep = options.phaseStep ?? 0.3;
+  const sinPhaseStep = Math.sin(phaseStep);
+  const cosPhaseStep = Math.cos(phaseStep);
+
+  const sampleSway = (timeMs: number): SceneVector2[] => {
+    if (vertexCount === 0) {
+      return deformed;
+    }
+    const omega = TAU / period;
+    const baseAngle = omega * timeMs + phase;
+    const globalSin = Math.sin(baseAngle);
+    const usesVertexPhase = !hasMovement;
+    const sinStep = usesVertexPhase ? sinPhaseStep : 0;
+    const cosStep = usesVertexPhase ? cosPhaseStep : 1;
+    let sinValue = globalSin;
+    let cosValue = Math.cos(baseAngle);
+    for (let i = 0; i < vertexCount; i += 1) {
+      const sinForVertex = usesVertexPhase ? sinValue : globalSin;
+      if (movementPerp && moveToward && moveMagnitude && hasMovement) {
+        const magnitude = moveMagnitude[i]! * sinForVertex * moveToward[i]!;
+        deformed[i]!.x = baseX[i]! + movementPerp.x * magnitude;
+        deformed[i]!.y = baseY[i]! + movementPerp.y * magnitude;
+      } else if (axis === "tangent") {
+        const magnitude = tangentMagnitude[i]! * sinForVertex;
+        deformed[i]!.x = baseX[i]! + tangentX[i]! * magnitude;
+        deformed[i]!.y = baseY[i]! + tangentY[i]! * magnitude;
+      } else {
+        const magnitude = normalMagnitude[i]! * sinForVertex;
+        deformed[i]!.x = baseX[i]! + normalX[i]! * magnitude;
+        deformed[i]!.y = baseY[i]! + normalY[i]! * magnitude;
+      }
+      if (usesVertexPhase) {
+        const prevSin = sinValue;
+        const prevCos = cosValue;
+        sinValue = prevSin * cosStep + prevCos * sinStep;
+        cosValue = prevCos * cosStep - prevSin * sinStep;
+      }
+    }
+    return deformed;
+  };
+
+  const samplePulse = (timeMs: number): SceneVector2[] => {
+    if (vertexCount === 0) {
+      return deformed;
+    }
+    const omega = TAU / period;
+    const baseAngle = omega * timeMs + phase;
+    let sinValue = Math.sin(baseAngle);
+    for (let i = 0; i < vertexCount; i += 1) {
+      const s = sinValue;
+      if (movementPerp && moveToward && moveMagnitude) {
+        const magnitude = moveMagnitude[i]! * s * moveToward[i]!;
+        deformed[i]!.x = baseX[i]! + movementPerp.x * magnitude;
+        deformed[i]!.y = baseY[i]! + movementPerp.y * magnitude;
+      } else if (axis === "tangent") {
+        const magnitude = amplitude * s;
+        deformed[i]!.x = baseX[i]! + tangentX[i]! * magnitude;
+        deformed[i]!.y = baseY[i]! + tangentY[i]! * magnitude;
+      } else {
+        const magnitude = amplitude * s;
+        deformed[i]!.x = baseX[i]! + normalX[i]! * magnitude;
+        deformed[i]!.y = baseY[i]! + normalY[i]! * magnitude;
+      }
+    }
+    return deformed;
+  };
+
+  const getDeformedVertices = (() => {
+    const UPDATE_INTERVAL_MS = 32;
+    let lastUpdateTime = -1;
+    return () => {
+      const now = options.timeSource();
+      if (now - lastUpdateTime < UPDATE_INTERVAL_MS) {
+        return deformed;
+      }
+      lastUpdateTime = now;
+      if (animCfg.type === "sway") {
+        sampleSway(now);
+      } else {
+        samplePulse(now);
+      }
+      return deformed;
+    };
+  })();
+
+  return {
+    getVertices: () => getDeformedVertices(),
+    getDeformedVertices: () => deformed,
+  };
+};

--- a/src/ui/renderers/utils/WebGLSceneRenderer.ts
+++ b/src/ui/renderers/utils/WebGLSceneRenderer.ts
@@ -24,6 +24,7 @@ import type { SceneCameraState } from "@core/logic/provided/services/scene-objec
 import { textureAtlasRegistry } from "../textures/TextureAtlasRegistry";
 import { loadSpriteTexture } from "../primitives/basic/SpritePrimitive";
 import { textureResourceManager } from "../textures/TextureResourceManager";
+import { setAnimationGpuContext, disposeAnimationGpuResources } from "../objects/shared/animation-gpu";
 
 const VERTEX_SHADER = SCENE_VERTEX_SHADER;
 const FRAGMENT_SHADER = createSceneFragmentShader();
@@ -69,6 +70,7 @@ export class WebGLSceneRenderer {
   ) {
     this.gl = gl;
     this.objectsRenderer = objectsRenderer;
+    setAnimationGpuContext(gl);
 
     // Compile shaders
     this.vertexShader = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
@@ -368,6 +370,8 @@ export class WebGLSceneRenderer {
    * Disposes all WebGL resources
    */
   public dispose(): void {
+    disposeAnimationGpuResources(this.gl);
+    setAnimationGpuContext(null);
     this.gl.deleteBuffer(this.staticBuffer);
     this.gl.deleteBuffer(this.dynamicBuffer);
     this.gl.deleteProgram(this.program);

--- a/src/ui/screens/Scene/hooks/useWebGLSceneSetup.ts
+++ b/src/ui/screens/Scene/hooks/useWebGLSceneSetup.ts
@@ -143,10 +143,10 @@ export const setupWebGLScene = (
 
   clearAllAuraSlots();
   petalAuraGpuRenderer.clearInstances();
-  objectsRenderer.bootstrap(scene.getObjects());
 
   // Initialize WebGL renderer (handles shaders, buffers, attributes, uniforms)
   const webglRenderer = new WebGLSceneRenderer(gl, objectsRenderer);
+  objectsRenderer.bootstrap(scene.getObjects());
 
   const cleanup = () => {
     // Dispose WebGL renderer first (handles buffers, program, shaders)


### PR DESCRIPTION
### Motivation
- Provide a way to select execution mode for layer animations (GPU vs CPU) and prepare systems for a future GPU-based pipeline while preserving a safe CPU fallback. 
- Enable layers to declare anchors so other renderers can locate and attach to vertices or spine positions at runtime.

### Description
- Add `executionMode?: "gpu" | "cpu" | "auto"` to `RendererLayerAnimationConfig` and introduce `RendererLayerAnchorConfig` and `anchors?: RendererLayerAnchorConfig[]` in `src/shared/types/renderer.types.ts`.
- Implement a shared animation helper `src/ui/renderers/objects/shared/animation-pipeline.ts` that exports `createPolygonAnimSampler`, `createSpineSwaySampler`, and `resolveAnimationExecutionMode` with a one-time console warning when GPU is requested but unavailable.
- Add a shared anchor registry and helpers in `src/ui/renderers/objects/shared/anchors.ts` with `resolveLayerAnchors`, `writeAnchorsForLayer`, `readAnchor`, and `readAnchorsForLayer`, plus `sampleSpineByT` for spine sampling.
- Wire samplers and execution-mode resolution into player and enemy composite primitive builders and propagate `groupId`/`anchors` through sanitizers so anchor positions are resolved/persisted at runtime (updates in `player-unit` and `enemy` renderer modules).

### Testing
- Ran the project's automated test suite with `npm test`, which completed successfully and reported `67 tests passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69824bbd106483208a0332d74e3605c1)