### PR TITLE
GPU polygon transform-feedback path: avoid getBufferSubData and add GPU primitive/renderer

### DIFF
--- a/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
@@ -8,6 +8,7 @@ import {
   createDynamicPolygonPrimitive,
   createDynamicPolygonStrokePrimitive,
   createDynamicSpritePrimitive,
+  createPolygonGpuPrimitive,
 } from "../../../primitives";
 import type { DynamicPrimitive } from "../../ObjectRenderer";
 import type { EnemyRendererCompositeConfig } from "@db/enemies-db";
@@ -115,22 +116,26 @@ export const createCompositePrimitives = (
       // Check for animation
       const animCfg = layer.anim;
       if (animCfg && (animCfg.type === "sway" || animCfg.type === "pulse")) {
+        const baseVertices = layer.vertices ?? [];
         // Animated polygon layer
         const executionMode = resolveAnimationExecutionMode({
           requested: animCfg.executionMode,
           gpuAvailable: isAnimationGpuAvailable(),
           warnKey: `enemy:${instance.id}:polygon:${layer.groupId ?? layerIndex}`,
         });
-        const sampler = createPolygonAnimSampler({
-          vertices: layer.vertices,
-          anim: animCfg,
-          timeSource: getAnimationTimeMs,
-          phaseStep: POLYGON_SWAY_PHASE_STEP,
-          executionMode,
-        });
         const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
+        const needsCpuVertices = executionMode !== "gpu" || Boolean(layer.stroke || hasAnchors);
+        const sampler = needsCpuVertices
+          ? createPolygonAnimSampler({
+              vertices: baseVertices,
+              anim: animCfg,
+              timeSource: getAnimationTimeMs,
+              phaseStep: POLYGON_SWAY_PHASE_STEP,
+              executionMode: "cpu",
+            })
+          : null;
         const getDeformedVertices = () => {
-          const deformed = sampler.getVertices();
+          const deformed = sampler ? sampler.getVertices() : baseVertices;
           if (hasAnchors) {
             const resolved = resolveLayerAnchors(layer.anchors, deformed, undefined, layer.offset);
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
@@ -153,13 +158,34 @@ export const createCompositePrimitives = (
           );
         }
         const animatedLayerFill = resolveLayerFill(instance, layer.fill, renderer);
-        dynamicPrimitives.push(
-          createDynamicPolygonPrimitive(instance, {
-            getVertices: () => getDeformedVertices(),
-            offset: layer.offset,
+        if (executionMode === "gpu") {
+          const gpuPrimitive = createPolygonGpuPrimitive(instance, {
+            vertices: baseVertices,
+            anim: animCfg,
             fill: animatedLayerFill,
-          })
-        );
+            offset: layer.offset,
+            phaseStep: POLYGON_SWAY_PHASE_STEP,
+          });
+          if (gpuPrimitive) {
+            dynamicPrimitives.push(gpuPrimitive);
+          } else {
+            dynamicPrimitives.push(
+              createDynamicPolygonPrimitive(instance, {
+                getVertices: () => getDeformedVertices(),
+                offset: layer.offset,
+                fill: animatedLayerFill,
+              })
+            );
+          }
+        } else {
+          dynamicPrimitives.push(
+            createDynamicPolygonPrimitive(instance, {
+              getVertices: () => getDeformedVertices(),
+              offset: layer.offset,
+              fill: animatedLayerFill,
+            })
+          );
+        }
       } else {
         // Static polygon layer
         if (layer.stroke) {

--- a/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
@@ -8,6 +8,7 @@ import {
   createDynamicPolygonPrimitive,
   createDynamicPolygonStrokePrimitive,
   createDynamicSpritePrimitive,
+  createPolygonGpuPrimitive,
 } from "../../../primitives";
 import { getInstanceRenderPosition } from "../../ObjectRenderer";
 import type { DynamicPrimitive } from "../../ObjectRenderer";
@@ -204,17 +205,20 @@ export const createCompositePrimitives = (
           gpuAvailable: isAnimationGpuAvailable(),
           warnKey: `player-unit:${instance.id}:polygon:${layer.groupId ?? layerIndex}`,
         });
-        const sampler = createPolygonAnimSampler({
-          vertices: layer.vertices,
-          anim: animCfg,
-          timeSource: getTentacleTimeMs,
-          enableMovementAxis: true,
-          phaseStep: POLYGON_SWAY_PHASE_STEP,
-          executionMode,
-        });
         const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
+        const needsCpuVertices = executionMode !== "gpu" || Boolean(layer.stroke || hasAnchors);
+        const sampler = needsCpuVertices
+          ? createPolygonAnimSampler({
+              vertices: layer.vertices,
+              anim: animCfg,
+              timeSource: getTentacleTimeMs,
+              enableMovementAxis: true,
+              phaseStep: POLYGON_SWAY_PHASE_STEP,
+              executionMode: "cpu",
+            })
+          : null;
         const getDeformedVertices = () => {
-          const deformed = sampler.getVertices();
+          const deformed = sampler ? sampler.getVertices() : layer.vertices;
           if (hasAnchors) {
             const resolved = resolveLayerAnchors(layer.anchors, deformed, undefined, layer.offset);
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
@@ -247,14 +251,38 @@ export const createCompositePrimitives = (
         // Always add refreshFill to track visual effect changes
         const animatedLayerFill = resolveLayerFill(instance, layer.fill, renderer);
         const layerFillForAnimated = layer.fill;
-        dynamicPrimitives.push(
-          createDynamicPolygonPrimitive(instance, {
-            getVertices: () => getDeformedVertices(),
-            offset: layer.offset,
+        if (executionMode === "gpu") {
+          const gpuPrimitive = createPolygonGpuPrimitive(instance, {
+            vertices: layer.vertices,
+            anim: animCfg,
             fill: animatedLayerFill,
+            offset: layer.offset,
+            phaseStep: POLYGON_SWAY_PHASE_STEP,
+            enableMovementAxis: true,
             refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
-          })
-        );
+          });
+          if (gpuPrimitive) {
+            dynamicPrimitives.push(gpuPrimitive);
+          } else {
+            dynamicPrimitives.push(
+              createDynamicPolygonPrimitive(instance, {
+                getVertices: () => getDeformedVertices(),
+                offset: layer.offset,
+                fill: animatedLayerFill,
+                refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
+              })
+            );
+          }
+        } else {
+          dynamicPrimitives.push(
+            createDynamicPolygonPrimitive(instance, {
+              getVertices: () => getDeformedVertices(),
+              offset: layer.offset,
+              fill: animatedLayerFill,
+              refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
+            })
+          );
+        }
       } else {
         if (layer.stroke) {
           const layerStrokeForStatic = layer.stroke;

--- a/src/ui/renderers/objects/shared/animation-gpu.ts
+++ b/src/ui/renderers/objects/shared/animation-gpu.ts
@@ -28,6 +28,8 @@ uniform int u_axisType; // 0 normal, 1 tangent, 2 movement
 uniform int u_useVertexPhase;
 uniform vec2 u_center;
 uniform vec2 u_movementPerp;
+uniform vec2 u_origin;
+uniform float u_rotation;
 
 out vec2 v_position;
 
@@ -71,7 +73,14 @@ void main() {
   }
 
   vec2 offset = axis * (magnitude * s);
-  v_position = basePos + offset;
+  vec2 localPos = basePos + offset;
+  float cosR = cos(u_rotation);
+  float sinR = sin(u_rotation);
+  vec2 rotated = vec2(
+    localPos.x * cosR - localPos.y * sinR,
+    localPos.x * sinR + localPos.y * cosR
+  );
+  v_position = u_origin + rotated;
 }
 `;
 
@@ -103,11 +112,7 @@ type PolygonGpuResources = {
   program: WebGLProgram;
   vertexShader: WebGLShader;
   fragmentShader: WebGLShader;
-  vao: WebGLVertexArrayObject;
-  inputBuffer: WebGLBuffer;
-  outputBuffer: WebGLBuffer;
   transformFeedback: WebGLTransformFeedback;
-  capacity: number;
   uniforms: {
     timeMs: WebGLUniformLocation | null;
     periodMs: WebGLUniformLocation | null;
@@ -120,7 +125,16 @@ type PolygonGpuResources = {
     useVertexPhase: WebGLUniformLocation | null;
     center: WebGLUniformLocation | null;
     movementPerp: WebGLUniformLocation | null;
+    origin: WebGLUniformLocation | null;
+    rotation: WebGLUniformLocation | null;
   };
+};
+
+export type PolygonTransformFeedbackResources = {
+  vao: WebGLVertexArrayObject;
+  inputBuffer: WebGLBuffer;
+  outputBuffer: WebGLBuffer;
+  capacity: number;
 };
 
 type SpineGpuResources = {
@@ -180,26 +194,6 @@ const createTransformFeedbackProgram = (
   return { program, vertexShader, fragmentShader };
 };
 
-const ensurePolygonResources = (
-  gl: WebGL2RenderingContext,
-  vertexCount: number
-): PolygonGpuResources | null => {
-  const resources = ensureResources(gl);
-  if (!resources) {
-    return null;
-  }
-  const polygon = resources.polygon;
-  if (vertexCount > polygon.capacity) {
-    polygon.capacity = Math.max(vertexCount, polygon.capacity * 2, 16);
-    gl.bindBuffer(gl.ARRAY_BUFFER, polygon.inputBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, polygon.capacity * 2 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_DRAW);
-    gl.bindBuffer(gl.ARRAY_BUFFER, polygon.outputBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, polygon.capacity * 2 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_DRAW);
-    gl.bindBuffer(gl.ARRAY_BUFFER, null);
-  }
-  return polygon;
-};
-
 const ensureSpineResources = (
   gl: WebGL2RenderingContext,
   vertexCount: number
@@ -233,24 +227,15 @@ const ensureResources = (gl: WebGL2RenderingContext): GpuAnimResources | null =>
     const polygonProgram = createTransformFeedbackProgram(gl, POLYGON_TF_VERTEX_SHADER, TF_VARYINGS);
     const spineProgram = createTransformFeedbackProgram(gl, SPINE_TF_VERTEX_SHADER, TF_VARYINGS);
 
-    const polygonVao = gl.createVertexArray();
     const spineVao = gl.createVertexArray();
-    const polygonInputBuffer = gl.createBuffer();
-    const polygonOutputBuffer = gl.createBuffer();
     const spineInputBuffer = gl.createBuffer();
     const spineOutputBuffer = gl.createBuffer();
     const polygonTf = gl.createTransformFeedback();
     const spineTf = gl.createTransformFeedback();
 
-    if (!polygonVao || !spineVao || !polygonInputBuffer || !polygonOutputBuffer || !spineInputBuffer || !spineOutputBuffer || !polygonTf || !spineTf) {
+    if (!spineVao || !spineInputBuffer || !spineOutputBuffer || !polygonTf || !spineTf) {
       return null;
     }
-
-    gl.bindVertexArray(polygonVao);
-    gl.bindBuffer(gl.ARRAY_BUFFER, polygonInputBuffer);
-    gl.enableVertexAttribArray(0);
-    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 2 * Float32Array.BYTES_PER_ELEMENT, 0);
-    gl.bindVertexArray(null);
 
     gl.bindVertexArray(spineVao);
     gl.bindBuffer(gl.ARRAY_BUFFER, spineInputBuffer);
@@ -267,11 +252,7 @@ const ensureResources = (gl: WebGL2RenderingContext): GpuAnimResources | null =>
       program: polygonProgram.program,
       vertexShader: polygonProgram.vertexShader,
       fragmentShader: polygonProgram.fragmentShader,
-      vao: polygonVao,
-      inputBuffer: polygonInputBuffer,
-      outputBuffer: polygonOutputBuffer,
       transformFeedback: polygonTf,
-      capacity: 0,
       uniforms: {
         timeMs: gl.getUniformLocation(polygonProgram.program, "u_timeMs"),
         periodMs: gl.getUniformLocation(polygonProgram.program, "u_periodMs"),
@@ -284,6 +265,8 @@ const ensureResources = (gl: WebGL2RenderingContext): GpuAnimResources | null =>
         useVertexPhase: gl.getUniformLocation(polygonProgram.program, "u_useVertexPhase"),
         center: gl.getUniformLocation(polygonProgram.program, "u_center"),
         movementPerp: gl.getUniformLocation(polygonProgram.program, "u_movementPerp"),
+        origin: gl.getUniformLocation(polygonProgram.program, "u_origin"),
+        rotation: gl.getUniformLocation(polygonProgram.program, "u_rotation"),
       },
     };
 
@@ -321,23 +304,82 @@ export const isAnimationGpuAvailable = (): boolean => {
   return Boolean(ensureResources(activeContext));
 };
 
-export const samplePolygonGpu = (options: {
+export const createPolygonTransformFeedbackResources = (options: {
+  vertexCount: number;
+  vertices: Float32Array;
+}): PolygonTransformFeedbackResources | null => {
+  const gl = activeContext;
+  if (!gl) {
+    return null;
+  }
+  const resources = ensureResources(gl);
+  if (!resources) {
+    return null;
+  }
+  const vao = gl.createVertexArray();
+  const inputBuffer = gl.createBuffer();
+  const outputBuffer = gl.createBuffer();
+  if (!vao || !inputBuffer || !outputBuffer) {
+    return null;
+  }
+  const capacity = Math.max(options.vertexCount, 8);
+  gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, capacity * 2 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_DRAW);
+  gl.bufferSubData(gl.ARRAY_BUFFER, 0, options.vertices);
+  gl.bindBuffer(gl.ARRAY_BUFFER, outputBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, capacity * 2 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_DRAW);
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+  gl.bindVertexArray(vao);
+  gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer);
+  gl.enableVertexAttribArray(0);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 2 * Float32Array.BYTES_PER_ELEMENT, 0);
+  gl.bindVertexArray(null);
+
+  return {
+    vao,
+    inputBuffer,
+    outputBuffer,
+    capacity,
+  };
+};
+
+export const updatePolygonTransformFeedback = (options: {
+  resources: PolygonTransformFeedbackResources;
   vertices: Float32Array;
   vertexCount: number;
   anim: RendererLayerAnimationConfig;
   timeMs: number;
   center: SceneVector2;
+  origin: SceneVector2;
+  rotation: number;
   phaseStep: number;
   enableMovementAxis: boolean;
-  output: Float32Array;
 }): boolean => {
   const gl = activeContext;
   if (!gl) {
     return false;
   }
-  const polygon = ensurePolygonResources(gl, options.vertexCount);
+  const polygon = ensureResources(gl)?.polygon;
   if (!polygon) {
     return false;
+  }
+  const resources = options.resources;
+  if (options.vertexCount > resources.capacity) {
+    resources.capacity = Math.max(options.vertexCount, resources.capacity * 2, 16);
+    gl.bindBuffer(gl.ARRAY_BUFFER, resources.inputBuffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      resources.capacity * 2 * Float32Array.BYTES_PER_ELEMENT,
+      gl.DYNAMIC_DRAW
+    );
+    gl.bindBuffer(gl.ARRAY_BUFFER, resources.outputBuffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      resources.capacity * 2 * Float32Array.BYTES_PER_ELEMENT,
+      gl.DYNAMIC_DRAW
+    );
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
   }
 
   const anim = options.anim;
@@ -350,7 +392,7 @@ export const samplePolygonGpu = (options: {
       ? anim.amplitudePercentage
       : -1;
 
-  gl.bindBuffer(gl.ARRAY_BUFFER, polygon.inputBuffer);
+  gl.bindBuffer(gl.ARRAY_BUFFER, resources.inputBuffer);
   gl.bufferSubData(gl.ARRAY_BUFFER, 0, options.vertices);
 
   gl.useProgram(polygon.program);
@@ -366,10 +408,12 @@ export const samplePolygonGpu = (options: {
   gl.uniform1i(polygon.uniforms.useVertexPhase, useVertexPhase);
   gl.uniform2f(polygon.uniforms.center, options.center.x, options.center.y);
   gl.uniform2f(polygon.uniforms.movementPerp, movementPerp.x, movementPerp.y);
+  gl.uniform2f(polygon.uniforms.origin, options.origin.x, options.origin.y);
+  gl.uniform1f(polygon.uniforms.rotation, options.rotation);
 
-  gl.bindVertexArray(polygon.vao);
+  gl.bindVertexArray(resources.vao);
   gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, polygon.transformFeedback);
-  gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, polygon.outputBuffer);
+  gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, resources.outputBuffer);
   gl.enable(gl.RASTERIZER_DISCARD);
   gl.beginTransformFeedback(gl.POINTS);
   gl.drawArrays(gl.POINTS, 0, options.vertexCount);
@@ -378,9 +422,6 @@ export const samplePolygonGpu = (options: {
   gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
   gl.bindVertexArray(null);
 
-  gl.bindBuffer(gl.ARRAY_BUFFER, polygon.outputBuffer);
-  gl.getBufferSubData(gl.ARRAY_BUFFER, 0, options.output);
-  gl.bindBuffer(gl.ARRAY_BUFFER, null);
   return true;
 };
 
@@ -421,9 +462,6 @@ export const sampleSpineGpu = (options: {
   gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
   gl.bindVertexArray(null);
 
-  gl.bindBuffer(gl.ARRAY_BUFFER, spine.outputBuffer);
-  gl.getBufferSubData(gl.ARRAY_BUFFER, 0, options.output);
-  gl.bindBuffer(gl.ARRAY_BUFFER, null);
   return true;
 };
 
@@ -436,9 +474,6 @@ export const disposeAnimationGpuResources = (gl: WebGL2RenderingContext): void =
   gl.deleteProgram(resources.polygon.program);
   gl.deleteShader(resources.polygon.vertexShader);
   gl.deleteShader(resources.polygon.fragmentShader);
-  gl.deleteVertexArray(resources.polygon.vao);
-  gl.deleteBuffer(resources.polygon.inputBuffer);
-  gl.deleteBuffer(resources.polygon.outputBuffer);
   gl.deleteTransformFeedback(resources.polygon.transformFeedback);
 
   gl.deleteProgram(resources.spine.program);

--- a/src/ui/renderers/objects/shared/animation-pipeline.ts
+++ b/src/ui/renderers/objects/shared/animation-pipeline.ts
@@ -1,6 +1,5 @@
 import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import type { RendererLayerAnimationConfig } from "@shared/types/renderer.types";
-import { isAnimationGpuAvailable, samplePolygonGpu, sampleSpineGpu } from "./animation-gpu";
 
 const TAU = Math.PI * 2;
 
@@ -181,21 +180,6 @@ export const createSpineSwaySampler = (options: {
     }
   };
 
-  const useGpu = options.executionMode === "gpu" && isAnimationGpuAvailable();
-  const gpuOutput = useGpu ? new Float32Array(baseSpine.length * 2) : null;
-  const gpuInput = useGpu ? new Float32Array(baseSpine.length * 5) : null;
-  if (useGpu && gpuInput) {
-    for (let i = 0; i < baseSpine.length; i += 1) {
-      const base = baseSpine[i]!;
-      const axisIndex = Math.max(i - 1, 0);
-      const writeOffset = i * 5;
-      gpuInput[writeOffset + 0] = base.x;
-      gpuInput[writeOffset + 1] = base.y;
-      gpuInput[writeOffset + 2] = axisX[axisIndex] ?? 0;
-      gpuInput[writeOffset + 3] = axisY[axisIndex] ?? 0;
-      gpuInput[writeOffset + 4] = falloffFactors[i] ?? 0;
-    }
-  }
 
   const sampleVertices = (() => {
     let lastSampleTime = -1;
@@ -206,27 +190,7 @@ export const createSpineSwaySampler = (options: {
         return quadVerts;
       }
       lastSampleTime = now;
-      if (useGpu && gpuInput && gpuOutput) {
-        const ok = sampleSpineGpu({
-          packedInput: gpuInput,
-          vertexCount: baseSpine.length,
-          anim,
-          timeMs: now,
-          output: gpuOutput,
-        });
-        if (ok) {
-          for (let i = 0; i < baseSpine.length; i += 1) {
-            const readOffset = i * 2;
-            deformed[i]!.x = gpuOutput[readOffset] ?? deformed[i]!.x;
-            deformed[i]!.y = gpuOutput[readOffset + 1] ?? deformed[i]!.y;
-            deformed[i]!.width = baseSpine[i]!.width;
-          }
-        } else {
-          deformSpine(now);
-        }
-      } else {
-        deformSpine(now);
-      }
+      deformSpine(now);
       buildQuad(segIndex);
       return quadVerts;
     };
@@ -379,16 +343,6 @@ export const createPolygonAnimSampler = (options: {
     return deformed;
   };
 
-  const useGpu = options.executionMode === "gpu" && isAnimationGpuAvailable();
-  const basePacked = useGpu ? new Float32Array(vertexCount * 2) : null;
-  if (basePacked) {
-    for (let i = 0; i < vertexCount; i += 1) {
-      const offset = i * 2;
-      basePacked[offset] = baseX[i] ?? 0;
-      basePacked[offset + 1] = baseY[i] ?? 0;
-    }
-  }
-  const gpuOutput = useGpu ? new Float32Array(vertexCount * 2) : null;
 
   const getDeformedVertices = (() => {
     const UPDATE_INTERVAL_MS = 32;
@@ -399,26 +353,6 @@ export const createPolygonAnimSampler = (options: {
         return deformed;
       }
       lastUpdateTime = now;
-      if (useGpu && basePacked && gpuOutput) {
-        const ok = samplePolygonGpu({
-          vertices: basePacked,
-          vertexCount,
-          anim: animCfg,
-          timeMs: now,
-          center,
-          phaseStep,
-          enableMovementAxis: Boolean(options.enableMovementAxis),
-          output: gpuOutput,
-        });
-        if (ok) {
-          for (let i = 0; i < vertexCount; i += 1) {
-            const readOffset = i * 2;
-            deformed[i]!.x = gpuOutput[readOffset] ?? deformed[i]!.x;
-            deformed[i]!.y = gpuOutput[readOffset + 1] ?? deformed[i]!.y;
-          }
-          return deformed;
-        }
-      }
       if (animCfg.type === "sway") {
         sampleSway(now);
       } else {

--- a/src/ui/renderers/primitives/PolygonGpuPrimitive.ts
+++ b/src/ui/renderers/primitives/PolygonGpuPrimitive.ts
@@ -1,0 +1,223 @@
+import type {
+  SceneFill,
+  SceneObjectInstance,
+  SceneVector2,
+} from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { RendererLayerAnimationConfig } from "@shared/types/renderer.types";
+import {
+  createPolygonTransformFeedbackResources,
+  getAnimationGpuContext,
+  updatePolygonTransformFeedback,
+  type PolygonTransformFeedbackResources,
+} from "@ui/renderers/objects/shared/animation-gpu";
+import {
+  FILL_COMPONENTS,
+  DynamicPrimitive,
+  getInstanceRenderPosition,
+  transformObjectPoint,
+} from "@ui/renderers/objects/ObjectRenderer";
+import { writeFillVertexComponents } from "@ui/renderers/primitives/utils/fill";
+import { polygonGpuRenderer, type PolygonGpuHandle } from "@ui/renderers/primitives/gpu/polygon";
+import { getSceneTimelineNow } from "@ui/renderers/primitives/utils/sceneTimeline";
+import { computePolygonGeometry } from "@ui/renderers/primitives/basic/PolygonPrimitive";
+
+export interface PolygonGpuPrimitiveOptions {
+  vertices: SceneVector2[];
+  anim: RendererLayerAnimationConfig;
+  fill: SceneFill;
+  offset?: SceneVector2;
+  phaseStep?: number;
+  enableMovementAxis?: boolean;
+  refreshFill?: (instance: SceneObjectInstance) => SceneFill;
+}
+
+const buildPackedVertices = (vertices: SceneVector2[]): Float32Array => {
+  const packed = new Float32Array(vertices.length * 2);
+  for (let i = 0; i < vertices.length; i += 1) {
+    const offset = i * 2;
+    const vertex = vertices[i]!;
+    packed[offset] = vertex.x;
+    packed[offset + 1] = vertex.y;
+  }
+  return packed;
+};
+
+const buildFillBufferData = (
+  vertexCount: number,
+  fillComponents: Float32Array,
+  target?: Float32Array
+): Float32Array => {
+  const data =
+    target && target.length === vertexCount * FILL_COMPONENTS
+      ? target
+      : new Float32Array(vertexCount * FILL_COMPONENTS);
+  for (let i = 0; i < vertexCount; i += 1) {
+    data.set(fillComponents, i * FILL_COMPONENTS);
+  }
+  return data;
+};
+
+export const createPolygonGpuPrimitive = (
+  instance: SceneObjectInstance,
+  options: PolygonGpuPrimitiveOptions
+): DynamicPrimitive | null => {
+  if (!options.vertices || options.vertices.length < 3) {
+    return null;
+  }
+  const vertexCount = options.vertices.length;
+  const packedVertices = buildPackedVertices(options.vertices);
+  const geometry = computePolygonGeometry(options.vertices);
+
+  const center = options.vertices.reduce(
+    (acc, v) => ({ x: acc.x + v.x, y: acc.y + v.y }),
+    { x: 0, y: 0 }
+  );
+  const invCount = vertexCount > 0 ? 1 / vertexCount : 0;
+  center.x *= invCount;
+  center.y *= invCount;
+
+  const fillScratch = new Float32Array(FILL_COMPONENTS);
+  let fillData: Float32Array | null = null;
+  let cachedFill: SceneFill = options.fill;
+  let prevInstanceFillRef: SceneFill | undefined =
+    typeof options.refreshFill === "function" ? instance.data.fill : undefined;
+
+  let gl = getAnimationGpuContext();
+  let tfResources: PolygonTransformFeedbackResources | null = null;
+  let fillBuffer: WebGLBuffer | null = null;
+  let renderHandle: PolygonGpuHandle | null = null;
+
+  let prevPosX = getInstanceRenderPosition(instance).x;
+  let prevPosY = getInstanceRenderPosition(instance).y;
+  let prevRotation = instance.data.rotation ?? 0;
+  let needsFillUpload = true;
+
+  const ensureResources = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    if (!tfResources) {
+      tfResources = createPolygonTransformFeedbackResources({
+        vertexCount,
+        vertices: packedVertices,
+      });
+      if (!tfResources) {
+        return false;
+      }
+    }
+    if (!fillBuffer) {
+      fillBuffer = gl.createBuffer();
+      if (!fillBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        vertexCount * FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+        gl.DYNAMIC_DRAW
+      );
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    polygonGpuRenderer.setContext(gl);
+    if (!renderHandle) {
+      renderHandle = polygonGpuRenderer.acquireHandle({
+        outputBuffer: tfResources.outputBuffer,
+        fillBuffer,
+        vertexCount,
+      });
+      if (!renderHandle) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureResources() || !gl || !tfResources || !fillBuffer) {
+        return null;
+      }
+
+      const pos = getInstanceRenderPosition(target);
+      const rotation = target.data.rotation ?? 0;
+      const origin = transformObjectPoint(pos, rotation, options.offset);
+
+      let fillRefChanged = false;
+      if (typeof options.refreshFill === "function") {
+        if (target.data.fill !== prevInstanceFillRef) {
+          prevInstanceFillRef = target.data.fill;
+          cachedFill = options.refreshFill(target);
+          fillRefChanged = true;
+        }
+      }
+
+      if (
+        needsFillUpload ||
+        fillRefChanged ||
+        pos.x !== prevPosX ||
+        pos.y !== prevPosY ||
+        rotation !== prevRotation
+      ) {
+        const fillCenter = transformObjectPoint(origin, rotation, geometry.centerOffset);
+        const fillComponents = writeFillVertexComponents(fillScratch, {
+          fill: cachedFill,
+          center: fillCenter,
+          rotation,
+          size: geometry.size,
+        });
+        fillData = buildFillBufferData(vertexCount, fillComponents, fillData ?? undefined);
+        gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, fillData);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        needsFillUpload = false;
+      }
+
+      prevPosX = pos.x;
+      prevPosY = pos.y;
+      prevRotation = rotation;
+
+      updatePolygonTransformFeedback({
+        resources: tfResources,
+        vertices: packedVertices,
+        vertexCount,
+        anim: options.anim,
+        timeMs: getSceneTimelineNow(),
+        center,
+        origin,
+        rotation,
+        phaseStep: options.phaseStep ?? 0.3,
+        enableMovementAxis: Boolean(options.enableMovementAxis),
+      });
+
+      return null;
+    },
+    dispose() {
+      if (!gl) {
+        return;
+      }
+      if (renderHandle) {
+        polygonGpuRenderer.releaseHandle(renderHandle);
+        renderHandle = null;
+      }
+      if (fillBuffer) {
+        gl.deleteBuffer(fillBuffer);
+        fillBuffer = null;
+      }
+      if (tfResources) {
+        gl.deleteBuffer(tfResources.inputBuffer);
+        gl.deleteBuffer(tfResources.outputBuffer);
+        gl.deleteVertexArray(tfResources.vao);
+        tfResources = null;
+      }
+    },
+  };
+
+  return primitive;
+};

--- a/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
+++ b/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
@@ -114,7 +114,10 @@ const resolveFill = (
 };
 
 // OPTIMIZATION: Reusable geometry object to avoid per-frame allocations
-const computeGeometry = (vertices: PolygonVertices, out?: PolygonGeometry): PolygonGeometry => {
+export const computePolygonGeometry = (
+  vertices: PolygonVertices,
+  out?: PolygonGeometry
+): PolygonGeometry => {
   const result = out ?? {
     centerOffset: { x: 0, y: 0 },
     size: { width: MIN_SIZE, height: MIN_SIZE },
@@ -425,7 +428,7 @@ export const createStaticPolygonPrimitive = (
 ): StaticPrimitive => {
   const { center, vertices, fill, rotation, offset } = options;
   const origin = transformObjectPoint(center, rotation, offset);
-  const geometry = computeGeometry(vertices);
+  const geometry = computePolygonGeometry(vertices);
   const fillCenter = transformObjectPoint(
     origin,
     rotation ?? 0,
@@ -456,7 +459,7 @@ export const createDynamicPolygonPrimitive = (
   
   const initialVertices = resolveVertices(options, instance);
   let vertexCount = initialVertices.length;
-  let geometry = computeGeometry(initialVertices);
+  let geometry = computePolygonGeometry(initialVertices);
   const getCenter = (target: SceneObjectInstance): SceneVector2 =>
     transformObjectPoint(
       getInstanceRenderPosition(target),
@@ -517,7 +520,7 @@ export const createDynamicPolygonPrimitive = (
         nextVertices = initialVertices;
       } else {
         nextVertices = resolveVertices(options, target);
-        computeGeometry(nextVertices, geometry);
+        computePolygonGeometry(nextVertices, geometry);
       }
       currentVertices = nextVertices;
       const nextVertexCount = nextVertices.length;
@@ -1012,7 +1015,7 @@ export const createDynamicPolygonStrokePrimitive = (
     );
 
   let inner = resolveVerts(instance);
-  let geometry = computeGeometry(inner);
+  let geometry = computePolygonGeometry(inner);
   let origin = getCenter(instance);
   let rotation = instance.data.rotation ?? 0;
   
@@ -1072,7 +1075,7 @@ export const createDynamicPolygonStrokePrimitive = (
       // Skip expensive geometry/vertices work for static vertices
       if (!isStaticVertices) {
         inner = resolveVerts(target);
-        computeGeometry(inner, geometry);
+      computePolygonGeometry(inner, geometry);
         outer = expandVertices(inner, geometry.centerOffset, cachedStroke.width, outer);
       }
       
@@ -1149,7 +1152,7 @@ export const createStaticPolygonStrokePrimitive = (
   if (!stroke || stroke.width <= 0) {
     return null;
   }
-  const geometry = computeGeometry(vertices);
+  const geometry = computePolygonGeometry(vertices);
   const expanded = expandVertices(vertices, geometry.centerOffset, stroke.width);
   return createStaticPolygonPrimitive({
     center: options.center,

--- a/src/ui/renderers/primitives/gpu/polygon/PolygonGpuRenderer.ts
+++ b/src/ui/renderers/primitives/gpu/polygon/PolygonGpuRenderer.ts
@@ -1,0 +1,329 @@
+import type { SceneCameraState } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import { compileShader, linkProgram } from "@ui/renderers/utils/webglProgram";
+import {
+  SCENE_VERTEX_SHADER,
+  createSceneFragmentShader,
+} from "@ui/renderers/shaders/fillEffects.glsl";
+import {
+  POSITION_COMPONENTS,
+  FILL_COMPONENTS,
+  FILL_INFO_COMPONENTS,
+  FILL_PARAMS0_COMPONENTS,
+  FILL_PARAMS1_COMPONENTS,
+  FILL_FILAMENTS0_COMPONENTS,
+  FILL_FILAMENTS1_COMPONENTS,
+  STOP_OFFSETS_COMPONENTS,
+  STOP_COLOR_COMPONENTS,
+  CRACK_UV_COMPONENTS,
+  CRACK_MASK_COMPONENTS,
+  CRACK_EFFECTS_COMPONENTS,
+} from "@ui/renderers/objects";
+import { textureAtlasRegistry } from "@ui/renderers/textures/TextureAtlasRegistry";
+import { textureResourceManager } from "@ui/renderers/textures/TextureResourceManager";
+import { loadSpriteTexture } from "@ui/renderers/primitives/basic/SpritePrimitive";
+
+interface AttributeConfig {
+  location: number;
+  size: number;
+  offset: number;
+}
+
+export type PolygonGpuHandle = {
+  vao: WebGLVertexArrayObject;
+  outputBuffer: WebGLBuffer;
+  fillBuffer: WebGLBuffer;
+  vertexCount: number;
+};
+
+const FRAGMENT_SHADER = createSceneFragmentShader();
+
+class PolygonGpuRenderer {
+  private gl: WebGL2RenderingContext | null = null;
+  private program: WebGLProgram | null = null;
+  private vertexShader: WebGLShader | null = null;
+  private fragmentShader: WebGLShader | null = null;
+  private handles = new Set<PolygonGpuHandle>();
+  private positionLocation = -1;
+  private fillAttributeConfigs: AttributeConfig[] = [];
+  private fillStride = 0;
+  private cameraPositionLocation: WebGLUniformLocation | null = null;
+  private viewportSizeLocation: WebGLUniformLocation | null = null;
+  private spriteTextureLocation: WebGLUniformLocation | null = null;
+  private crackAtlasIndexLocation: WebGLUniformLocation | null = null;
+  private crackAtlasGridLocation: WebGLUniformLocation | null = null;
+  private crackAtlasSamplerLocation: WebGLUniformLocation | null = null;
+
+  public setContext(gl: WebGL2RenderingContext | null): void {
+    if (this.gl === gl) {
+      return;
+    }
+    this.dispose();
+    this.gl = gl;
+    if (!gl) {
+      return;
+    }
+
+    this.vertexShader = compileShader(gl, gl.VERTEX_SHADER, SCENE_VERTEX_SHADER);
+    this.fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+    this.program = linkProgram(gl, this.vertexShader, this.fragmentShader);
+
+    this.positionLocation = gl.getAttribLocation(this.program, "a_position");
+    if (this.positionLocation < 0) {
+      throw new Error("[PolygonGpuRenderer] Unable to resolve position attribute");
+    }
+
+    this.fillAttributeConfigs = this.createFillAttributeConfigs(gl, this.program);
+    this.fillStride = FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+
+    this.cameraPositionLocation = gl.getUniformLocation(this.program, "u_cameraPosition");
+    this.viewportSizeLocation = gl.getUniformLocation(this.program, "u_viewportSize");
+    this.spriteTextureLocation = gl.getUniformLocation(this.program, "u_spriteTexture");
+    this.crackAtlasIndexLocation = gl.getUniformLocation(this.program, "u_crackAtlasIndex");
+    this.crackAtlasGridLocation = gl.getUniformLocation(this.program, "u_crackAtlasGrid");
+    this.crackAtlasSamplerLocation = gl.getUniformLocation(this.program, "u_cracksAtlas");
+  }
+
+  public acquireHandle(options: {
+    outputBuffer: WebGLBuffer;
+    fillBuffer: WebGLBuffer;
+    vertexCount: number;
+  }): PolygonGpuHandle | null {
+    const gl = this.gl;
+    if (!gl || !this.program) {
+      return null;
+    }
+    const vao = gl.createVertexArray();
+    if (!vao) {
+      return null;
+    }
+    gl.bindVertexArray(vao);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, options.outputBuffer);
+    gl.enableVertexAttribArray(this.positionLocation);
+    gl.vertexAttribPointer(
+      this.positionLocation,
+      POSITION_COMPONENTS,
+      gl.FLOAT,
+      false,
+      POSITION_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+      0
+    );
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, options.fillBuffer);
+    this.fillAttributeConfigs.forEach(({ location, size, offset }) => {
+      gl.enableVertexAttribArray(location);
+      gl.vertexAttribPointer(location, size, gl.FLOAT, false, this.fillStride, offset);
+    });
+
+    gl.bindVertexArray(null);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+    const handle: PolygonGpuHandle = {
+      vao,
+      outputBuffer: options.outputBuffer,
+      fillBuffer: options.fillBuffer,
+      vertexCount: options.vertexCount,
+    };
+    this.handles.add(handle);
+    return handle;
+  }
+
+  public updateHandle(handle: PolygonGpuHandle, vertexCount: number): void {
+    handle.vertexCount = vertexCount;
+  }
+
+  public releaseHandle(handle: PolygonGpuHandle): void {
+    if (!this.gl) {
+      return;
+    }
+    if (this.handles.has(handle)) {
+      this.handles.delete(handle);
+    }
+    this.gl.deleteVertexArray(handle.vao);
+  }
+
+  public render(gl: WebGL2RenderingContext, cameraState: SceneCameraState): void {
+    if (!this.program || this.handles.size === 0) {
+      return;
+    }
+    gl.useProgram(this.program);
+    if (this.cameraPositionLocation) {
+      gl.uniform2f(
+        this.cameraPositionLocation,
+        cameraState.position.x,
+        cameraState.position.y
+      );
+    }
+    if (this.viewportSizeLocation) {
+      gl.uniform2f(
+        this.viewportSizeLocation,
+        cameraState.viewportSize.width,
+        cameraState.viewportSize.height
+      );
+    }
+
+    if (this.crackAtlasIndexLocation !== null || this.crackAtlasGridLocation !== null) {
+      const crackAtlasIndex = textureAtlasRegistry.getAtlasIndex("cracks");
+      const crackAtlasGrid = textureAtlasRegistry.getAtlasGrid("cracks");
+      if (this.crackAtlasIndexLocation !== null) {
+        gl.uniform1i(this.crackAtlasIndexLocation, crackAtlasIndex);
+      }
+      if (this.crackAtlasGridLocation !== null) {
+        gl.uniform2f(this.crackAtlasGridLocation, crackAtlasGrid.cols, crackAtlasGrid.rows);
+      }
+    }
+
+    if (this.crackAtlasSamplerLocation !== null) {
+      gl.activeTexture(gl.TEXTURE1);
+      gl.uniform1i(this.crackAtlasSamplerLocation, 1);
+
+      const crackPath = "images/sprites/cracks/cracks_atlas.png";
+      const crackTexture = textureResourceManager.getTexture(crackPath);
+      if (crackTexture?.texture && crackTexture.gl === gl) {
+        gl.bindTexture(gl.TEXTURE_2D, crackTexture.texture);
+      } else {
+        if (!crackTexture || crackTexture.gl !== gl) {
+          loadSpriteTexture(gl, crackPath).catch(() => {});
+        }
+        const dummyTexture = gl.createTexture();
+        if (dummyTexture) {
+          gl.bindTexture(gl.TEXTURE_2D, dummyTexture);
+          gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA,
+            1,
+            1,
+            0,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            new Uint8Array([255, 255, 255, 255])
+          );
+        }
+      }
+    }
+
+    if (this.spriteTextureLocation !== null) {
+      gl.activeTexture(gl.TEXTURE0);
+      gl.uniform1i(this.spriteTextureLocation, 0);
+      const firstTexture = textureResourceManager.getAnyTexture();
+      if (firstTexture?.texture) {
+        gl.bindTexture(gl.TEXTURE_2D, firstTexture.texture);
+      } else {
+        const dummyTexture = gl.createTexture();
+        if (dummyTexture) {
+          gl.bindTexture(gl.TEXTURE_2D, dummyTexture);
+          gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA,
+            1,
+            1,
+            0,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            new Uint8Array([255, 255, 255, 255])
+          );
+        }
+      }
+    }
+
+    this.handles.forEach((handle) => {
+      if (handle.vertexCount < 3) {
+        return;
+      }
+      gl.bindVertexArray(handle.vao);
+      gl.drawArrays(gl.TRIANGLE_FAN, 0, handle.vertexCount);
+    });
+    gl.bindVertexArray(null);
+  }
+
+  private createFillAttributeConfigs(
+    gl: WebGL2RenderingContext,
+    program: WebGLProgram
+  ): AttributeConfig[] {
+    const fillInfoLocation = gl.getAttribLocation(program, "a_fillInfo");
+    const fillParams0Location = gl.getAttribLocation(program, "a_fillParams0");
+    const fillParams1Location = gl.getAttribLocation(program, "a_fillParams1");
+    const filaments0Location = gl.getAttribLocation(program, "a_filaments0");
+    const filamentEdgeBlurLocation = gl.getAttribLocation(program, "a_filamentEdgeBlur");
+    const stopOffsetsLocation = gl.getAttribLocation(program, "a_stopOffsets");
+    const stopColor0Location = gl.getAttribLocation(program, "a_stopColor0");
+    const stopColor1Location = gl.getAttribLocation(program, "a_stopColor1");
+    const stopColor2Location = gl.getAttribLocation(program, "a_stopColor2");
+    const crackUvLocation = gl.getAttribLocation(program, "a_crackUv");
+    const crackMaskLocation = gl.getAttribLocation(program, "a_crackMask");
+    const crackEffectsLocation = gl.getAttribLocation(program, "a_crackEffects");
+
+    const attributeLocations = [
+      fillInfoLocation,
+      fillParams0Location,
+      fillParams1Location,
+      filaments0Location,
+      filamentEdgeBlurLocation,
+      stopOffsetsLocation,
+      stopColor0Location,
+      stopColor1Location,
+      stopColor2Location,
+      crackUvLocation,
+      crackMaskLocation,
+      crackEffectsLocation,
+    ];
+
+    if (attributeLocations.some((location) => location < 0)) {
+      throw new Error("[PolygonGpuRenderer] Unable to resolve fill attribute locations");
+    }
+
+    let offset = 0;
+    const configs: AttributeConfig[] = [];
+    configs.push({ location: fillInfoLocation, size: FILL_INFO_COMPONENTS, offset });
+    offset += FILL_INFO_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: fillParams0Location, size: FILL_PARAMS0_COMPONENTS, offset });
+    offset += FILL_PARAMS0_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: fillParams1Location, size: FILL_PARAMS1_COMPONENTS, offset });
+    offset += FILL_PARAMS1_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: filaments0Location, size: FILL_FILAMENTS0_COMPONENTS, offset });
+    offset += FILL_FILAMENTS0_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: filamentEdgeBlurLocation, size: FILL_FILAMENTS1_COMPONENTS, offset });
+    offset += FILL_FILAMENTS1_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: stopOffsetsLocation, size: STOP_OFFSETS_COMPONENTS, offset });
+    offset += STOP_OFFSETS_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: stopColor0Location, size: STOP_COLOR_COMPONENTS, offset });
+    offset += STOP_COLOR_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: stopColor1Location, size: STOP_COLOR_COMPONENTS, offset });
+    offset += STOP_COLOR_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: stopColor2Location, size: STOP_COLOR_COMPONENTS, offset });
+    offset += STOP_COLOR_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: crackUvLocation, size: CRACK_UV_COMPONENTS, offset });
+    offset += CRACK_UV_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: crackMaskLocation, size: CRACK_MASK_COMPONENTS, offset });
+    offset += CRACK_MASK_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: crackEffectsLocation, size: CRACK_EFFECTS_COMPONENTS, offset });
+
+    return configs;
+  }
+
+  private dispose(): void {
+    if (!this.gl) {
+      return;
+    }
+    this.handles.forEach((handle) => {
+      this.gl?.deleteVertexArray(handle.vao);
+    });
+    this.handles.clear();
+    if (this.program) {
+      this.gl.deleteProgram(this.program);
+    }
+    if (this.vertexShader) {
+      this.gl.deleteShader(this.vertexShader);
+    }
+    if (this.fragmentShader) {
+      this.gl.deleteShader(this.fragmentShader);
+    }
+    this.program = null;
+    this.vertexShader = null;
+    this.fragmentShader = null;
+  }
+}
+
+export const polygonGpuRenderer = new PolygonGpuRenderer();

--- a/src/ui/renderers/primitives/gpu/polygon/index.ts
+++ b/src/ui/renderers/primitives/gpu/polygon/index.ts
@@ -1,0 +1,1 @@
+export { polygonGpuRenderer, type PolygonGpuHandle } from "./PolygonGpuRenderer";

--- a/src/ui/renderers/primitives/index.ts
+++ b/src/ui/renderers/primitives/index.ts
@@ -16,6 +16,7 @@ export {
   createStaticPolygonStrokePrimitive,
   createDynamicPolygonStrokePrimitive,
 } from "./basic/PolygonPrimitive";
+export { createPolygonGpuPrimitive } from "./PolygonGpuPrimitive";
 export { createParticleEmitterPrimitive } from "./ParticleEmitterPrimitive";
 export { createParticleSystemPrimitive } from "./ParticleSystemPrimitive";
 export { createFireRingPrimitive } from "./FireRingPrimitive";

--- a/src/ui/renderers/utils/WebGLSceneRenderer.ts
+++ b/src/ui/renderers/utils/WebGLSceneRenderer.ts
@@ -25,6 +25,7 @@ import { textureAtlasRegistry } from "../textures/TextureAtlasRegistry";
 import { loadSpriteTexture } from "../primitives/basic/SpritePrimitive";
 import { textureResourceManager } from "../textures/TextureResourceManager";
 import { setAnimationGpuContext, disposeAnimationGpuResources } from "../objects/shared/animation-gpu";
+import { polygonGpuRenderer } from "../primitives/gpu/polygon";
 
 const VERTEX_SHADER = SCENE_VERTEX_SHADER;
 const FRAGMENT_SHADER = createSceneFragmentShader();
@@ -310,6 +311,8 @@ export class WebGLSceneRenderer {
 
     this.drawBuffer(this.staticBuffer, this.objectsRenderer.getStaticVertexCount());
     this.drawBuffer(this.dynamicBuffer, this.objectsRenderer.getDynamicVertexCount());
+    polygonGpuRenderer.setContext(this.gl);
+    polygonGpuRenderer.render(this.gl, cameraState);
   }
 
   /**
@@ -372,6 +375,7 @@ export class WebGLSceneRenderer {
   public dispose(): void {
     disposeAnimationGpuResources(this.gl);
     setAnimationGpuContext(null);
+    polygonGpuRenderer.setContext(null);
     this.gl.deleteBuffer(this.staticBuffer);
     this.gl.deleteBuffer(this.dynamicBuffer);
     this.gl.deleteProgram(this.program);


### PR DESCRIPTION
### Motivation
- Eliminate CPU readback of transform-feedback outputs (no more `gl.getBufferSubData`) and keep CPU path as a fallback for environments without WebGL2 or when GPU mode is not possible. 
- Render animated polygon layers entirely on GPU (TF output → VBO/VAO) to avoid building Float32Array CPU-side for every frame in GPU mode.

### Description
- Reworked TF pipeline to emit world-space positions and added TF helpers that keep data on GPU: `createPolygonTransformFeedbackResources` and `updatePolygonTransformFeedback`, and removed reliance on reading back TF buffers to CPU in `animation-gpu.ts`.
- Added a GPU polygon primitive and renderer: `src/ui/renderers/primitives/PolygonGpuPrimitive.ts` and `src/ui/renderers/primitives/gpu/polygon/PolygonGpuRenderer.ts` to bind TF output as a vertex buffer (VAO/VBO) and a per-vertex fill buffer for rendering without CPU copies. 
- Integrated GPU primitive selection into polygon layer construction so animated polygons use the GPU primitive when `gpu` execution is available and safe, while keeping the existing `createDynamicPolygonPrimitive` CPU path as a fallback (composite-primitives changes in player/enemy helpers). 
- Updated scene renderer to drive the new polygon GPU renderer each frame and to set/unset TF animation context (`WebGLSceneRenderer.ts`). 
- Small API/utility adjustments: exported `computePolygonGeometry` and replaced internal usages, added fill buffer upload logic per-instance, and ensured TF resources are sized/updated on demand.

### Testing
- Ran the automated test suite with `npm test` (TypeScript build + test runner); all tests passed: 67 tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836adb453c8320a8a15eeab076b404)