### PR TITLE
Add Joined GPU debug mode and runtime metrics

### DIFF
--- a/docs/technology/index.md
+++ b/docs/technology/index.md
@@ -6,3 +6,4 @@
 - [objects-renderer-manager.md](objects-renderer-manager.md) — детальний опис `ObjectsRendererManager` — центрального менеджера рендерингу об'єктів.
 - [particle-emitter-optimization.md](particle-emitter-optimization.md) — як оптимізовано роботу частинок для вибухів та порталів.
 - [gpu-instanced-effects.md](gpu-instanced-effects.md) — архітектура GPU-рендерерів, життєвий цикл, різні типи примітивів та робота з Transform Feedback.
+- [joined-gpu-debug.md](joined-gpu-debug.md) — debug‑режим для профайлування GPU‑join примітивів.

--- a/docs/technology/joined-gpu-debug.md
+++ b/docs/technology/joined-gpu-debug.md
@@ -1,0 +1,26 @@
+# Joined GPU debug mode
+
+Цей режим створено для швидкого профайлування GPU‑join шляху (anchor → joined primitives) із масовими інстансами.
+
+## Як увімкнути
+1. Запустіть dev server:
+   ```bash
+   npm start
+   ```
+2. Відкрийте:
+   ```
+   http://localhost:3000/?joinedDebug=1
+   ```
+3. На сцені з’явиться **1024 joined‑елементи** (32×32). У правому верхньому куті буде банер, а в debug‑панелі — метрики.
+
+## Метрики
+Debug‑панель показує:
+- **Joined GPU**: кількість handles та draw calls.
+- **Joined GPU timing**: час рендера (render) і час апдейта anchor‑текстури (upload).
+- Додатково: FPS, VBO, particle stats тощо.
+
+## Manual checklist (опційно)
+- [ ] Увімкнути `joinedDebug=1`, переконатися що joined‑елементи видимі.
+- [ ] Перевірити, що метрики Joined GPU оновлюються.
+- [ ] Перемкнути WebGL2 → fallback і перевірити лог попередження.
+- [ ] Переконатися, що CPU‑fallback не має візуальних зсувів.

--- a/src/db/player-units-db.ts
+++ b/src/db/player-units-db.ts
@@ -432,6 +432,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
             fill: { type: "solid", fill: { fillType: FILL_TYPES.SOLID, color: { r: 1, g: 0.6, b: 0.24, a: 0.75 } } },
             anim: { type: "sway", periodMs: 1650, amplitude: 5.6, falloff: "tip", axis: "normal", phase: 0.42 },
             groupId: "burningTail-glow",
+            connectionSlots: [{ id: "tailEnd", mode: "spine", index: 1 }],
           },
           { epsilon: 0.2, winding: "CCW" }
         ),
@@ -439,19 +440,20 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
           shape: "polygon",
           requiresModule: "burningTail",
           vertices: [
-            { x: -34.4, y: -1.3 },
-            { x: -38.2, y: -0.7 },
-            { x: -33.8, y: -0.2 },
-            { x: -31.0, y: -0.7 },
+            { x: 0.6, y: -0.1 },
+            { x: -3.2, y: 0.5 },
+            { x: 1.2, y: 1.0 },
+            { x: 4.0, y: 0.5 },
           ],
           fill: { type: "solid", fill: { fillType: FILL_TYPES.SOLID, color: { r: 1, g: 0.58, b: 0.2, a: 0.85 } } },
           stroke: { type: "solid", width: 0.6, color: { r: 0.75, g: 0.22, b: 0.05, a: 1 } },
+          join: { anchorId: "tailEnd", targetGroupId: "burningTail-glow" },
         },
         {
           shape: "circle",
           requiresModule: "burningTail",
           radius: 22,
-          offset: { x: -36.6, y: -1.4 },
+          offset: { x: -1.6, y: -0.2 },
           fill: {
             type: "gradient",
             fill: {
@@ -463,6 +465,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
               ],
             },
           },
+          join: { anchorId: "tailEnd", targetGroupId: "burningTail-glow" },
         },
 
         // Freezing tail (crystal spine + glow)
@@ -507,6 +510,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
             fill: { type: "solid", fill: { fillType: FILL_TYPES.SOLID, color: { r: 0.66, g: 0.95, b: 1, a: 0.78 } } },
             anim: { type: "sway", periodMs: 1880, amplitude: 5.4, falloff: "tip", axis: "normal", phase: 0.48 },
             groupId: "freezingTail-glow",
+            connectionSlots: [{ id: "tailEnd", mode: "spine", index: 1 }],
           },
           { epsilon: 0.2, winding: "CCW" }
         ),
@@ -514,19 +518,20 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
           shape: "polygon",
           requiresModule: "freezingTail",
           vertices: [
-            { x: -33.0, y: -0.9 },
-            { x: -36.4, y: -0.5 },
-            { x: -32.4, y: -0.1 },
-            { x: -30.0, y: -0.6 },
+            { x: 1.0, y: -0.5 },
+            { x: -2.4, y: -0.1 },
+            { x: 1.6, y: 0.3 },
+            { x: 4.0, y: -0.2 },
           ],
           fill: { type: "solid", fill: { fillType: FILL_TYPES.SOLID, color: { r: 0.66, g: 0.95, b: 1, a: 0.85 } } },
           stroke: { type: "solid", width: 0.6, color: { r: 0.24, g: 0.62, b: 0.95, a: 1 } },
+          join: { anchorId: "tailEnd", targetGroupId: "freezingTail-glow" },
         },
         {
           shape: "circle",
           requiresModule: "freezingTail",
           radius: 22.0,
-          offset: { x: -35.2, y: -0.6 },
+          offset: { x: -1.2, y: -0.2 },
           fill: {
             type: "gradient",
             fill: {
@@ -538,6 +543,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
               ],
             },
           },
+          join: { anchorId: "tailEnd", targetGroupId: "freezingTail-glow" },
         },
 
         // Effects

--- a/src/db/player-units-db.ts
+++ b/src/db/player-units-db.ts
@@ -432,7 +432,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
             fill: { type: "solid", fill: { fillType: FILL_TYPES.SOLID, color: { r: 1, g: 0.6, b: 0.24, a: 0.75 } } },
             anim: { type: "sway", periodMs: 1650, amplitude: 5.6, falloff: "tip", axis: "normal", phase: 0.42 },
             groupId: "burningTail-glow",
-            connectionSlots: [{ id: "tailEnd", mode: "spine", index: 1 }],
+            connectionSlots: [{ id: "tailEnd", mode: "spine", t: 1 }],
           },
           { epsilon: 0.2, winding: "CCW" }
         ),
@@ -510,7 +510,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
             fill: { type: "solid", fill: { fillType: FILL_TYPES.SOLID, color: { r: 0.66, g: 0.95, b: 1, a: 0.78 } } },
             anim: { type: "sway", periodMs: 1880, amplitude: 5.4, falloff: "tip", axis: "normal", phase: 0.48 },
             groupId: "freezingTail-glow",
-            connectionSlots: [{ id: "tailEnd", mode: "spine", index: 1 }],
+            connectionSlots: [{ id: "tailEnd", mode: "spine", t: 1 }],
           },
           { epsilon: 0.2, winding: "CCW" }
         ),

--- a/src/shared/helpers/renderer-clone.helper.ts
+++ b/src/shared/helpers/renderer-clone.helper.ts
@@ -136,6 +136,15 @@ const cloneRendererLayerShape = (
   };
 };
 
+const cloneRendererLayerAnchors = (
+  anchors: PlayerUnitRendererLayerConfig["anchors"] | undefined
+): PlayerUnitRendererLayerConfig["anchors"] | undefined => {
+  if (!anchors) {
+    return undefined;
+  }
+  return anchors.map((anchor) => ({ ...anchor }));
+};
+
 /**
  * Clones a PlayerUnitRendererLayerConfig.
  */
@@ -153,6 +162,15 @@ export const cloneRendererLayer = (
     requiresEffect: layer.requiresEffect,
     anim: layer.anim,
     groupId: layer.groupId,
+    anchors: cloneRendererLayerAnchors(layer.anchors),
+    connectionSlots: cloneRendererLayerAnchors(layer.connectionSlots),
+    join: layer.join
+      ? {
+          anchorId: layer.join.anchorId,
+          targetGroupId: layer.join.targetGroupId,
+          offset: layer.join.offset ? { ...layer.join.offset } : undefined,
+        }
+      : undefined,
   };
 
   if (layer.shape === "polygon") {

--- a/src/shared/types/renderer.types.ts
+++ b/src/shared/types/renderer.types.ts
@@ -20,13 +20,27 @@ export interface RendererLayerAnimationConfig {
   executionMode?: "gpu" | "cpu" | "auto";
 }
 
-export type RendererLayerAnchorMode = "vertex" | "spine";
+export type RendererLayerAnchorMode = "vertex" | "spine" | "circle" | "sprite";
+
+export type RendererSpriteAnchorName =
+  | "center"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+  | "top"
+  | "bottom"
+  | "left"
+  | "right";
 
 export interface RendererLayerAnchorConfig {
   id: string;
   mode: RendererLayerAnchorMode;
   index?: number;
   t?: number;
+  angleRad?: number;
+  spriteAnchor?: RendererSpriteAnchorName;
+  uv?: SceneVector2;
 }
 
 export interface RendererLayerJoinConfig {

--- a/src/shared/types/renderer.types.ts
+++ b/src/shared/types/renderer.types.ts
@@ -29,6 +29,12 @@ export interface RendererLayerAnchorConfig {
   t?: number;
 }
 
+export interface RendererLayerJoinConfig {
+  anchorId: string;
+  targetGroupId?: string;
+  offset?: SceneVector2;
+}
+
 /**
  * Base fields shared by all renderer layer configurations.
  */
@@ -42,6 +48,8 @@ export interface BaseRendererLayerFields {
   anim?: RendererLayerAnimationConfig;
   groupId?: string;
   anchors?: RendererLayerAnchorConfig[];
+  connectionSlots?: RendererLayerAnchorConfig[];
+  join?: RendererLayerJoinConfig;
 }
 
 /**

--- a/src/ui/renderers/objects/implementations/enemy/composite-helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-helpers.ts
@@ -59,6 +59,8 @@ export const sanitizeCompositeLayer = (
     buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
     groupId?: string;
     anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+    connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+    join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
   }
 ): {
   shape: "polygon" | "circle" | "sprite";
@@ -77,6 +79,8 @@ export const sanitizeCompositeLayer = (
   buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
   groupId?: string;
   anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+  connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+  join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
 } | null => {
   return sanitizeEnemyCompositeLayer(layer);
 };
@@ -89,6 +93,8 @@ type EnemyLayerExtras = {
   buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
   groupId?: string;
   anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+  connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+  join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
 };
 
 const sanitizeEnemyCompositeLayer = createCompositeLayerSanitizer<
@@ -109,6 +115,8 @@ const sanitizeEnemyCompositeLayer = createCompositeLayerSanitizer<
     buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
     groupId?: string;
     anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+    connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+    join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
   },
   EnemyLayerExtras
 >({
@@ -144,5 +152,7 @@ const sanitizeEnemyCompositeLayer = createCompositeLayerSanitizer<
     buildOpts: layer.buildOpts,
     groupId: layer.groupId,
     anchors: layer.anchors,
+    connectionSlots: layer.connectionSlots,
+    join: layer.join,
   }),
 });

--- a/src/ui/renderers/objects/implementations/enemy/composite-helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-helpers.ts
@@ -6,6 +6,7 @@ import type {
 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import type { EnemyRendererCompositeConfig } from "@db/enemies-db";
 import type { RendererFillConfig, RendererStrokeConfig } from "@shared/types/renderer-config";
+import type { RendererLayerAnchorConfig } from "@shared/types/renderer.types";
 import {
   type CompositeRendererLayerFill,
   type CompositeRendererLayerStroke,
@@ -58,8 +59,8 @@ export const sanitizeCompositeLayer = (
     segmentIndex?: number;
     buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
     groupId?: string;
-    anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
-    connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+    anchors?: RendererLayerAnchorConfig[];
+    connectionSlots?: RendererLayerAnchorConfig[];
     join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
   }
 ): {
@@ -78,8 +79,8 @@ export const sanitizeCompositeLayer = (
   segmentIndex?: number;
   buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
   groupId?: string;
-  anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
-  connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+  anchors?: RendererLayerAnchorConfig[];
+  connectionSlots?: RendererLayerAnchorConfig[];
   join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
 } | null => {
   return sanitizeEnemyCompositeLayer(layer);
@@ -92,8 +93,8 @@ type EnemyLayerExtras = {
   segmentIndex?: number;
   buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
   groupId?: string;
-  anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
-  connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+  anchors?: RendererLayerAnchorConfig[];
+  connectionSlots?: RendererLayerAnchorConfig[];
   join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
 };
 
@@ -114,8 +115,8 @@ const sanitizeEnemyCompositeLayer = createCompositeLayerSanitizer<
     segmentIndex?: number;
     buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
     groupId?: string;
-    anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
-    connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+    anchors?: RendererLayerAnchorConfig[];
+    connectionSlots?: RendererLayerAnchorConfig[];
     join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
   },
   EnemyLayerExtras

--- a/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
@@ -9,6 +9,8 @@ import {
   createDynamicPolygonStrokePrimitive,
   createDynamicSpritePrimitive,
   createPolygonGpuPrimitive,
+  createJoinedPolygonGpuPrimitive,
+  createJoinedCircleGpuPrimitive,
 } from "../../../primitives";
 import type { DynamicPrimitive } from "../../ObjectRenderer";
 import type { EnemyRendererCompositeConfig } from "@db/enemies-db";
@@ -19,13 +21,24 @@ import {
   sanitizeCompositeLayer,
 } from "./composite-helpers";
 import { getNowMs } from "@shared/helpers/time.helper";
-import { resolveLayerAnchors, writeAnchorsForLayer } from "../../shared/anchors";
+import {
+  mergeLayerAnchors,
+  resolveJoinOffset,
+  resolveLayerAnchors,
+  writeAnchorsForLayer,
+} from "../../shared/anchors";
+import {
+  createPolygonAnchorGpuPrimitive,
+  createSpineAnchorGpuPrimitive,
+  getGpuAnchorIndex,
+} from "../../shared/anchors-gpu";
 import {
   createPolygonAnimSampler,
   createSpineSwaySampler,
   resolveAnimationExecutionMode,
 } from "../../shared/animation-pipeline";
 import { isAnimationGpuAvailable } from "../../shared/animation-gpu";
+import type { RendererLayerAnchorConfig } from "@shared/types/renderer.types";
 
 const POLYGON_SWAY_PHASE_STEP = 0.3; // Phase difference between vertices for wave-like animation
 
@@ -42,6 +55,42 @@ export const createCompositePrimitives = (
   renderer: EnemyRendererCompositeConfig,
   dynamicPrimitives: DynamicPrimitive[]
 ): void => {
+  const emptyData = new Float32Array(0);
+  const normalizeGroupId = (groupId: string | undefined): string => groupId ?? "default";
+  const gpuJoinAvailable = isAnimationGpuAvailable();
+  const supportsGpuJoin = (layer: { shape?: string }): boolean =>
+    gpuJoinAvailable && (layer.shape === "polygon" || layer.shape === "circle");
+  const warnedJoinFallbacks = new Set<string>();
+  const warnJoinFallback = (key: string, reason: string) => {
+    if (warnedJoinFallbacks.has(key)) {
+      return;
+    }
+    warnedJoinFallbacks.add(key);
+    console.warn(`[CompositeRenderer] GPU join fallback (${reason}) for ${key}.`);
+  };
+  const joinTargets = new Set<string>();
+  renderer.layers.forEach((layer) => {
+    if (layer.join && !supportsGpuJoin(layer)) {
+      joinTargets.add(normalizeGroupId(layer.join.targetGroupId));
+    }
+  });
+  const collectAnchors = (layer: {
+    anchors?: RendererLayerAnchorConfig[];
+    connectionSlots?: RendererLayerAnchorConfig[];
+  }): RendererLayerAnchorConfig[] => mergeLayerAnchors(layer.anchors, layer.connectionSlots);
+  const resolveJoinOffsetForLayer = (layer: {
+    join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
+    offset?: { x: number; y: number };
+  }) =>
+    layer.join
+      ? (target: SceneObjectInstance) =>
+          resolveJoinOffset({
+            instanceId: target.id,
+            join: layer.join,
+            baseOffset: layer.offset,
+          })
+      : undefined;
+
   // Process each layer
   renderer.layers.forEach((layerConfig, layerIndex) => {
     const layer = sanitizeCompositeLayer(layerConfig);
@@ -50,9 +99,67 @@ export const createCompositePrimitives = (
     }
 
     if (layer.shape === "polygon") {
+      const joinOffset = resolveJoinOffsetForLayer(layer);
+      const getOffset = joinOffset ? joinOffset : undefined;
+      const staticOffset = joinOffset ? undefined : layer.offset;
+      const anchorIndex = layer.join && supportsGpuJoin(layer)
+        ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
+        : null;
+      const joinOffsetForGpu = layer.join
+        ? {
+            x: (layer.offset?.x ?? 0) + (layer.join.offset?.x ?? 0),
+            y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
+          }
+        : undefined;
+      const canUseGpuJoin = anchorIndex !== null && !layer.anim;
+      const groupKey = normalizeGroupId(layer.groupId);
+      const needsCpuAnchors = joinTargets.has(groupKey);
       // Handle polygon layers
       if (!layer.vertices || layer.vertices.length < 3) {
         return;
+      }
+      if (layer.join && !supportsGpuJoin(layer)) {
+        const warnKey = `${instance.id}:${layer.join.targetGroupId ?? "default"}:${layer.join.anchorId}`;
+        warnJoinFallback(warnKey, "gpu-unavailable");
+      }
+      if (layer.join && supportsGpuJoin(layer) && anchorIndex === null) {
+        const warnKey = `${instance.id}:${layer.join.targetGroupId ?? "default"}:${layer.join.anchorId}`;
+        warnJoinFallback(warnKey, "anchor-missing");
+      }
+      if (layer.join && canUseGpuJoin) {
+        const fillPrimitive = createJoinedPolygonGpuPrimitive(instance, {
+          vertices: layer.vertices,
+          fill: resolveLayerFill(instance, layer.fill, renderer),
+          anchorIndex,
+          joinOffset: joinOffsetForGpu,
+          refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
+        });
+        if (fillPrimitive) {
+          dynamicPrimitives.push(fillPrimitive);
+        }
+        if (layer.stroke) {
+          const strokeColor =
+            layer.stroke.kind === "solid"
+              ? layer.stroke.color
+              : resolveStrokeColor(instance, renderer.stroke?.color, renderer.fill);
+          const sceneStroke: SceneStroke = {
+            width: layer.stroke.width,
+            color: strokeColor,
+          };
+          const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
+            vertices: layer.vertices,
+            stroke: sceneStroke,
+            offset: staticOffset,
+            getOffset,
+          });
+          if (getOffset) {
+            strokePrimitive.autoAnimate = true;
+          }
+          dynamicPrimitives.push(strokePrimitive);
+        }
+        if (fillPrimitive) {
+          return;
+        }
       }
 
       // Sway animation for tentacle segments built from a line spine (like player units)
@@ -70,15 +177,29 @@ export const createCompositePrimitives = (
           timeSource: getAnimationTimeMs,
           executionMode,
         });
-        const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
+        const anchorConfigs = collectAnchors(layer);
+        const hasAnchors = anchorConfigs.length > 0;
+        if (executionMode === "gpu" && hasAnchors) {
+          const gpuAnchorPrimitive = createSpineAnchorGpuPrimitive({
+            instance,
+            groupId: layer.groupId,
+            anchors: anchorConfigs,
+            spine: layer.spine,
+            anim: layer.anim,
+            offset: staticOffset,
+          });
+          if (gpuAnchorPrimitive) {
+            dynamicPrimitives.push(gpuAnchorPrimitive);
+          }
+        }
         const sampleVertices = () => {
           const quadVerts = sampler.getVertices();
-          if (hasAnchors) {
+          if (hasAnchors && needsCpuAnchors) {
             const resolved = resolveLayerAnchors(
-              layer.anchors,
+              anchorConfigs,
               quadVerts,
               sampler.getDeformedSpine(),
-              layer.offset
+              staticOffset
             );
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
@@ -98,7 +219,8 @@ export const createCompositePrimitives = (
             createDynamicPolygonStrokePrimitive(instance, {
               getVertices: sampleVertices,
               stroke: sceneStroke,
-              offset: layer.offset,
+              offset: staticOffset,
+              getOffset,
             })
           );
         }
@@ -106,7 +228,8 @@ export const createCompositePrimitives = (
         dynamicPrimitives.push(
           createDynamicPolygonPrimitive(instance, {
             getVertices: sampleVertices,
-            offset: layer.offset,
+            offset: staticOffset,
+            getOffset,
             fill: tentacleFill,
           })
         );
@@ -123,8 +246,10 @@ export const createCompositePrimitives = (
           gpuAvailable: isAnimationGpuAvailable(),
           warnKey: `enemy:${instance.id}:polygon:${layer.groupId ?? layerIndex}`,
         });
-        const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
-        const needsCpuVertices = executionMode !== "gpu" || Boolean(layer.stroke || hasAnchors);
+        const anchorConfigs = collectAnchors(layer);
+        const hasAnchors = anchorConfigs.length > 0;
+        const needsCpuVertices =
+          executionMode !== "gpu" || Boolean(layer.stroke) || (hasAnchors && needsCpuAnchors);
         const sampler = needsCpuVertices
           ? createPolygonAnimSampler({
               vertices: baseVertices,
@@ -136,8 +261,8 @@ export const createCompositePrimitives = (
           : null;
         const getDeformedVertices = () => {
           const deformed = sampler ? sampler.getVertices() : baseVertices;
-          if (hasAnchors) {
-            const resolved = resolveLayerAnchors(layer.anchors, deformed, undefined, layer.offset);
+          if (hasAnchors && needsCpuAnchors) {
+            const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return deformed;
@@ -153,7 +278,8 @@ export const createCompositePrimitives = (
             createDynamicPolygonStrokePrimitive(instance, {
               getVertices: () => getDeformedVertices(),
               stroke: sceneStroke,
-              offset: layer.offset,
+              offset: staticOffset,
+              getOffset,
             })
           );
         }
@@ -163,28 +289,63 @@ export const createCompositePrimitives = (
             vertices: baseVertices,
             anim: animCfg,
             fill: animatedLayerFill,
-            offset: layer.offset,
+            offset: staticOffset,
             phaseStep: POLYGON_SWAY_PHASE_STEP,
           });
           if (gpuPrimitive) {
             dynamicPrimitives.push(gpuPrimitive);
+            if (hasAnchors) {
+              const anchorGpuPrimitive = createPolygonAnchorGpuPrimitive({
+                instance,
+                groupId: layer.groupId,
+                anchors: anchorConfigs,
+                vertices: baseVertices,
+                anim: animCfg,
+                offset: staticOffset,
+                phaseStep: POLYGON_SWAY_PHASE_STEP,
+              });
+              if (anchorGpuPrimitive) {
+                dynamicPrimitives.push(anchorGpuPrimitive);
+              }
+            }
+            if (hasAnchors && sampler && needsCpuAnchors) {
+              const anchorPrimitive: DynamicPrimitive = {
+                get data() {
+                  return emptyData;
+                },
+                autoAnimate: true,
+                update: () => {
+                  const deformed = sampler.getVertices();
+                  const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
+                  writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+                  return null;
+                },
+              };
+              dynamicPrimitives.push(anchorPrimitive);
+            }
           } else {
-            dynamicPrimitives.push(
-              createDynamicPolygonPrimitive(instance, {
-                getVertices: () => getDeformedVertices(),
-                offset: layer.offset,
-                fill: animatedLayerFill,
-              })
-            );
+            const primitive = createDynamicPolygonPrimitive(instance, {
+              getVertices: () => getDeformedVertices(),
+              offset: staticOffset,
+              getOffset,
+              fill: animatedLayerFill,
+            });
+            if (getOffset) {
+              primitive.autoAnimate = true;
+            }
+            dynamicPrimitives.push(primitive);
           }
         } else {
-          dynamicPrimitives.push(
-            createDynamicPolygonPrimitive(instance, {
-              getVertices: () => getDeformedVertices(),
-              offset: layer.offset,
-              fill: animatedLayerFill,
-            })
-          );
+          const primitive = createDynamicPolygonPrimitive(instance, {
+            getVertices: () => getDeformedVertices(),
+            offset: staticOffset,
+            getOffset,
+            fill: animatedLayerFill,
+          });
+          if (getOffset) {
+            primitive.autoAnimate = true;
+          }
+          dynamicPrimitives.push(primitive);
         }
       } else {
         // Static polygon layer
@@ -201,64 +362,107 @@ export const createCompositePrimitives = (
             createDynamicPolygonStrokePrimitive(instance, {
               vertices: layer.vertices,
               stroke: sceneStroke,
-              offset: layer.offset,
+              offset: staticOffset,
+              getOffset,
             })
           );
         }
         const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
-        if (Array.isArray(layer.anchors) && layer.anchors.length > 0) {
-          const resolved = resolveLayerAnchors(layer.anchors, layer.vertices, layer.spine, layer.offset);
+        const anchorConfigs = collectAnchors(layer);
+        if (anchorConfigs.length > 0 && needsCpuAnchors) {
+          const resolved = resolveLayerAnchors(anchorConfigs, layer.vertices, layer.spine, staticOffset);
           writeAnchorsForLayer(instance.id, layer.groupId, resolved);
         }
-        dynamicPrimitives.push(
-          createDynamicPolygonPrimitive(instance, {
-            vertices: layer.vertices,
-            offset: layer.offset,
-            fill: cachedFill,
-          })
-        );
+        const primitive = createDynamicPolygonPrimitive(instance, {
+          vertices: layer.vertices,
+          offset: staticOffset,
+          getOffset,
+          fill: cachedFill,
+        });
+        if (getOffset) {
+          primitive.autoAnimate = true;
+        }
+        dynamicPrimitives.push(primitive);
       }
       return;
     }
 
     if (layer.shape === "circle") {
+      const joinOffset = resolveJoinOffsetForLayer(layer);
+      const getOffset = joinOffset ? joinOffset : undefined;
+      const staticOffset = joinOffset ? undefined : layer.offset;
+      const anchorIndex = layer.join && supportsGpuJoin(layer)
+        ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
+        : null;
+      const joinOffsetForGpu = layer.join
+        ? {
+            x: (layer.offset?.x ?? 0) + (layer.join.offset?.x ?? 0),
+            y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
+          }
+        : undefined;
+      if (layer.join && anchorIndex !== null && !layer.stroke) {
+        const fillPrimitive = createJoinedCircleGpuPrimitive(instance, {
+          radius: layer.radius!,
+          segments: layer.segments,
+          fill: resolveLayerFill(instance, layer.fill, renderer),
+          anchorIndex,
+          joinOffset: joinOffsetForGpu,
+          refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
+        });
+        if (fillPrimitive) {
+          dynamicPrimitives.push(fillPrimitive);
+          return;
+        }
+      }
       // Circle layer
       if (layer.stroke) {
         const cachedStrokeFill = resolveLayerStrokeFill(instance, layer.stroke, renderer);
-        dynamicPrimitives.push(
-          createDynamicCirclePrimitive(instance, {
-            segments: layer.segments,
-            offset: layer.offset,
-            radius: layer.radius! + layer.stroke.width,
-            fill: cachedStrokeFill,
-          })
-        );
+        const strokePrimitive = createDynamicCirclePrimitive(instance, {
+          segments: layer.segments,
+          offset: staticOffset,
+          getOffset,
+          radius: layer.radius! + layer.stroke.width,
+          fill: cachedStrokeFill,
+        });
+        if (getOffset) {
+          strokePrimitive.autoAnimate = true;
+        }
+        dynamicPrimitives.push(strokePrimitive);
       }
       const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
-      dynamicPrimitives.push(
-        createDynamicCirclePrimitive(instance, {
-          segments: layer.segments,
-          offset: layer.offset,
-          radius: layer.radius!,
-          fill: cachedFill,
-        })
-      );
+      const circlePrimitive = createDynamicCirclePrimitive(instance, {
+        segments: layer.segments,
+        offset: staticOffset,
+        getOffset,
+        radius: layer.radius!,
+        fill: cachedFill,
+      });
+      if (getOffset) {
+        circlePrimitive.autoAnimate = true;
+      }
+      dynamicPrimitives.push(circlePrimitive);
       return;
     }
 
     if (layer.shape === "sprite") {
+      const joinOffset = resolveJoinOffsetForLayer(layer);
+      const getOffset = joinOffset ? joinOffset : undefined;
+      const staticOffset = joinOffset ? undefined : layer.offset;
       // Sprite layer - uses RectanglePrimitive as fallback until texture support is added
       if (!layer.spritePath || typeof layer.width !== "number" || typeof layer.height !== "number") {
         return; // Skip invalid sprite layers
       }
-      dynamicPrimitives.push(
-        createDynamicSpritePrimitive(instance, {
-          spritePath: layer.spritePath,
-          getWidth: () => layer.width!,
-          getHeight: () => layer.height!,
-          offset: layer.offset,
-        })
-      );
+      const spritePrimitive = createDynamicSpritePrimitive(instance, {
+        spritePath: layer.spritePath,
+        getWidth: () => layer.width!,
+        getHeight: () => layer.height!,
+        offset: staticOffset,
+        getOffset,
+      });
+      if (getOffset) {
+        spritePrimitive.autoAnimate = true;
+      }
+      dynamicPrimitives.push(spritePrimitive);
       return;
     }
   });

--- a/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
@@ -11,6 +11,9 @@ import {
   createPolygonGpuPrimitive,
   createJoinedPolygonGpuPrimitive,
   createJoinedCircleGpuPrimitive,
+  createJoinedPolygonStrokeGpuPrimitive,
+  createJoinedCircleStrokeGpuPrimitive,
+  createJoinedSpriteGpuPrimitive,
 } from "../../../primitives";
 import type { DynamicPrimitive } from "../../ObjectRenderer";
 import type { EnemyRendererCompositeConfig } from "@db/enemies-db";
@@ -134,9 +137,7 @@ export const createCompositePrimitives = (
           joinOffset: joinOffsetForGpu,
           refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
         });
-        if (fillPrimitive) {
-          dynamicPrimitives.push(fillPrimitive);
-        }
+        let strokeGpuPrimitive: DynamicPrimitive | null = null;
         if (layer.stroke) {
           const strokeColor =
             layer.stroke.kind === "solid"
@@ -146,18 +147,38 @@ export const createCompositePrimitives = (
             width: layer.stroke.width,
             color: strokeColor,
           };
-          const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
+          strokeGpuPrimitive = createJoinedPolygonStrokeGpuPrimitive(instance, {
             vertices: layer.vertices,
             stroke: sceneStroke,
-            offset: staticOffset,
-            getOffset,
+            anchorIndex,
+            joinOffset: joinOffsetForGpu,
+            refreshStroke: layer.stroke.kind === "base"
+              ? (inst) => ({
+                  width: layer.stroke!.width,
+                  color: resolveStrokeColor(inst, renderer.stroke?.color, renderer.fill),
+                })
+              : undefined,
           });
-          if (getOffset) {
-            strokePrimitive.autoAnimate = true;
+          if (!strokeGpuPrimitive) {
+            const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
+              vertices: layer.vertices,
+              stroke: sceneStroke,
+              offset: staticOffset,
+              getOffset,
+            });
+            if (getOffset) {
+              strokePrimitive.autoAnimate = true;
+            }
+            dynamicPrimitives.push(strokePrimitive);
           }
-          dynamicPrimitives.push(strokePrimitive);
         }
         if (fillPrimitive) {
+          dynamicPrimitives.push(fillPrimitive);
+        }
+        if (strokeGpuPrimitive) {
+          dynamicPrimitives.push(strokeGpuPrimitive);
+        }
+        if (fillPrimitive || strokeGpuPrimitive) {
           return;
         }
       }
@@ -195,12 +216,12 @@ export const createCompositePrimitives = (
         const sampleVertices = () => {
           const quadVerts = sampler.getVertices();
           if (hasAnchors && needsCpuAnchors) {
-            const resolved = resolveLayerAnchors(
-              anchorConfigs,
-              quadVerts,
-              sampler.getDeformedSpine(),
-              staticOffset
-            );
+            const resolved = resolveLayerAnchors({
+              anchors: anchorConfigs,
+              vertices: quadVerts,
+              spine: sampler.getDeformedSpine(),
+              offset: staticOffset,
+            });
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return quadVerts;
@@ -262,7 +283,11 @@ export const createCompositePrimitives = (
         const getDeformedVertices = () => {
           const deformed = sampler ? sampler.getVertices() : baseVertices;
           if (hasAnchors && needsCpuAnchors) {
-            const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
+            const resolved = resolveLayerAnchors({
+              anchors: anchorConfigs,
+              vertices: deformed,
+              offset: staticOffset,
+            });
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return deformed;
@@ -316,7 +341,11 @@ export const createCompositePrimitives = (
                 autoAnimate: true,
                 update: () => {
                   const deformed = sampler.getVertices();
-                  const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
+                  const resolved = resolveLayerAnchors({
+                    anchors: anchorConfigs,
+                    vertices: deformed,
+                    offset: staticOffset,
+                  });
                   writeAnchorsForLayer(instance.id, layer.groupId, resolved);
                   return null;
                 },
@@ -370,7 +399,12 @@ export const createCompositePrimitives = (
         const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
         const anchorConfigs = collectAnchors(layer);
         if (anchorConfigs.length > 0 && needsCpuAnchors) {
-          const resolved = resolveLayerAnchors(anchorConfigs, layer.vertices, layer.spine, staticOffset);
+          const resolved = resolveLayerAnchors({
+            anchors: anchorConfigs,
+            vertices: layer.vertices,
+            spine: layer.spine,
+            offset: staticOffset,
+          });
           writeAnchorsForLayer(instance.id, layer.groupId, resolved);
         }
         const primitive = createDynamicPolygonPrimitive(instance, {
@@ -391,6 +425,16 @@ export const createCompositePrimitives = (
       const joinOffset = resolveJoinOffsetForLayer(layer);
       const getOffset = joinOffset ? joinOffset : undefined;
       const staticOffset = joinOffset ? undefined : layer.offset;
+      const needsCpuAnchors = joinTargets.has(normalizeGroupId(layer.groupId));
+      const anchorConfigs = collectAnchors(layer);
+      if (anchorConfigs.length > 0 && needsCpuAnchors) {
+        const resolved = resolveLayerAnchors({
+          anchors: anchorConfigs,
+          offset: staticOffset,
+          circle: { radius: layer.radius!, segments: layer.segments },
+        });
+        writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+      }
       const anchorIndex = layer.join && supportsGpuJoin(layer)
         ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
         : null;
@@ -400,7 +444,7 @@ export const createCompositePrimitives = (
             y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
           }
         : undefined;
-      if (layer.join && anchorIndex !== null && !layer.stroke) {
+      if (layer.join && anchorIndex !== null) {
         const fillPrimitive = createJoinedCircleGpuPrimitive(instance, {
           radius: layer.radius!,
           segments: layer.segments,
@@ -409,8 +453,51 @@ export const createCompositePrimitives = (
           joinOffset: joinOffsetForGpu,
           refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
         });
+        let strokeGpuPrimitive: DynamicPrimitive | null = null;
+        if (layer.stroke) {
+          const strokeColor =
+            layer.stroke.kind === "solid"
+              ? layer.stroke.color
+              : resolveStrokeColor(instance, renderer.stroke?.color, renderer.fill);
+          const sceneStroke: SceneStroke = {
+            width: layer.stroke.width,
+            color: strokeColor,
+          };
+          strokeGpuPrimitive = createJoinedCircleStrokeGpuPrimitive(instance, {
+            radius: layer.radius!,
+            segments: layer.segments,
+            stroke: sceneStroke,
+            anchorIndex,
+            joinOffset: joinOffsetForGpu,
+            refreshStroke: layer.stroke.kind === "base"
+              ? (inst) => ({
+                  width: layer.stroke!.width,
+                  color: resolveStrokeColor(inst, renderer.stroke?.color, renderer.fill),
+                })
+              : undefined,
+          });
+          if (!strokeGpuPrimitive) {
+            const cachedStrokeFill = resolveLayerStrokeFill(instance, layer.stroke, renderer);
+            const strokePrimitive = createDynamicCirclePrimitive(instance, {
+              segments: layer.segments,
+              offset: staticOffset,
+              getOffset,
+              radius: layer.radius! + layer.stroke.width,
+              fill: cachedStrokeFill,
+            });
+            if (getOffset) {
+              strokePrimitive.autoAnimate = true;
+            }
+            dynamicPrimitives.push(strokePrimitive);
+          }
+        }
         if (fillPrimitive) {
           dynamicPrimitives.push(fillPrimitive);
+        }
+        if (strokeGpuPrimitive) {
+          dynamicPrimitives.push(strokeGpuPrimitive);
+        }
+        if (fillPrimitive || strokeGpuPrimitive) {
           return;
         }
       }
@@ -448,9 +535,41 @@ export const createCompositePrimitives = (
       const joinOffset = resolveJoinOffsetForLayer(layer);
       const getOffset = joinOffset ? joinOffset : undefined;
       const staticOffset = joinOffset ? undefined : layer.offset;
+      const needsCpuAnchors = joinTargets.has(normalizeGroupId(layer.groupId));
+      const anchorConfigs = collectAnchors(layer);
+      if (anchorConfigs.length > 0 && needsCpuAnchors) {
+        const resolved = resolveLayerAnchors({
+          anchors: anchorConfigs,
+          offset: staticOffset,
+          sprite: { width: layer.width!, height: layer.height! },
+        });
+        writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+      }
+      const anchorIndex = layer.join
+        ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
+        : null;
+      const joinOffsetForGpu = layer.join
+        ? {
+            x: (layer.offset?.x ?? 0) + (layer.join.offset?.x ?? 0),
+            y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
+          }
+        : undefined;
       // Sprite layer - uses RectanglePrimitive as fallback until texture support is added
       if (!layer.spritePath || typeof layer.width !== "number" || typeof layer.height !== "number") {
         return; // Skip invalid sprite layers
+      }
+      if (layer.join && anchorIndex !== null) {
+        const spritePrimitive = createJoinedSpriteGpuPrimitive(instance, {
+          spritePath: layer.spritePath,
+          width: layer.width!,
+          height: layer.height!,
+          anchorIndex,
+          joinOffset: joinOffsetForGpu,
+        });
+        if (spritePrimitive) {
+          dynamicPrimitives.push(spritePrimitive);
+          return;
+        }
       }
       const spritePrimitive = createDynamicSpritePrimitive(instance, {
         spritePath: layer.spritePath,

--- a/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
@@ -9,6 +9,8 @@ import {
   createDynamicPolygonStrokePrimitive,
   createDynamicSpritePrimitive,
   createPolygonGpuPrimitive,
+  createJoinedPolygonGpuPrimitive,
+  createJoinedCircleGpuPrimitive,
 } from "../../../primitives";
 import { getInstanceRenderPosition } from "../../ObjectRenderer";
 import type { DynamicPrimitive } from "../../ObjectRenderer";
@@ -18,7 +20,17 @@ import {
   resolveLayerStrokeFill,
   resolveStrokeColor,
 } from "./helpers";
-import { resolveLayerAnchors, writeAnchorsForLayer } from "../../shared/anchors";
+import {
+  mergeLayerAnchors,
+  resolveJoinOffset,
+  resolveLayerAnchors,
+  writeAnchorsForLayer,
+} from "../../shared/anchors";
+import {
+  createPolygonAnchorGpuPrimitive,
+  createSpineAnchorGpuPrimitive,
+  getGpuAnchorIndex,
+} from "../../shared/anchors-gpu";
 import {
   getAuraInstanceMap,
   acquireAuraSlotForInstance,
@@ -32,6 +44,7 @@ import {
   resolveAnimationExecutionMode,
 } from "../../shared/animation-pipeline";
 import { isAnimationGpuAvailable } from "../../shared/animation-gpu";
+import type { RendererLayerAnchorConfig } from "@shared/types/renderer.types";
 
 /**
  * Creates composite primitives for player unit renderer
@@ -101,6 +114,37 @@ export const createCompositePrimitives = (
     auraInstanceMap.set(instanceId, newSlots);
   }
 
+  const emptyData = new Float32Array(0);
+  const normalizeGroupId = (groupId: string | undefined): string => groupId ?? "default";
+  const gpuJoinAvailable = isAnimationGpuAvailable();
+  const supportsGpuJoin = (layer: RendererLayer): boolean =>
+    gpuJoinAvailable && (layer.shape === "polygon" || layer.shape === "circle");
+  const warnedJoinFallbacks = new Set<string>();
+  const warnJoinFallback = (key: string, reason: string) => {
+    if (warnedJoinFallbacks.has(key)) {
+      return;
+    }
+    warnedJoinFallbacks.add(key);
+    console.warn(`[CompositeRenderer] GPU join fallback (${reason}) for ${key}.`);
+  };
+  const joinTargets = new Set<string>();
+  renderer.layers.forEach((layer) => {
+    if (layer.join && !supportsGpuJoin(layer)) {
+      joinTargets.add(normalizeGroupId(layer.join.targetGroupId));
+    }
+  });
+  const collectAnchors = (layer: RendererLayer): RendererLayerAnchorConfig[] =>
+    mergeLayerAnchors(layer.anchors, layer.connectionSlots);
+  const resolveJoinOffsetForLayer = (layer: RendererLayer) =>
+    layer.join
+      ? (target: SceneObjectInstance) =>
+          resolveJoinOffset({
+            instanceId: target.id,
+            join: layer.join,
+            baseOffset: layer.offset,
+          })
+      : undefined;
+
   // Group tentacle segments by groupId for potential future use (not required to animate basic sway)
   renderer.layers.forEach((layer, layerIndex) => {
     // If a layer requires a module, render it only when present
@@ -127,6 +171,67 @@ export const createCompositePrimitives = (
       }
     }
     if (layer.shape === "polygon") {
+      const joinOffset = resolveJoinOffsetForLayer(layer);
+      const getOffset = joinOffset ? joinOffset : undefined;
+      const staticOffset = joinOffset ? undefined : layer.offset;
+      const anchorIndex = layer.join && supportsGpuJoin(layer)
+        ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
+        : null;
+      const joinOffsetForGpu = layer.join
+        ? {
+            x: (layer.offset?.x ?? 0) + (layer.join.offset?.x ?? 0),
+            y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
+          }
+        : undefined;
+      const canUseGpuJoin = anchorIndex !== null && !layer.anim;
+      const groupKey = normalizeGroupId(layer.groupId);
+      const needsCpuAnchors = joinTargets.has(groupKey);
+      if (layer.join && !supportsGpuJoin(layer)) {
+        const warnKey = `${instance.id}:${layer.join.targetGroupId ?? "default"}:${layer.join.anchorId}`;
+        warnJoinFallback(warnKey, "gpu-unavailable");
+      }
+      if (layer.join && supportsGpuJoin(layer) && anchorIndex === null) {
+        const warnKey = `${instance.id}:${layer.join.targetGroupId ?? "default"}:${layer.join.anchorId}`;
+        warnJoinFallback(warnKey, "anchor-missing");
+      }
+      if (layer.join && canUseGpuJoin) {
+        const fillPrimitive = createJoinedPolygonGpuPrimitive(instance, {
+          vertices: layer.vertices,
+          fill: resolveLayerFill(instance, layer.fill, renderer),
+          anchorIndex,
+          joinOffset: joinOffsetForGpu,
+          refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
+        });
+        if (fillPrimitive) {
+          dynamicPrimitives.push(fillPrimitive);
+        } else {
+          // Fallback to CPU path if GPU primitive could not be created
+          // Continue with regular handling below.
+        }
+        if (layer.stroke) {
+          const strokeColor =
+            layer.stroke.kind === "solid"
+              ? layer.stroke.color
+              : resolveStrokeColor(instance, renderer.baseStrokeColor, renderer.baseFillColor);
+          const sceneStroke: SceneStroke = {
+            width: layer.stroke.width,
+            color: strokeColor,
+          };
+          const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
+            vertices: layer.vertices,
+            stroke: sceneStroke,
+            offset: staticOffset,
+            getOffset,
+          });
+          if (getOffset) {
+            strokePrimitive.autoAnimate = true;
+          }
+          dynamicPrimitives.push(strokePrimitive);
+        }
+        if (fillPrimitive) {
+          return;
+        }
+      }
       // Sway animation for tentacle segments built from a line spine
       if (Array.isArray(layer.spine) && layer.anim?.type === "sway") {
         const executionMode = resolveAnimationExecutionMode({
@@ -142,15 +247,29 @@ export const createCompositePrimitives = (
           timeSource: getTentacleTimeMs,
           executionMode,
         });
-        const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
+        const anchorConfigs = collectAnchors(layer);
+        const hasAnchors = anchorConfigs.length > 0;
+        if (executionMode === "gpu" && hasAnchors) {
+          const gpuAnchorPrimitive = createSpineAnchorGpuPrimitive({
+            instance,
+            groupId: layer.groupId,
+            anchors: anchorConfigs,
+            spine: layer.spine,
+            anim: layer.anim,
+            offset: staticOffset,
+          });
+          if (gpuAnchorPrimitive) {
+            dynamicPrimitives.push(gpuAnchorPrimitive);
+          }
+        }
         const sampleVertices = () => {
           const quadVerts = sampler.getVertices();
-          if (hasAnchors) {
+          if (hasAnchors && needsCpuAnchors) {
             const resolved = resolveLayerAnchors(
-              layer.anchors,
+              anchorConfigs,
               quadVerts,
               sampler.getDeformedSpine(),
-              layer.offset
+              staticOffset
             );
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
@@ -171,7 +290,8 @@ export const createCompositePrimitives = (
             createDynamicPolygonStrokePrimitive(instance, {
               getVertices: sampleVertices,
               stroke: sceneStroke,
-              offset: layer.offset,
+              offset: staticOffset,
+              getOffset,
               refreshStroke: layerStrokeForTentacle.kind === "base"
                 ? (inst) => ({
                     width: layerStrokeForTentacle.width,
@@ -189,7 +309,8 @@ export const createCompositePrimitives = (
         dynamicPrimitives.push(
           createDynamicPolygonPrimitive(instance, {
             getVertices: sampleVertices,
-            offset: layer.offset,
+            offset: staticOffset,
+            getOffset,
             fill: tentacleFill,
             refreshFill: (inst) => resolveLayerFill(inst, layerFillForTentacle, renderer),
           })
@@ -205,8 +326,10 @@ export const createCompositePrimitives = (
           gpuAvailable: isAnimationGpuAvailable(),
           warnKey: `player-unit:${instance.id}:polygon:${layer.groupId ?? layerIndex}`,
         });
-        const hasAnchors = Array.isArray(layer.anchors) && layer.anchors.length > 0;
-        const needsCpuVertices = executionMode !== "gpu" || Boolean(layer.stroke || hasAnchors);
+        const anchorConfigs = collectAnchors(layer);
+        const hasAnchors = anchorConfigs.length > 0;
+        const needsCpuVertices =
+          executionMode !== "gpu" || Boolean(layer.stroke) || (hasAnchors && needsCpuAnchors);
         const sampler = needsCpuVertices
           ? createPolygonAnimSampler({
               vertices: layer.vertices,
@@ -219,8 +342,8 @@ export const createCompositePrimitives = (
           : null;
         const getDeformedVertices = () => {
           const deformed = sampler ? sampler.getVertices() : layer.vertices;
-          if (hasAnchors) {
-            const resolved = resolveLayerAnchors(layer.anchors, deformed, undefined, layer.offset);
+          if (hasAnchors && needsCpuAnchors) {
+            const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return deformed;
@@ -237,7 +360,8 @@ export const createCompositePrimitives = (
             createDynamicPolygonStrokePrimitive(instance, {
               getVertices: () => getDeformedVertices(),
               stroke: sceneStroke,
-              offset: layer.offset,
+              offset: staticOffset,
+              getOffset,
               refreshStroke: layerStrokeForAnimated.kind === "base"
                 ? (inst) => ({
                     width: layerStrokeForAnimated.width,
@@ -256,32 +380,68 @@ export const createCompositePrimitives = (
             vertices: layer.vertices,
             anim: animCfg,
             fill: animatedLayerFill,
-            offset: layer.offset,
+            offset: staticOffset,
             phaseStep: POLYGON_SWAY_PHASE_STEP,
             enableMovementAxis: true,
             refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
           });
           if (gpuPrimitive) {
             dynamicPrimitives.push(gpuPrimitive);
+            if (hasAnchors) {
+              const anchorGpuPrimitive = createPolygonAnchorGpuPrimitive({
+                instance,
+                groupId: layer.groupId,
+                anchors: anchorConfigs,
+                vertices: layer.vertices,
+                anim: animCfg,
+                offset: staticOffset,
+                phaseStep: POLYGON_SWAY_PHASE_STEP,
+                enableMovementAxis: true,
+              });
+              if (anchorGpuPrimitive) {
+                dynamicPrimitives.push(anchorGpuPrimitive);
+              }
+            }
+            if (hasAnchors && sampler && needsCpuAnchors) {
+              const anchorPrimitive: DynamicPrimitive = {
+                get data() {
+                  return emptyData;
+                },
+                autoAnimate: true,
+                update: () => {
+                  const deformed = sampler.getVertices();
+                  const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
+                  writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+                  return null;
+                },
+              };
+              dynamicPrimitives.push(anchorPrimitive);
+            }
           } else {
-            dynamicPrimitives.push(
-              createDynamicPolygonPrimitive(instance, {
-                getVertices: () => getDeformedVertices(),
-                offset: layer.offset,
-                fill: animatedLayerFill,
-                refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
-              })
-            );
-          }
-        } else {
-          dynamicPrimitives.push(
-            createDynamicPolygonPrimitive(instance, {
+            const primitive = createDynamicPolygonPrimitive(instance, {
               getVertices: () => getDeformedVertices(),
-              offset: layer.offset,
+              offset: staticOffset,
+              getOffset,
               fill: animatedLayerFill,
               refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
-            })
-          );
+            });
+            if (getOffset) {
+              primitive.autoAnimate = true;
+            }
+            dynamicPrimitives.push(primitive);
+          }
+        } else {
+          const primitive = createDynamicPolygonPrimitive(instance, {
+            getVertices: () => getDeformedVertices(),
+            offset: staticOffset,
+            getOffset,
+            fill: animatedLayerFill,
+            refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
+          });
+          if (getOffset) {
+            primitive.autoAnimate = true;
+          }
+          dynamicPrimitives.push(primitive);
         }
       } else {
         if (layer.stroke) {
@@ -298,7 +458,8 @@ export const createCompositePrimitives = (
             createDynamicPolygonStrokePrimitive(instance, {
               vertices: layer.vertices,
               stroke: sceneStroke,
-              offset: layer.offset,
+              offset: staticOffset,
+              getOffset,
               refreshStroke: layerStrokeForStatic.kind === "base"
                 ? (inst) => ({
                     width: layerStrokeForStatic.width,
@@ -312,64 +473,106 @@ export const createCompositePrimitives = (
         // Always add refreshFill to track visual effect changes
         const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
         const layerFillForStatic = layer.fill;
-        if (Array.isArray(layer.anchors) && layer.anchors.length > 0) {
-          const resolved = resolveLayerAnchors(layer.anchors, layer.vertices, layer.spine, layer.offset);
+        const anchorConfigs = collectAnchors(layer);
+        if (anchorConfigs.length > 0 && needsCpuAnchors) {
+          const resolved = resolveLayerAnchors(anchorConfigs, layer.vertices, layer.spine, staticOffset);
           writeAnchorsForLayer(instance.id, layer.groupId, resolved);
         }
-        dynamicPrimitives.push(
-          createDynamicPolygonPrimitive(instance, {
-            vertices: layer.vertices,
-            offset: layer.offset,
-            fill: cachedFill,
-            refreshFill: (inst) => resolveLayerFill(inst, layerFillForStatic, renderer),
-          })
-        );
+        const primitive = createDynamicPolygonPrimitive(instance, {
+          vertices: layer.vertices,
+          offset: staticOffset,
+          getOffset,
+          fill: cachedFill,
+          refreshFill: (inst) => resolveLayerFill(inst, layerFillForStatic, renderer),
+        });
+        if (getOffset) {
+          primitive.autoAnimate = true;
+        }
+        dynamicPrimitives.push(primitive);
       }
       return;
     }
 
     if (layer.shape === "circle") {
+      const joinOffset = resolveJoinOffsetForLayer(layer);
+      const getOffset = joinOffset ? joinOffset : undefined;
+      const staticOffset = joinOffset ? undefined : layer.offset;
+      const anchorIndex = layer.join && supportsGpuJoin(layer)
+        ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
+        : null;
+      const joinOffsetForGpu = layer.join
+        ? {
+            x: (layer.offset?.x ?? 0) + (layer.join.offset?.x ?? 0),
+            y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
+          }
+        : undefined;
+      if (layer.join && anchorIndex !== null && !layer.stroke) {
+        const fillPrimitive = createJoinedCircleGpuPrimitive(instance, {
+          radius: layer.radius,
+          segments: layer.segments,
+          fill: resolveLayerFill(instance, layer.fill, renderer),
+          anchorIndex,
+          joinOffset: joinOffsetForGpu,
+          refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
+        });
+        if (fillPrimitive) {
+          dynamicPrimitives.push(fillPrimitive);
+          return;
+        }
+      }
       // OPTIMIZATION: Cache fills at registration time for static layers
       if (layer.stroke) {
         const layerStrokeForCircle = layer.stroke;
         const cachedStrokeFill = resolveLayerStrokeFill(instance, layer.stroke, renderer);
-        dynamicPrimitives.push(
-          createDynamicCirclePrimitive(instance, {
-            segments: layer.segments,
-            offset: layer.offset,
-            radius: layer.radius + layer.stroke.width,
-            fill: cachedStrokeFill,
-            refreshFill: layerStrokeForCircle.kind === "base"
-              ? (inst) => resolveLayerStrokeFill(inst, layerStrokeForCircle, renderer)
-              : undefined,
-          })
-        );
+        const strokePrimitive = createDynamicCirclePrimitive(instance, {
+          segments: layer.segments,
+          offset: staticOffset,
+          getOffset,
+          radius: layer.radius + layer.stroke.width,
+          fill: cachedStrokeFill,
+          refreshFill: layerStrokeForCircle.kind === "base"
+            ? (inst) => resolveLayerStrokeFill(inst, layerStrokeForCircle, renderer)
+            : undefined,
+        });
+        if (getOffset) {
+          strokePrimitive.autoAnimate = true;
+        }
+        dynamicPrimitives.push(strokePrimitive);
       }
       // Always add refreshFill to track visual effect changes
       const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
       const layerFillForCircle = layer.fill;
-      dynamicPrimitives.push(
-        createDynamicCirclePrimitive(instance, {
-          segments: layer.segments,
-          offset: layer.offset,
-          radius: layer.radius,
-          fill: cachedFill,
-          refreshFill: (inst) => resolveLayerFill(inst, layerFillForCircle, renderer),
-        })
-      );
+      const circlePrimitive = createDynamicCirclePrimitive(instance, {
+        segments: layer.segments,
+        offset: staticOffset,
+        getOffset,
+        radius: layer.radius,
+        fill: cachedFill,
+        refreshFill: (inst) => resolveLayerFill(inst, layerFillForCircle, renderer),
+      });
+      if (getOffset) {
+        circlePrimitive.autoAnimate = true;
+      }
+      dynamicPrimitives.push(circlePrimitive);
       return;
     }
 
     if (layer.shape === "sprite") {
+      const joinOffset = resolveJoinOffsetForLayer(layer);
+      const getOffset = joinOffset ? joinOffset : undefined;
+      const staticOffset = joinOffset ? undefined : layer.offset;
       // Sprite layer - uses RectanglePrimitive as fallback until texture support is added
-      dynamicPrimitives.push(
-        createDynamicSpritePrimitive(instance, {
-          spritePath: layer.spritePath,
-          getWidth: () => layer.width,
-          getHeight: () => layer.height,
-          offset: layer.offset,
-        })
-      );
+      const spritePrimitive = createDynamicSpritePrimitive(instance, {
+        spritePath: layer.spritePath,
+        getWidth: () => layer.width,
+        getHeight: () => layer.height,
+        offset: staticOffset,
+        getOffset,
+      });
+      if (getOffset) {
+        spritePrimitive.autoAnimate = true;
+      }
+      dynamicPrimitives.push(spritePrimitive);
       return;
     }
   });

--- a/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
@@ -11,6 +11,9 @@ import {
   createPolygonGpuPrimitive,
   createJoinedPolygonGpuPrimitive,
   createJoinedCircleGpuPrimitive,
+  createJoinedPolygonStrokeGpuPrimitive,
+  createJoinedCircleStrokeGpuPrimitive,
+  createJoinedSpriteGpuPrimitive,
 } from "../../../primitives";
 import { getInstanceRenderPosition } from "../../ObjectRenderer";
 import type { DynamicPrimitive } from "../../ObjectRenderer";
@@ -202,12 +205,7 @@ export const createCompositePrimitives = (
           joinOffset: joinOffsetForGpu,
           refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
         });
-        if (fillPrimitive) {
-          dynamicPrimitives.push(fillPrimitive);
-        } else {
-          // Fallback to CPU path if GPU primitive could not be created
-          // Continue with regular handling below.
-        }
+        let strokeGpuPrimitive: DynamicPrimitive | null = null;
         if (layer.stroke) {
           const strokeColor =
             layer.stroke.kind === "solid"
@@ -217,18 +215,38 @@ export const createCompositePrimitives = (
             width: layer.stroke.width,
             color: strokeColor,
           };
-          const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
+          strokeGpuPrimitive = createJoinedPolygonStrokeGpuPrimitive(instance, {
             vertices: layer.vertices,
             stroke: sceneStroke,
-            offset: staticOffset,
-            getOffset,
+            anchorIndex,
+            joinOffset: joinOffsetForGpu,
+            refreshStroke: layer.stroke.kind === "base"
+              ? (inst) => ({
+                  width: layer.stroke!.width,
+                  color: resolveStrokeColor(inst, renderer.baseStrokeColor, renderer.baseFillColor),
+                })
+              : undefined,
           });
-          if (getOffset) {
-            strokePrimitive.autoAnimate = true;
+          if (!strokeGpuPrimitive) {
+            const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
+              vertices: layer.vertices,
+              stroke: sceneStroke,
+              offset: staticOffset,
+              getOffset,
+            });
+            if (getOffset) {
+              strokePrimitive.autoAnimate = true;
+            }
+            dynamicPrimitives.push(strokePrimitive);
           }
-          dynamicPrimitives.push(strokePrimitive);
         }
         if (fillPrimitive) {
+          dynamicPrimitives.push(fillPrimitive);
+        }
+        if (strokeGpuPrimitive) {
+          dynamicPrimitives.push(strokeGpuPrimitive);
+        }
+        if (fillPrimitive || strokeGpuPrimitive) {
           return;
         }
       }
@@ -265,12 +283,12 @@ export const createCompositePrimitives = (
         const sampleVertices = () => {
           const quadVerts = sampler.getVertices();
           if (hasAnchors && needsCpuAnchors) {
-            const resolved = resolveLayerAnchors(
-              anchorConfigs,
-              quadVerts,
-              sampler.getDeformedSpine(),
-              staticOffset
-            );
+            const resolved = resolveLayerAnchors({
+              anchors: anchorConfigs,
+              vertices: quadVerts,
+              spine: sampler.getDeformedSpine(),
+              offset: staticOffset,
+            });
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return quadVerts;
@@ -343,7 +361,11 @@ export const createCompositePrimitives = (
         const getDeformedVertices = () => {
           const deformed = sampler ? sampler.getVertices() : layer.vertices;
           if (hasAnchors && needsCpuAnchors) {
-            const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
+            const resolved = resolveLayerAnchors({
+              anchors: anchorConfigs,
+              vertices: deformed,
+              offset: staticOffset,
+            });
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return deformed;
@@ -410,7 +432,11 @@ export const createCompositePrimitives = (
                 autoAnimate: true,
                 update: () => {
                   const deformed = sampler.getVertices();
-                  const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
+                  const resolved = resolveLayerAnchors({
+                    anchors: anchorConfigs,
+                    vertices: deformed,
+                    offset: staticOffset,
+                  });
                   writeAnchorsForLayer(instance.id, layer.groupId, resolved);
                   return null;
                 },
@@ -475,7 +501,12 @@ export const createCompositePrimitives = (
         const layerFillForStatic = layer.fill;
         const anchorConfigs = collectAnchors(layer);
         if (anchorConfigs.length > 0 && needsCpuAnchors) {
-          const resolved = resolveLayerAnchors(anchorConfigs, layer.vertices, layer.spine, staticOffset);
+          const resolved = resolveLayerAnchors({
+            anchors: anchorConfigs,
+            vertices: layer.vertices,
+            spine: layer.spine,
+            offset: staticOffset,
+          });
           writeAnchorsForLayer(instance.id, layer.groupId, resolved);
         }
         const primitive = createDynamicPolygonPrimitive(instance, {
@@ -497,6 +528,16 @@ export const createCompositePrimitives = (
       const joinOffset = resolveJoinOffsetForLayer(layer);
       const getOffset = joinOffset ? joinOffset : undefined;
       const staticOffset = joinOffset ? undefined : layer.offset;
+      const needsCpuAnchors = joinTargets.has(normalizeGroupId(layer.groupId));
+      const anchorConfigs = collectAnchors(layer);
+      if (anchorConfigs.length > 0 && needsCpuAnchors) {
+        const resolved = resolveLayerAnchors({
+          anchors: anchorConfigs,
+          offset: staticOffset,
+          circle: { radius: layer.radius, segments: layer.segments },
+        });
+        writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+      }
       const anchorIndex = layer.join && supportsGpuJoin(layer)
         ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
         : null;
@@ -506,7 +547,7 @@ export const createCompositePrimitives = (
             y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
           }
         : undefined;
-      if (layer.join && anchorIndex !== null && !layer.stroke) {
+      if (layer.join && anchorIndex !== null) {
         const fillPrimitive = createJoinedCircleGpuPrimitive(instance, {
           radius: layer.radius,
           segments: layer.segments,
@@ -515,8 +556,55 @@ export const createCompositePrimitives = (
           joinOffset: joinOffsetForGpu,
           refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
         });
+        let strokeGpuPrimitive: DynamicPrimitive | null = null;
+        if (layer.stroke) {
+          const strokeColor =
+            layer.stroke.kind === "solid"
+              ? layer.stroke.color
+              : resolveStrokeColor(instance, renderer.baseStrokeColor, renderer.baseFillColor);
+          const sceneStroke: SceneStroke = {
+            width: layer.stroke.width,
+            color: strokeColor,
+          };
+          strokeGpuPrimitive = createJoinedCircleStrokeGpuPrimitive(instance, {
+            radius: layer.radius,
+            segments: layer.segments,
+            stroke: sceneStroke,
+            anchorIndex,
+            joinOffset: joinOffsetForGpu,
+            refreshStroke: layer.stroke.kind === "base"
+              ? (inst) => ({
+                  width: layer.stroke!.width,
+                  color: resolveStrokeColor(inst, renderer.baseStrokeColor, renderer.baseFillColor),
+                })
+              : undefined,
+          });
+          if (!strokeGpuPrimitive) {
+            const layerStrokeForCircle = layer.stroke;
+            const cachedStrokeFill = resolveLayerStrokeFill(instance, layer.stroke, renderer);
+            const strokePrimitive = createDynamicCirclePrimitive(instance, {
+              segments: layer.segments,
+              offset: staticOffset,
+              getOffset,
+              radius: layer.radius + layer.stroke.width,
+              fill: cachedStrokeFill,
+              refreshFill: layerStrokeForCircle.kind === "base"
+                ? (inst) => resolveLayerStrokeFill(inst, layerStrokeForCircle, renderer)
+                : undefined,
+            });
+            if (getOffset) {
+              strokePrimitive.autoAnimate = true;
+            }
+            dynamicPrimitives.push(strokePrimitive);
+          }
+        }
         if (fillPrimitive) {
           dynamicPrimitives.push(fillPrimitive);
+        }
+        if (strokeGpuPrimitive) {
+          dynamicPrimitives.push(strokeGpuPrimitive);
+        }
+        if (fillPrimitive || strokeGpuPrimitive) {
           return;
         }
       }
@@ -561,6 +649,38 @@ export const createCompositePrimitives = (
       const joinOffset = resolveJoinOffsetForLayer(layer);
       const getOffset = joinOffset ? joinOffset : undefined;
       const staticOffset = joinOffset ? undefined : layer.offset;
+      const needsCpuAnchors = joinTargets.has(normalizeGroupId(layer.groupId));
+      const anchorConfigs = collectAnchors(layer);
+      if (anchorConfigs.length > 0 && needsCpuAnchors) {
+        const resolved = resolveLayerAnchors({
+          anchors: anchorConfigs,
+          offset: staticOffset,
+          sprite: { width: layer.width, height: layer.height },
+        });
+        writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+      }
+      const anchorIndex = layer.join
+        ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
+        : null;
+      const joinOffsetForGpu = layer.join
+        ? {
+            x: (layer.offset?.x ?? 0) + (layer.join.offset?.x ?? 0),
+            y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
+          }
+        : undefined;
+      if (layer.join && anchorIndex !== null && layer.spritePath) {
+        const spritePrimitive = createJoinedSpriteGpuPrimitive(instance, {
+          spritePath: layer.spritePath,
+          width: layer.width,
+          height: layer.height,
+          anchorIndex,
+          joinOffset: joinOffsetForGpu,
+        });
+        if (spritePrimitive) {
+          dynamicPrimitives.push(spritePrimitive);
+          return;
+        }
+      }
       // Sprite layer - uses RectanglePrimitive as fallback until texture support is added
       const spritePrimitive = createDynamicSpritePrimitive(instance, {
         spritePath: layer.spritePath,

--- a/src/ui/renderers/objects/shared/anchors-gpu.ts
+++ b/src/ui/renderers/objects/shared/anchors-gpu.ts
@@ -1,0 +1,886 @@
+import type { SceneObjectInstance, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { RendererLayerAnchorConfig, RendererLayerAnimationConfig } from "@shared/types/renderer.types";
+import { getAnimationGpuContext } from "@ui/renderers/objects/shared/animation-gpu";
+import { compileShader } from "@ui/renderers/utils/webglProgram";
+import { DynamicPrimitive } from "@ui/renderers/objects/ObjectRenderer";
+import { getSceneTimelineNow } from "@ui/renderers/primitives/utils/sceneTimeline";
+
+const TF_VERTEX_HEADER = `#version 300 es
+precision highp float;
+`;
+
+const TF_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+out vec4 outColor;
+void main() {
+  outColor = vec4(0.0);
+}
+`;
+
+const POLYGON_ANCHOR_TF_VERTEX_SHADER = `${TF_VERTEX_HEADER}
+layout(location = 0) in vec2 a_position;
+layout(location = 1) in float a_vertexIndex;
+
+uniform float u_timeMs;
+uniform float u_periodMs;
+uniform float u_phase;
+uniform float u_amplitude;
+uniform float u_amplitudePercent;
+uniform float u_phaseStep;
+uniform int u_animType; // 0 sway, 1 pulse
+uniform int u_axisType; // 0 normal, 1 tangent, 2 movement
+uniform int u_useVertexPhase;
+uniform vec2 u_center;
+uniform vec2 u_movementPerp;
+uniform vec2 u_offset;
+
+out vec2 v_position;
+
+vec2 resolveNormal(vec2 pos) {
+  vec2 d = pos - u_center;
+  float len = length(d);
+  if (len < 1e-6) {
+    return vec2(0.0, 0.0);
+  }
+  return d / len;
+}
+
+void main() {
+  vec2 basePos = a_position;
+  float omega = 6.28318530718 / max(u_periodMs, 1.0);
+  float baseAngle = omega * u_timeMs + u_phase;
+  float phaseOffset = (u_useVertexPhase == 1) ? (u_phaseStep * a_vertexIndex) : 0.0;
+  float angle = baseAngle + phaseOffset;
+  float s = sin(angle);
+
+  vec2 normal = resolveNormal(basePos);
+  vec2 tangent = vec2(-normal.y, normal.x);
+  vec2 axis;
+  if (u_axisType == 1) {
+    axis = tangent;
+  } else if (u_axisType == 2) {
+    axis = u_movementPerp;
+  } else {
+    axis = normal;
+  }
+
+  float magnitude = u_amplitude;
+  if (u_axisType == 2) {
+    float signedDist = dot(basePos, u_movementPerp);
+    float moveToward = -sign(signedDist);
+    float moveMagnitude = (u_amplitudePercent >= 0.0) ? abs(signedDist) * u_amplitudePercent : u_amplitude;
+    magnitude = moveMagnitude * moveToward;
+  } else if (u_amplitudePercent >= 0.0 && u_axisType == 0) {
+    float radius = length(basePos - u_center);
+    magnitude = radius * u_amplitudePercent;
+  }
+
+  vec2 offset = axis * (magnitude * s);
+  v_position = basePos + offset + u_offset;
+}
+`;
+
+const SPINE_ANCHOR_TF_VERTEX_SHADER = `${TF_VERTEX_HEADER}
+layout(location = 0) in vec2 a_position;
+layout(location = 1) in vec2 a_axis;
+layout(location = 2) in float a_falloff;
+layout(location = 3) in float a_pointIndex;
+
+uniform float u_timeMs;
+uniform float u_periodMs;
+uniform float u_phase;
+uniform float u_amplitude;
+uniform vec2 u_offset;
+
+out vec2 v_position;
+
+void main() {
+  float omega = 6.28318530718 / max(u_periodMs, 1.0);
+  float baseAngle = omega * u_timeMs + u_phase;
+  float segmentPhase = a_pointIndex * 0.5;
+  float s = sin(baseAngle + segmentPhase);
+  float displacement = u_amplitude * a_falloff * s;
+  v_position = a_position + a_axis * displacement + u_offset;
+}
+`;
+
+const TF_VARYINGS = ["v_position"] as const;
+
+type AnchorSlotRecord = {
+  baseIndex: number;
+  ids: string[];
+};
+
+type PolygonAnchorUniforms = {
+  timeMs: WebGLUniformLocation | null;
+  periodMs: WebGLUniformLocation | null;
+  phase: WebGLUniformLocation | null;
+  amplitude: WebGLUniformLocation | null;
+  amplitudePercent: WebGLUniformLocation | null;
+  phaseStep: WebGLUniformLocation | null;
+  animType: WebGLUniformLocation | null;
+  axisType: WebGLUniformLocation | null;
+  useVertexPhase: WebGLUniformLocation | null;
+  center: WebGLUniformLocation | null;
+  movementPerp: WebGLUniformLocation | null;
+  offset: WebGLUniformLocation | null;
+};
+
+type SpineAnchorUniforms = {
+  timeMs: WebGLUniformLocation | null;
+  periodMs: WebGLUniformLocation | null;
+  phase: WebGLUniformLocation | null;
+  amplitude: WebGLUniformLocation | null;
+  offset: WebGLUniformLocation | null;
+};
+
+type AnchorGpuProgram<TUniforms> = {
+  program: WebGLProgram;
+  vertexShader: WebGLShader;
+  fragmentShader: WebGLShader;
+  transformFeedback: WebGLTransformFeedback;
+  uniforms: TUniforms;
+};
+
+type AnchorGpuResources = {
+  anchorBuffer: WebGLBuffer;
+  capacity: number;
+  texture: WebGLTexture | null;
+  textureSize: number;
+  polygon: AnchorGpuProgram<PolygonAnchorUniforms>;
+  spine: AnchorGpuProgram<SpineAnchorUniforms>;
+};
+
+const rendererContexts = new WeakMap<WebGL2RenderingContext, AnchorGpuResources>();
+const failedContexts = new WeakSet<WebGL2RenderingContext>();
+const warnedGpuTexture = new WeakSet<WebGL2RenderingContext>();
+
+const anchorRegistry = new Map<string, AnchorSlotRecord>();
+const freeRanges: Array<{ start: number; count: number }> = [];
+let nextIndex = 0;
+
+const normalizeGroupId = (groupId: string | undefined): string => groupId ?? "default";
+const buildRegistryKey = (instanceId: string, groupId: string | undefined): string =>
+  `${instanceId}::${normalizeGroupId(groupId)}`;
+
+const createTransformFeedbackProgram = (
+  gl: WebGL2RenderingContext,
+  vertexSource: string,
+  varyings: readonly string[]
+): { program: WebGLProgram; vertexShader: WebGLShader; fragmentShader: WebGLShader } => {
+  const vertexShader = compileShader(gl, gl.VERTEX_SHADER, vertexSource);
+  const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, TF_FRAGMENT_SHADER);
+  const program = gl.createProgram();
+  if (!program) {
+    throw new Error("Unable to create program");
+  }
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.transformFeedbackVaryings(program, varyings, gl.SEPARATE_ATTRIBS);
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const info = gl.getProgramInfoLog(program);
+    gl.deleteProgram(program);
+    throw new Error(`Failed to link program: ${info ?? "unknown"}`);
+  }
+  return { program, vertexShader, fragmentShader };
+};
+
+const ensureResources = (gl: WebGL2RenderingContext): AnchorGpuResources | null => {
+  const existing = rendererContexts.get(gl);
+  if (existing) {
+    return existing;
+  }
+  if (failedContexts.has(gl)) {
+    return null;
+  }
+  try {
+    const polygonProgram = createTransformFeedbackProgram(gl, POLYGON_ANCHOR_TF_VERTEX_SHADER, TF_VARYINGS);
+    const spineProgram = createTransformFeedbackProgram(gl, SPINE_ANCHOR_TF_VERTEX_SHADER, TF_VARYINGS);
+
+    const polygonTf = gl.createTransformFeedback();
+    const spineTf = gl.createTransformFeedback();
+    const anchorBuffer = gl.createBuffer();
+    if (!polygonTf || !spineTf || !anchorBuffer) {
+      return null;
+    }
+
+    const polygon: AnchorGpuProgram<PolygonAnchorUniforms> = {
+      program: polygonProgram.program,
+      vertexShader: polygonProgram.vertexShader,
+      fragmentShader: polygonProgram.fragmentShader,
+      transformFeedback: polygonTf,
+      uniforms: {
+        timeMs: gl.getUniformLocation(polygonProgram.program, "u_timeMs"),
+        periodMs: gl.getUniformLocation(polygonProgram.program, "u_periodMs"),
+        phase: gl.getUniformLocation(polygonProgram.program, "u_phase"),
+        amplitude: gl.getUniformLocation(polygonProgram.program, "u_amplitude"),
+        amplitudePercent: gl.getUniformLocation(polygonProgram.program, "u_amplitudePercent"),
+        phaseStep: gl.getUniformLocation(polygonProgram.program, "u_phaseStep"),
+        animType: gl.getUniformLocation(polygonProgram.program, "u_animType"),
+        axisType: gl.getUniformLocation(polygonProgram.program, "u_axisType"),
+        useVertexPhase: gl.getUniformLocation(polygonProgram.program, "u_useVertexPhase"),
+        center: gl.getUniformLocation(polygonProgram.program, "u_center"),
+        movementPerp: gl.getUniformLocation(polygonProgram.program, "u_movementPerp"),
+        offset: gl.getUniformLocation(polygonProgram.program, "u_offset"),
+      },
+    };
+
+    const spine: AnchorGpuProgram<SpineAnchorUniforms> = {
+      program: spineProgram.program,
+      vertexShader: spineProgram.vertexShader,
+      fragmentShader: spineProgram.fragmentShader,
+      transformFeedback: spineTf,
+      uniforms: {
+        timeMs: gl.getUniformLocation(spineProgram.program, "u_timeMs"),
+        periodMs: gl.getUniformLocation(spineProgram.program, "u_periodMs"),
+        phase: gl.getUniformLocation(spineProgram.program, "u_phase"),
+        amplitude: gl.getUniformLocation(spineProgram.program, "u_amplitude"),
+        offset: gl.getUniformLocation(spineProgram.program, "u_offset"),
+      },
+    };
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, anchorBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, 8 * 2 * Float32Array.BYTES_PER_ELEMENT, gl.DYNAMIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+    const resources: AnchorGpuResources = {
+      anchorBuffer,
+      capacity: 8,
+      texture: null,
+      textureSize: 0,
+      polygon,
+      spine,
+    };
+    rendererContexts.set(gl, resources);
+    return resources;
+  } catch (error) {
+    console.warn("[AnchorsGpu] Failed to initialize GPU anchor resources", error);
+    failedContexts.add(gl);
+    return null;
+  }
+};
+
+const ensureAnchorCapacity = (
+  gl: WebGL2RenderingContext,
+  resources: AnchorGpuResources,
+  needed: number
+): void => {
+  if (needed <= resources.capacity) {
+    return;
+  }
+  resources.capacity = Math.max(needed, resources.capacity * 2, 16);
+  gl.bindBuffer(gl.ARRAY_BUFFER, resources.anchorBuffer);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    resources.capacity * 2 * Float32Array.BYTES_PER_ELEMENT,
+    gl.DYNAMIC_DRAW
+  );
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+};
+
+const allocateAnchorRange = (count: number): number => {
+  if (count <= 0) {
+    return -1;
+  }
+  for (let i = 0; i < freeRanges.length; i += 1) {
+    const range = freeRanges[i]!;
+    if (range.count >= count) {
+      const start = range.start;
+      if (range.count === count) {
+        freeRanges.splice(i, 1);
+      } else {
+        range.start += count;
+        range.count -= count;
+      }
+      return start;
+    }
+  }
+  const start = nextIndex;
+  nextIndex += count;
+  return start;
+};
+
+const releaseAnchorRange = (start: number, count: number): void => {
+  if (count <= 0 || start < 0) {
+    return;
+  }
+  freeRanges.push({ start, count });
+  freeRanges.sort((a, b) => a.start - b.start);
+  for (let i = 0; i < freeRanges.length - 1; ) {
+    const current = freeRanges[i]!;
+    const next = freeRanges[i + 1]!;
+    if (current.start + current.count === next.start) {
+      current.count += next.count;
+      freeRanges.splice(i + 1, 1);
+      continue;
+    }
+    i += 1;
+  }
+};
+
+export const registerGpuAnchors = (options: {
+  instanceId: string;
+  groupId: string | undefined;
+  anchors: RendererLayerAnchorConfig[];
+}): AnchorSlotRecord | null => {
+  const validAnchors = options.anchors.filter((anchor) => anchor.id);
+  if (validAnchors.length === 0) {
+    return null;
+  }
+  const key = buildRegistryKey(options.instanceId, options.groupId);
+  const existing = anchorRegistry.get(key);
+  if (existing && existing.ids.length === validAnchors.length) {
+    const sameIds = existing.ids.every((id, index) => id === validAnchors[index]?.id);
+    if (sameIds) {
+      return existing;
+    }
+  }
+  if (existing) {
+    releaseAnchorRange(existing.baseIndex, existing.ids.length);
+  }
+  const baseIndex = allocateAnchorRange(validAnchors.length);
+  const record: AnchorSlotRecord = {
+    baseIndex,
+    ids: validAnchors.map((anchor) => anchor.id),
+  };
+  anchorRegistry.set(key, record);
+  return record;
+};
+
+export const releaseGpuAnchors = (instanceId: string, groupId: string | undefined): void => {
+  const key = buildRegistryKey(instanceId, groupId);
+  const record = anchorRegistry.get(key);
+  if (!record) {
+    return;
+  }
+  releaseAnchorRange(record.baseIndex, record.ids.length);
+  anchorRegistry.delete(key);
+};
+
+export const getGpuAnchorIndex = (
+  instanceId: string,
+  groupId: string | undefined,
+  anchorId: string
+): number | null => {
+  const record = anchorRegistry.get(buildRegistryKey(instanceId, groupId));
+  if (!record) {
+    return null;
+  }
+  const idx = record.ids.indexOf(anchorId);
+  if (idx === -1) {
+    return null;
+  }
+  return record.baseIndex + idx;
+};
+
+const buildPolygonAnchorInputs = (
+  anchors: RendererLayerAnchorConfig[],
+  vertices: SceneVector2[]
+): { data: Float32Array; ids: string[] } | null => {
+  const inputs: number[] = [];
+  const ids: string[] = [];
+  anchors.forEach((anchor) => {
+    if (anchor.mode !== "vertex" || typeof anchor.index !== "number") {
+      return;
+    }
+    const vertex = vertices[anchor.index];
+    if (!vertex) {
+      return;
+    }
+    inputs.push(vertex.x, vertex.y, anchor.index);
+    ids.push(anchor.id);
+  });
+  if (ids.length === 0) {
+    return null;
+  }
+  return { data: new Float32Array(inputs), ids };
+};
+
+type SpineAnchorInput = {
+  data: Float32Array;
+  ids: string[];
+};
+
+const buildSpineAnchors = (
+  anchors: RendererLayerAnchorConfig[],
+  spine: Array<{ x: number; y: number; width: number }>,
+  anim: RendererLayerAnimationConfig
+): SpineAnchorInput | null => {
+  if (spine.length === 0) {
+    return null;
+  }
+  const falloffKind = anim.falloff ?? "tip";
+  const falloffFactors = new Float32Array(spine.length);
+  if (spine.length > 1) {
+    for (let i = 1; i < spine.length; i += 1) {
+      const ratio = i / (spine.length - 1);
+      falloffFactors[i] =
+        falloffKind === "tip"
+          ? ratio
+          : falloffKind === "root"
+          ? 1 - ratio
+          : 1;
+    }
+  }
+
+  const segmentCount = Math.max(spine.length - 1, 0);
+  const axis = anim.axis ?? "normal";
+  const axisX = new Float32Array(segmentCount);
+  const axisY = new Float32Array(segmentCount);
+  for (let i = 0; i < segmentCount; i += 1) {
+    const a = spine[i]!;
+    const b = spine[i + 1]!;
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const length = Math.hypot(dx, dy) || 1;
+    const tangentX = dx / length;
+    const tangentY = dy / length;
+    const normalX = -tangentY;
+    const normalY = tangentX;
+    axisX[i] = axis === "tangent" ? tangentX : normalX;
+    axisY[i] = axis === "tangent" ? tangentY : normalY;
+  }
+
+  const resolvePointByT = (t: number): { position: SceneVector2; segmentIndex: number; pointIndex: number } => {
+    if (spine.length === 1) {
+      return { position: spine[0]!, segmentIndex: 0, pointIndex: 0 };
+    }
+    const clampedT = Math.max(0, Math.min(1, t));
+    let totalLength = 0;
+    const lengths = new Array<number>(spine.length - 1);
+    for (let i = 0; i < spine.length - 1; i += 1) {
+      const a = spine[i]!;
+      const b = spine[i + 1]!;
+      const length = Math.hypot(b.x - a.x, b.y - a.y);
+      lengths[i] = length;
+      totalLength += length;
+    }
+    if (totalLength <= 0) {
+      return { position: spine[0]!, segmentIndex: 0, pointIndex: 0 };
+    }
+    let distance = clampedT * totalLength;
+    for (let i = 0; i < lengths.length; i += 1) {
+      const segmentLength = lengths[i] ?? 0;
+      if (distance <= segmentLength || i === lengths.length - 1) {
+        const a = spine[i]!;
+        const b = spine[i + 1]!;
+        const segmentT = segmentLength > 0 ? distance / segmentLength : 0;
+        return {
+          position: {
+            x: a.x + (b.x - a.x) * segmentT,
+            y: a.y + (b.y - a.y) * segmentT,
+          },
+          segmentIndex: i,
+          pointIndex: i + segmentT,
+        };
+      }
+      distance -= segmentLength;
+    }
+    return {
+      position: spine[spine.length - 1]!,
+      segmentIndex: spine.length - 2,
+      pointIndex: spine.length - 1,
+    };
+  };
+
+  const inputs: number[] = [];
+  const ids: string[] = [];
+  anchors.forEach((anchor) => {
+    if (anchor.mode !== "spine") {
+      return;
+    }
+    let position: SceneVector2 | null = null;
+    let segmentIndex = 0;
+    let pointIndex = 0;
+    if (typeof anchor.index === "number") {
+      const clampedIndex = Math.max(0, Math.min(spine.length - 1, anchor.index));
+      position = spine[clampedIndex] ?? null;
+      segmentIndex = Math.max(0, clampedIndex - 1);
+      pointIndex = clampedIndex;
+    } else if (typeof anchor.t === "number") {
+      const resolved = resolvePointByT(anchor.t);
+      position = resolved.position;
+      segmentIndex = resolved.segmentIndex;
+      pointIndex = resolved.pointIndex;
+    }
+    if (!position) {
+      return;
+    }
+    const axisIdx = Math.max(0, Math.min(axisX.length - 1, segmentIndex));
+    const ax = axisX[axisIdx] ?? 0;
+    const ay = axisY[axisIdx] ?? 0;
+    const falloffIndex = Math.max(0, Math.min(falloffFactors.length - 1, Math.floor(pointIndex)));
+    const falloff = falloffFactors[falloffIndex] ?? 0;
+    inputs.push(position.x, position.y, ax, ay, falloff, pointIndex);
+    ids.push(anchor.id);
+  });
+
+  if (ids.length === 0) {
+    return null;
+  }
+  return { data: new Float32Array(inputs), ids };
+};
+
+const buildPolygonCenter = (vertices: SceneVector2[]): SceneVector2 => {
+  const center = vertices.reduce(
+    (acc, v) => ({ x: acc.x + v.x, y: acc.y + v.y }),
+    { x: 0, y: 0 }
+  );
+  const invCount = vertices.length > 0 ? 1 / vertices.length : 0;
+  return { x: center.x * invCount, y: center.y * invCount };
+};
+
+export const createPolygonAnchorGpuPrimitive = (options: {
+  instance: SceneObjectInstance;
+  groupId: string | undefined;
+  anchors: RendererLayerAnchorConfig[];
+  vertices: SceneVector2[];
+  anim: RendererLayerAnimationConfig;
+  offset: SceneVector2 | undefined;
+  phaseStep?: number;
+  enableMovementAxis?: boolean;
+}): DynamicPrimitive | null => {
+  const input = buildPolygonAnchorInputs(options.anchors, options.vertices);
+  if (!input) {
+    return null;
+  }
+  const record = registerGpuAnchors({
+    instanceId: options.instance.id,
+    groupId: options.groupId,
+    anchors: input.ids.map((id) => ({ id, mode: "vertex" })),
+  });
+  if (!record) {
+    return null;
+  }
+  const baseIndex = record.baseIndex;
+  const anchorCount = input.ids.length;
+  const center = buildPolygonCenter(options.vertices);
+
+  let gl = getAnimationGpuContext();
+  let resources: AnchorGpuResources | null = null;
+  let vao: WebGLVertexArrayObject | null = null;
+  let inputBuffer: WebGLBuffer | null = null;
+
+  const ensureBuffers = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    resources = ensureResources(gl);
+    if (!resources) {
+      return false;
+    }
+    ensureAnchorCapacity(gl, resources, baseIndex + anchorCount);
+    if (!inputBuffer) {
+      inputBuffer = gl.createBuffer();
+      if (!inputBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, input.data, gl.DYNAMIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    if (!vao) {
+      vao = gl.createVertexArray();
+      if (!vao) {
+        return false;
+      }
+      gl.bindVertexArray(vao);
+      gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer);
+      const stride = 3 * Float32Array.BYTES_PER_ELEMENT;
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, stride, 0);
+      gl.enableVertexAttribArray(1);
+      gl.vertexAttribPointer(1, 1, gl.FLOAT, false, stride, 2 * Float32Array.BYTES_PER_ELEMENT);
+      gl.bindVertexArray(null);
+    }
+    return true;
+  };
+
+  return {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureBuffers() || !gl || !resources || !vao || !inputBuffer) {
+        return null;
+      }
+      const anim = options.anim;
+      const axis = anim.axis ?? "normal";
+      const useMovementAxis = Boolean(options.enableMovementAxis) && (axis === "movement-tangent" || axis === "movement-normal");
+      const axisType = useMovementAxis ? 2 : axis === "tangent" ? 1 : 0;
+      const movementPerp = axis === "movement-normal" ? { x: -1, y: 0 } : { x: 0, y: 1 };
+      const amplitudePercent =
+        typeof anim.amplitudePercentage === "number" && Number.isFinite(anim.amplitudePercentage)
+          ? anim.amplitudePercentage
+          : -1;
+      const offset = options.offset ?? { x: 0, y: 0 };
+      const origin = offset;
+
+      gl.useProgram(resources.polygon.program);
+      gl.uniform1f(resources.polygon.uniforms.timeMs, getSceneTimelineNow());
+      gl.uniform1f(resources.polygon.uniforms.periodMs, Math.max(anim.periodMs ?? 1500, 1));
+      gl.uniform1f(resources.polygon.uniforms.phase, anim.phase ?? 0);
+      gl.uniform1f(resources.polygon.uniforms.amplitude, anim.amplitude ?? 6);
+      gl.uniform1f(resources.polygon.uniforms.amplitudePercent, amplitudePercent);
+      gl.uniform1f(resources.polygon.uniforms.phaseStep, options.phaseStep ?? 0.3);
+      gl.uniform1i(resources.polygon.uniforms.animType, anim.type === "pulse" ? 1 : 0);
+      gl.uniform1i(resources.polygon.uniforms.axisType, axisType);
+      gl.uniform1i(resources.polygon.uniforms.useVertexPhase, anim.type === "sway" && !useMovementAxis ? 1 : 0);
+      gl.uniform2f(resources.polygon.uniforms.center, center.x, center.y);
+      gl.uniform2f(resources.polygon.uniforms.movementPerp, movementPerp.x, movementPerp.y);
+      gl.uniform2f(resources.polygon.uniforms.offset, origin.x, origin.y);
+
+      const bytesPerAnchor = 2 * Float32Array.BYTES_PER_ELEMENT;
+      const rangeOffset = baseIndex * bytesPerAnchor;
+      const rangeSize = anchorCount * bytesPerAnchor;
+
+      gl.bindVertexArray(vao);
+      gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, resources.polygon.transformFeedback);
+      gl.bindBufferRange(
+        gl.TRANSFORM_FEEDBACK_BUFFER,
+        0,
+        resources.anchorBuffer,
+        rangeOffset,
+        rangeSize
+      );
+      gl.enable(gl.RASTERIZER_DISCARD);
+      gl.beginTransformFeedback(gl.POINTS);
+      gl.drawArrays(gl.POINTS, 0, anchorCount);
+      gl.endTransformFeedback();
+      gl.disable(gl.RASTERIZER_DISCARD);
+      gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+      gl.bindVertexArray(null);
+      return null;
+    },
+    dispose() {
+      if (gl && inputBuffer) {
+        gl.deleteBuffer(inputBuffer);
+      }
+      if (gl && vao) {
+        gl.deleteVertexArray(vao);
+      }
+      releaseGpuAnchors(options.instance.id, options.groupId);
+    },
+  };
+};
+
+export const createSpineAnchorGpuPrimitive = (options: {
+  instance: SceneObjectInstance;
+  groupId: string | undefined;
+  anchors: RendererLayerAnchorConfig[];
+  spine: Array<{ x: number; y: number; width: number }>;
+  anim: RendererLayerAnimationConfig;
+  offset: SceneVector2 | undefined;
+}): DynamicPrimitive | null => {
+  const input = buildSpineAnchors(options.anchors, options.spine, options.anim);
+  if (!input) {
+    return null;
+  }
+  const record = registerGpuAnchors({
+    instanceId: options.instance.id,
+    groupId: options.groupId,
+    anchors: input.ids.map((id) => ({ id, mode: "spine" })),
+  });
+  if (!record) {
+    return null;
+  }
+  const baseIndex = record.baseIndex;
+  const anchorCount = input.ids.length;
+
+  let gl = getAnimationGpuContext();
+  let resources: AnchorGpuResources | null = null;
+  let vao: WebGLVertexArrayObject | null = null;
+  let inputBuffer: WebGLBuffer | null = null;
+
+  const ensureBuffers = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    resources = ensureResources(gl);
+    if (!resources) {
+      return false;
+    }
+    ensureAnchorCapacity(gl, resources, baseIndex + anchorCount);
+    if (!inputBuffer) {
+      inputBuffer = gl.createBuffer();
+      if (!inputBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, input.data, gl.DYNAMIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    if (!vao) {
+      vao = gl.createVertexArray();
+      if (!vao) {
+        return false;
+      }
+      gl.bindVertexArray(vao);
+      gl.bindBuffer(gl.ARRAY_BUFFER, inputBuffer);
+      const stride = 6 * Float32Array.BYTES_PER_ELEMENT;
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, stride, 0);
+      gl.enableVertexAttribArray(1);
+      gl.vertexAttribPointer(1, 2, gl.FLOAT, false, stride, 2 * Float32Array.BYTES_PER_ELEMENT);
+      gl.enableVertexAttribArray(2);
+      gl.vertexAttribPointer(2, 1, gl.FLOAT, false, stride, 4 * Float32Array.BYTES_PER_ELEMENT);
+      gl.enableVertexAttribArray(3);
+      gl.vertexAttribPointer(3, 1, gl.FLOAT, false, stride, 5 * Float32Array.BYTES_PER_ELEMENT);
+      gl.bindVertexArray(null);
+    }
+    return true;
+  };
+
+  return {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureBuffers() || !gl || !resources || !vao || !inputBuffer) {
+        return null;
+      }
+      const anim = options.anim;
+      const offset = options.offset ?? { x: 0, y: 0 };
+      const origin = offset;
+
+      gl.useProgram(resources.spine.program);
+      gl.uniform1f(resources.spine.uniforms.timeMs, getSceneTimelineNow());
+      gl.uniform1f(resources.spine.uniforms.periodMs, Math.max(anim.periodMs ?? 1400, 1));
+      gl.uniform1f(resources.spine.uniforms.phase, anim.phase ?? 0);
+      gl.uniform1f(resources.spine.uniforms.amplitude, anim.amplitude ?? 1.0);
+      gl.uniform2f(resources.spine.uniforms.offset, origin.x, origin.y);
+
+      const bytesPerAnchor = 2 * Float32Array.BYTES_PER_ELEMENT;
+      const rangeOffset = baseIndex * bytesPerAnchor;
+      const rangeSize = anchorCount * bytesPerAnchor;
+
+      gl.bindVertexArray(vao);
+      gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, resources.spine.transformFeedback);
+      gl.bindBufferRange(
+        gl.TRANSFORM_FEEDBACK_BUFFER,
+        0,
+        resources.anchorBuffer,
+        rangeOffset,
+        rangeSize
+      );
+      gl.enable(gl.RASTERIZER_DISCARD);
+      gl.beginTransformFeedback(gl.POINTS);
+      gl.drawArrays(gl.POINTS, 0, anchorCount);
+      gl.endTransformFeedback();
+      gl.disable(gl.RASTERIZER_DISCARD);
+      gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+      gl.bindVertexArray(null);
+      return null;
+    },
+    dispose() {
+      if (gl && inputBuffer) {
+        gl.deleteBuffer(inputBuffer);
+      }
+      if (gl && vao) {
+        gl.deleteVertexArray(vao);
+      }
+      releaseGpuAnchors(options.instance.id, options.groupId);
+    },
+  };
+};
+
+export const getAnchorsGpuBuffer = (gl: WebGL2RenderingContext): WebGLBuffer | null => {
+  return ensureResources(gl)?.anchorBuffer ?? null;
+};
+
+export const updateAnchorsGpuTexture = (
+  gl: WebGL2RenderingContext
+): { texture: WebGLTexture; width: number } | null => {
+  const resources = ensureResources(gl);
+  if (!resources) {
+    if (!warnedGpuTexture.has(gl)) {
+      warnedGpuTexture.add(gl);
+      console.warn("[AnchorsGpu] GPU anchor texture unavailable; joined primitives will fall back to CPU.");
+    }
+    return null;
+  }
+  if (!resources.texture) {
+    resources.texture = gl.createTexture();
+    if (!resources.texture) {
+      if (!warnedGpuTexture.has(gl)) {
+        warnedGpuTexture.add(gl);
+        console.warn("[AnchorsGpu] Failed to create anchor texture; joined primitives will fall back to CPU.");
+      }
+      return null;
+    }
+    gl.bindTexture(gl.TEXTURE_2D, resources.texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.bindTexture(gl.TEXTURE_2D, null);
+  }
+  if (resources.textureSize !== resources.capacity) {
+    resources.textureSize = resources.capacity;
+    gl.bindTexture(gl.TEXTURE_2D, resources.texture);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RG32F,
+      resources.textureSize,
+      1,
+      0,
+      gl.RG,
+      gl.FLOAT,
+      null
+    );
+    gl.bindTexture(gl.TEXTURE_2D, null);
+  }
+
+  gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, resources.anchorBuffer);
+  gl.bindTexture(gl.TEXTURE_2D, resources.texture);
+  gl.texSubImage2D(
+    gl.TEXTURE_2D,
+    0,
+    0,
+    0,
+    resources.textureSize,
+    1,
+    gl.RG,
+    gl.FLOAT,
+    0
+  );
+  gl.bindTexture(gl.TEXTURE_2D, null);
+  gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
+
+  return { texture: resources.texture, width: resources.textureSize };
+};
+
+export const disposeAnchorsGpuResources = (gl: WebGL2RenderingContext): void => {
+  const resources = rendererContexts.get(gl);
+  if (!resources) {
+    failedContexts.delete(gl);
+    return;
+  }
+  gl.deleteProgram(resources.polygon.program);
+  gl.deleteShader(resources.polygon.vertexShader);
+  gl.deleteShader(resources.polygon.fragmentShader);
+  gl.deleteTransformFeedback(resources.polygon.transformFeedback);
+
+  gl.deleteProgram(resources.spine.program);
+  gl.deleteShader(resources.spine.vertexShader);
+  gl.deleteShader(resources.spine.fragmentShader);
+  gl.deleteTransformFeedback(resources.spine.transformFeedback);
+
+  gl.deleteBuffer(resources.anchorBuffer);
+  if (resources.texture) {
+    gl.deleteTexture(resources.texture);
+  }
+
+  rendererContexts.delete(gl);
+  failedContexts.delete(gl);
+};

--- a/src/ui/renderers/objects/shared/anchors.ts
+++ b/src/ui/renderers/objects/shared/anchors.ts
@@ -128,20 +128,23 @@ const sampleSpineByT = (spine: SceneVector2[], t: number): SceneVector2 | null =
   return spine[spine.length - 1] ?? null;
 };
 
-export const resolveLayerAnchors = (
-  anchors: RendererLayerAnchorConfig[] | undefined,
-  vertices: SceneVector2[] | undefined,
-  spine: SceneVector2[] | undefined,
-  offset: SceneVector2 | undefined
-): RendererAnchorRecord[] => {
-  if (!anchors || anchors.length === 0) {
+export const resolveLayerAnchors = (options: {
+  anchors: RendererLayerAnchorConfig[] | undefined;
+  vertices?: SceneVector2[];
+  spine?: SceneVector2[];
+  offset?: SceneVector2;
+  circle?: { radius: number; segments?: number };
+  sprite?: { width: number; height: number };
+}): RendererAnchorRecord[] => {
+  if (!options.anchors || options.anchors.length === 0) {
     return [];
   }
   const resolved: RendererAnchorRecord[] = [];
-  const offsetX = offset?.x ?? 0;
-  const offsetY = offset?.y ?? 0;
-  anchors.forEach((anchor) => {
+  const offsetX = options.offset?.x ?? 0;
+  const offsetY = options.offset?.y ?? 0;
+  options.anchors.forEach((anchor) => {
     if (anchor.mode === "vertex") {
+      const vertices = options.vertices;
       if (!vertices || vertices.length === 0 || typeof anchor.index !== "number") {
         return;
       }
@@ -155,22 +158,110 @@ export const resolveLayerAnchors = (
       });
       return;
     }
-    if (!spine || spine.length === 0) {
+    if (anchor.mode === "spine") {
+      const spine = options.spine;
+      if (!spine || spine.length === 0) {
+        return;
+      }
+      let point: SceneVector2 | null = null;
+      if (typeof anchor.index === "number") {
+        point = spine[Math.max(0, Math.min(spine.length - 1, anchor.index))] ?? null;
+      } else if (typeof anchor.t === "number") {
+        point = sampleSpineByT(spine, anchor.t);
+      }
+      if (!point) {
+        return;
+      }
+      resolved.push({
+        id: anchor.id,
+        position: { x: point.x + offsetX, y: point.y + offsetY },
+      });
       return;
     }
-    let point: SceneVector2 | null = null;
-    if (typeof anchor.index === "number") {
-      point = spine[Math.max(0, Math.min(spine.length - 1, anchor.index))] ?? null;
-    } else if (typeof anchor.t === "number") {
-      point = sampleSpineByT(spine, anchor.t);
-    }
-    if (!point) {
+    if (anchor.mode === "circle") {
+      const circle = options.circle;
+      if (!circle || circle.radius <= 0) {
+        return;
+      }
+      const segments = Math.max(3, Math.floor(circle.segments ?? 24));
+      let angle = anchor.angleRad;
+      if (typeof angle !== "number") {
+        if (typeof anchor.t === "number") {
+          angle = anchor.t * Math.PI * 2;
+        } else if (typeof anchor.index === "number") {
+          angle = (anchor.index / segments) * Math.PI * 2;
+        }
+      }
+      if (typeof angle !== "number") {
+        return;
+      }
+      resolved.push({
+        id: anchor.id,
+        position: {
+          x: Math.cos(angle) * circle.radius + offsetX,
+          y: Math.sin(angle) * circle.radius + offsetY,
+        },
+      });
       return;
     }
-    resolved.push({
-      id: anchor.id,
-      position: { x: point.x + offsetX, y: point.y + offsetY },
-    });
+    if (anchor.mode === "sprite") {
+      const sprite = options.sprite;
+      if (!sprite) {
+        return;
+      }
+      const halfWidth = sprite.width * 0.5;
+      const halfHeight = sprite.height * 0.5;
+      let x = 0;
+      let y = 0;
+      if (anchor.uv) {
+        x = (anchor.uv.x - 0.5) * sprite.width;
+        y = (anchor.uv.y - 0.5) * sprite.height;
+      } else {
+        switch (anchor.spriteAnchor ?? "center") {
+          case "top-left":
+            x = -halfWidth;
+            y = -halfHeight;
+            break;
+          case "top-right":
+            x = halfWidth;
+            y = -halfHeight;
+            break;
+          case "bottom-left":
+            x = -halfWidth;
+            y = halfHeight;
+            break;
+          case "bottom-right":
+            x = halfWidth;
+            y = halfHeight;
+            break;
+          case "top":
+            x = 0;
+            y = -halfHeight;
+            break;
+          case "bottom":
+            x = 0;
+            y = halfHeight;
+            break;
+          case "left":
+            x = -halfWidth;
+            y = 0;
+            break;
+          case "right":
+            x = halfWidth;
+            y = 0;
+            break;
+          case "center":
+          default:
+            x = 0;
+            y = 0;
+            break;
+        }
+      }
+      resolved.push({
+        id: anchor.id,
+        position: { x: x + offsetX, y: y + offsetY },
+      });
+    }
   });
   return resolved;
 };

--- a/src/ui/renderers/objects/shared/anchors.ts
+++ b/src/ui/renderers/objects/shared/anchors.ts
@@ -1,5 +1,8 @@
 import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
-import type { RendererLayerAnchorConfig } from "@shared/types/renderer.types";
+import type {
+  RendererLayerAnchorConfig,
+  RendererLayerJoinConfig,
+} from "@shared/types/renderer.types";
 
 export type RendererAnchorRecord = {
   id: string;
@@ -47,6 +50,45 @@ export const readAnchorsForLayer = (
     return [];
   }
   return Array.from(record.entries()).map(([id, position]) => ({ id, position }));
+};
+
+export const mergeLayerAnchors = (
+  anchors: RendererLayerAnchorConfig[] | undefined,
+  connectionSlots: RendererLayerAnchorConfig[] | undefined
+): RendererLayerAnchorConfig[] => {
+  if (!anchors || anchors.length === 0) {
+    return connectionSlots ?? [];
+  }
+  if (!connectionSlots || connectionSlots.length === 0) {
+    return anchors;
+  }
+  return [...anchors, ...connectionSlots];
+};
+
+export const resolveJoinOffset = (options: {
+  instanceId: string;
+  join: RendererLayerJoinConfig | undefined;
+  baseOffset: SceneVector2 | undefined;
+}): SceneVector2 | undefined => {
+  const join = options.join;
+  if (!join) {
+    return options.baseOffset;
+  }
+  const baseOffsetX = options.baseOffset?.x ?? 0;
+  const baseOffsetY = options.baseOffset?.y ?? 0;
+  const joinOffsetX = join.offset?.x ?? 0;
+  const joinOffsetY = join.offset?.y ?? 0;
+  const anchor = readAnchor(options.instanceId, join.targetGroupId, join.anchorId);
+  if (!anchor) {
+    return {
+      x: baseOffsetX + joinOffsetX,
+      y: baseOffsetY + joinOffsetY,
+    };
+  }
+  return {
+    x: anchor.x + baseOffsetX + joinOffsetX,
+    y: anchor.y + baseOffsetY + joinOffsetY,
+  };
 };
 
 const sampleSpineByT = (spine: SceneVector2[], t: number): SceneVector2 | null => {

--- a/src/ui/renderers/primitives/JoinedPolygonGpuPrimitive.ts
+++ b/src/ui/renderers/primitives/JoinedPolygonGpuPrimitive.ts
@@ -1,6 +1,7 @@
 import type {
   SceneFill,
   SceneObjectInstance,
+  SceneStroke,
   SceneVector2,
 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import {
@@ -12,6 +13,18 @@ import { computePolygonGeometry } from "@ui/renderers/primitives/basic/PolygonPr
 import { joinedPolygonGpuRenderer, type JoinedPolygonGpuHandle } from "@ui/renderers/primitives/gpu/joined/JoinedPolygonGpuRenderer";
 import { getAnimationGpuContext } from "@ui/renderers/objects/shared/animation-gpu";
 import { FILL_COMPONENTS } from "@ui/renderers/objects/ObjectRenderer";
+import { createSpriteFill } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.helpers";
+import { FILL_TYPES } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.const";
+
+const createStrokeFill = (stroke: SceneStroke): SceneFill => ({
+  fillType: FILL_TYPES.SOLID,
+  color: {
+    r: stroke.color.r,
+    g: stroke.color.g,
+    b: stroke.color.b,
+    a: typeof stroke.color.a === "number" ? stroke.color.a : 1,
+  },
+});
 
 const buildPackedVertices = (vertices: SceneVector2[]): Float32Array => {
   const packed = new Float32Array(vertices.length * 2);
@@ -47,6 +60,37 @@ const buildCircleFanVertices = (radius: number, segments: number): SceneVector2[
     verts.push({ x: Math.cos(angle) * radius, y: Math.sin(angle) * radius });
   }
   return verts;
+};
+
+const buildStrokeBandVertices = (
+  inner: SceneVector2[],
+  outer: SceneVector2[]
+): SceneVector2[] => {
+  const n = Math.min(inner.length, outer.length);
+  if (n < 3) {
+    return [];
+  }
+  const verts: SceneVector2[] = [];
+  for (let i = 0; i < n; i += 1) {
+    const j = (i + 1) % n;
+    const outerI = outer[i]!;
+    const outerJ = outer[j]!;
+    const innerI = inner[i]!;
+    const innerJ = inner[j]!;
+    verts.push(outerI, outerJ, innerI, innerI, outerJ, innerJ);
+  }
+  return verts;
+};
+
+const buildSpriteQuadVertices = (width: number, height: number): SceneVector2[] => {
+  const halfWidth = width * 0.5;
+  const halfHeight = height * 0.5;
+  return [
+    { x: -halfWidth, y: halfHeight },
+    { x: halfWidth, y: halfHeight },
+    { x: halfWidth, y: -halfHeight },
+    { x: -halfWidth, y: -halfHeight },
+  ];
 };
 
 export interface JoinedGpuPrimitiveOptions {
@@ -297,6 +341,435 @@ export const createJoinedCircleGpuPrimitive = (
           rotation: 0,
           size,
           radius: options.radius,
+        });
+        fillData = buildFillBufferData(vertexCount, fillComponents, fillData ?? undefined);
+        gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, fillData);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+      }
+
+      const pos = getInstanceRenderPosition(target);
+      renderHandle.instancePosition.x = pos.x;
+      renderHandle.instancePosition.y = pos.y;
+      renderHandle.instanceRotation = target.data.rotation ?? 0;
+      return null;
+    },
+    dispose() {
+      if (!gl) {
+        return;
+      }
+      if (renderHandle) {
+        joinedPolygonGpuRenderer.releaseHandle(renderHandle);
+        renderHandle = null;
+      }
+      if (fillBuffer) {
+        gl.deleteBuffer(fillBuffer);
+        fillBuffer = null;
+      }
+      if (positionBuffer) {
+        gl.deleteBuffer(positionBuffer);
+        positionBuffer = null;
+      }
+    },
+  };
+
+  return primitive;
+};
+
+export const createJoinedPolygonStrokeGpuPrimitive = (
+  instance: SceneObjectInstance,
+  options: {
+    vertices: SceneVector2[];
+    stroke: SceneStroke;
+    refreshStroke?: (instance: SceneObjectInstance) => SceneStroke;
+  } & JoinedGpuPrimitiveOptions
+): DynamicPrimitive | null => {
+  if (!options.vertices || options.vertices.length < 3) {
+    return null;
+  }
+  const geometry = computePolygonGeometry(options.vertices);
+  const inner = options.vertices;
+  let outer = inner.map((vertex) => {
+    const dirX = vertex.x - geometry.centerOffset.x;
+    const dirY = vertex.y - geometry.centerOffset.y;
+    const length = Math.hypot(dirX, dirY) || 1;
+    const scale = (length + options.stroke.width) / length;
+    return {
+      x: geometry.centerOffset.x + dirX * scale,
+      y: geometry.centerOffset.y + dirY * scale,
+    };
+  });
+  let vertices = buildStrokeBandVertices(inner, outer);
+  if (vertices.length === 0) {
+    return null;
+  }
+  let packedVertices = buildPackedVertices(vertices);
+
+  const fillScratch = new Float32Array(FILL_COMPONENTS);
+  let fillData: Float32Array | null = null;
+  let cachedStroke: SceneStroke = options.stroke;
+  let prevInstanceStrokeRef: SceneStroke | undefined =
+    typeof options.refreshStroke === "function" ? instance.data.stroke : undefined;
+
+  let gl = getAnimationGpuContext();
+  let fillBuffer: WebGLBuffer | null = null;
+  let positionBuffer: WebGLBuffer | null = null;
+  let renderHandle: JoinedPolygonGpuHandle | null = null;
+
+  const writeFill = () => {
+    const fillComponents = writeFillVertexComponents(fillScratch, {
+      fill: createStrokeFill(cachedStroke),
+      center: geometry.centerOffset,
+      rotation: 0,
+      size: geometry.size,
+    });
+    fillData = buildFillBufferData(vertices.length, fillComponents, fillData ?? undefined);
+    gl!.bindBuffer(gl!.ARRAY_BUFFER, fillBuffer);
+    gl!.bufferSubData(gl!.ARRAY_BUFFER, 0, fillData);
+    gl!.bindBuffer(gl!.ARRAY_BUFFER, null);
+  };
+
+  const ensureResources = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    if (!positionBuffer) {
+      positionBuffer = gl.createBuffer();
+      if (!positionBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, packedVertices, gl.DYNAMIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    if (!fillBuffer) {
+      fillBuffer = gl.createBuffer();
+      if (!fillBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        vertices.length * FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+        gl.DYNAMIC_DRAW
+      );
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    joinedPolygonGpuRenderer.setContext(gl);
+    if (!renderHandle) {
+      renderHandle = joinedPolygonGpuRenderer.acquireHandle({
+        positionBuffer,
+        fillBuffer,
+        vertexCount: vertices.length,
+        anchorIndex: options.anchorIndex,
+        joinOffset: options.joinOffset ?? { x: 0, y: 0 },
+        drawMode: gl.TRIANGLES,
+      });
+      if (!renderHandle) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureResources() || !gl || !fillBuffer || !positionBuffer || !renderHandle) {
+        return null;
+      }
+
+      let strokeChanged = false;
+      if (typeof options.refreshStroke === "function") {
+        if (target.data.stroke !== prevInstanceStrokeRef) {
+          prevInstanceStrokeRef = target.data.stroke;
+          const nextStroke = options.refreshStroke(target);
+          if (nextStroke.width !== cachedStroke.width) {
+            cachedStroke = nextStroke;
+            outer = inner.map((vertex) => {
+              const dirX = vertex.x - geometry.centerOffset.x;
+              const dirY = vertex.y - geometry.centerOffset.y;
+              const length = Math.hypot(dirX, dirY) || 1;
+              const scale = (length + cachedStroke.width) / length;
+              return {
+                x: geometry.centerOffset.x + dirX * scale,
+                y: geometry.centerOffset.y + dirY * scale,
+              };
+            });
+            vertices = buildStrokeBandVertices(inner, outer);
+            packedVertices = buildPackedVertices(vertices);
+            gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+            gl.bufferSubData(gl.ARRAY_BUFFER, 0, packedVertices);
+            gl.bindBuffer(gl.ARRAY_BUFFER, null);
+            joinedPolygonGpuRenderer.updateHandle(renderHandle, vertices.length);
+          } else {
+            cachedStroke = nextStroke;
+          }
+          strokeChanged = true;
+        }
+      }
+
+      if (strokeChanged || !fillData) {
+        writeFill();
+      }
+
+      const pos = getInstanceRenderPosition(target);
+      renderHandle.instancePosition.x = pos.x;
+      renderHandle.instancePosition.y = pos.y;
+      renderHandle.instanceRotation = target.data.rotation ?? 0;
+      return null;
+    },
+    dispose() {
+      if (!gl) {
+        return;
+      }
+      if (renderHandle) {
+        joinedPolygonGpuRenderer.releaseHandle(renderHandle);
+        renderHandle = null;
+      }
+      if (fillBuffer) {
+        gl.deleteBuffer(fillBuffer);
+        fillBuffer = null;
+      }
+      if (positionBuffer) {
+        gl.deleteBuffer(positionBuffer);
+        positionBuffer = null;
+      }
+    },
+  };
+
+  return primitive;
+};
+
+export const createJoinedCircleStrokeGpuPrimitive = (
+  instance: SceneObjectInstance,
+  options: {
+    radius: number;
+    segments?: number;
+    stroke: SceneStroke;
+    refreshStroke?: (instance: SceneObjectInstance) => SceneStroke;
+  } & JoinedGpuPrimitiveOptions
+): DynamicPrimitive | null => {
+  const buildVertices = (radius: number) =>
+    buildCircleFanVertices(radius, options.segments ?? 24);
+  let cachedStroke: SceneStroke = options.stroke;
+  let vertices = buildVertices(options.radius + cachedStroke.width);
+  let packedVertices = buildPackedVertices(vertices);
+
+  const fillScratch = new Float32Array(FILL_COMPONENTS);
+  let fillData: Float32Array | null = null;
+  let prevInstanceStrokeRef: SceneStroke | undefined =
+    typeof options.refreshStroke === "function" ? instance.data.stroke : undefined;
+
+  let gl = getAnimationGpuContext();
+  let fillBuffer: WebGLBuffer | null = null;
+  let positionBuffer: WebGLBuffer | null = null;
+  let renderHandle: JoinedPolygonGpuHandle | null = null;
+
+  const ensureResources = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    if (!positionBuffer) {
+      positionBuffer = gl.createBuffer();
+      if (!positionBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, packedVertices, gl.DYNAMIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    if (!fillBuffer) {
+      fillBuffer = gl.createBuffer();
+      if (!fillBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        vertices.length * FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+        gl.DYNAMIC_DRAW
+      );
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    joinedPolygonGpuRenderer.setContext(gl);
+    if (!renderHandle) {
+      renderHandle = joinedPolygonGpuRenderer.acquireHandle({
+        positionBuffer,
+        fillBuffer,
+        vertexCount: vertices.length,
+        anchorIndex: options.anchorIndex,
+        joinOffset: options.joinOffset ?? { x: 0, y: 0 },
+      });
+      if (!renderHandle) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureResources() || !gl || !fillBuffer || !positionBuffer || !renderHandle) {
+        return null;
+      }
+      let strokeChanged = false;
+      if (typeof options.refreshStroke === "function") {
+        if (target.data.stroke !== prevInstanceStrokeRef) {
+          prevInstanceStrokeRef = target.data.stroke;
+          const nextStroke = options.refreshStroke(target);
+          if (nextStroke.width !== cachedStroke.width) {
+            cachedStroke = nextStroke;
+            vertices = buildVertices(options.radius + cachedStroke.width);
+            packedVertices = buildPackedVertices(vertices);
+            gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+            gl.bufferSubData(gl.ARRAY_BUFFER, 0, packedVertices);
+            gl.bindBuffer(gl.ARRAY_BUFFER, null);
+            joinedPolygonGpuRenderer.updateHandle(renderHandle, vertices.length);
+          } else {
+            cachedStroke = nextStroke;
+          }
+          strokeChanged = true;
+        }
+      }
+      if (strokeChanged || !fillData) {
+        const fillComponents = writeFillVertexComponents(fillScratch, {
+          fill: createStrokeFill(cachedStroke),
+          center: { x: 0, y: 0 },
+          rotation: 0,
+          size: { width: options.radius * 2, height: options.radius * 2 },
+        });
+        fillData = buildFillBufferData(vertices.length, fillComponents, fillData ?? undefined);
+        gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, fillData);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+      }
+      const pos = getInstanceRenderPosition(target);
+      renderHandle.instancePosition.x = pos.x;
+      renderHandle.instancePosition.y = pos.y;
+      renderHandle.instanceRotation = target.data.rotation ?? 0;
+      return null;
+    },
+    dispose() {
+      if (!gl) {
+        return;
+      }
+      if (renderHandle) {
+        joinedPolygonGpuRenderer.releaseHandle(renderHandle);
+        renderHandle = null;
+      }
+      if (fillBuffer) {
+        gl.deleteBuffer(fillBuffer);
+        fillBuffer = null;
+      }
+      if (positionBuffer) {
+        gl.deleteBuffer(positionBuffer);
+        positionBuffer = null;
+      }
+    },
+  };
+
+  return primitive;
+};
+
+export const createJoinedSpriteGpuPrimitive = (
+  instance: SceneObjectInstance,
+  options: {
+    spritePath: string;
+    width: number;
+    height: number;
+  } & JoinedGpuPrimitiveOptions
+): DynamicPrimitive | null => {
+  if (!options.spritePath || options.width <= 0 || options.height <= 0) {
+    return null;
+  }
+  const vertices = buildSpriteQuadVertices(options.width, options.height);
+  const vertexCount = vertices.length;
+  const packedVertices = buildPackedVertices(vertices);
+  const geometry = computePolygonGeometry(vertices);
+
+  const fillScratch = new Float32Array(FILL_COMPONENTS);
+  let fillData: Float32Array | null = null;
+  const spriteFill = createSpriteFill(options.spritePath);
+
+  let gl = getAnimationGpuContext();
+  let fillBuffer: WebGLBuffer | null = null;
+  let positionBuffer: WebGLBuffer | null = null;
+  let renderHandle: JoinedPolygonGpuHandle | null = null;
+
+  const ensureResources = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    if (!positionBuffer) {
+      positionBuffer = gl.createBuffer();
+      if (!positionBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, packedVertices, gl.STATIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    if (!fillBuffer) {
+      fillBuffer = gl.createBuffer();
+      if (!fillBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        vertexCount * FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+        gl.DYNAMIC_DRAW
+      );
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    joinedPolygonGpuRenderer.setContext(gl);
+    if (!renderHandle) {
+      renderHandle = joinedPolygonGpuRenderer.acquireHandle({
+        positionBuffer,
+        fillBuffer,
+        vertexCount,
+        anchorIndex: options.anchorIndex,
+        joinOffset: options.joinOffset ?? { x: 0, y: 0 },
+      });
+      if (!renderHandle) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureResources() || !gl || !fillBuffer || !renderHandle) {
+        return null;
+      }
+      if (!fillData) {
+        const fillComponents = writeFillVertexComponents(fillScratch, {
+          fill: spriteFill,
+          center: geometry.centerOffset,
+          rotation: 0,
+          size: geometry.size,
         });
         fillData = buildFillBufferData(vertexCount, fillComponents, fillData ?? undefined);
         gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);

--- a/src/ui/renderers/primitives/JoinedPolygonGpuPrimitive.ts
+++ b/src/ui/renderers/primitives/JoinedPolygonGpuPrimitive.ts
@@ -1,0 +1,333 @@
+import type {
+  SceneFill,
+  SceneObjectInstance,
+  SceneVector2,
+} from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import {
+  DynamicPrimitive,
+  getInstanceRenderPosition,
+} from "@ui/renderers/objects/ObjectRenderer";
+import { writeFillVertexComponents } from "@ui/renderers/primitives/utils/fill";
+import { computePolygonGeometry } from "@ui/renderers/primitives/basic/PolygonPrimitive";
+import { joinedPolygonGpuRenderer, type JoinedPolygonGpuHandle } from "@ui/renderers/primitives/gpu/joined/JoinedPolygonGpuRenderer";
+import { getAnimationGpuContext } from "@ui/renderers/objects/shared/animation-gpu";
+import { FILL_COMPONENTS } from "@ui/renderers/objects/ObjectRenderer";
+
+const buildPackedVertices = (vertices: SceneVector2[]): Float32Array => {
+  const packed = new Float32Array(vertices.length * 2);
+  for (let i = 0; i < vertices.length; i += 1) {
+    const offset = i * 2;
+    const vertex = vertices[i]!;
+    packed[offset] = vertex.x;
+    packed[offset + 1] = vertex.y;
+  }
+  return packed;
+};
+
+const buildFillBufferData = (
+  vertexCount: number,
+  fillComponents: Float32Array,
+  target?: Float32Array
+): Float32Array => {
+  const data =
+    target && target.length === vertexCount * FILL_COMPONENTS
+      ? target
+      : new Float32Array(vertexCount * FILL_COMPONENTS);
+  for (let i = 0; i < vertexCount; i += 1) {
+    data.set(fillComponents, i * FILL_COMPONENTS);
+  }
+  return data;
+};
+
+const buildCircleFanVertices = (radius: number, segments: number): SceneVector2[] => {
+  const normalized = Math.max(3, Math.floor(segments));
+  const verts: SceneVector2[] = [{ x: 0, y: 0 }];
+  for (let i = 0; i <= normalized; i += 1) {
+    const angle = (i / normalized) * Math.PI * 2;
+    verts.push({ x: Math.cos(angle) * radius, y: Math.sin(angle) * radius });
+  }
+  return verts;
+};
+
+export interface JoinedGpuPrimitiveOptions {
+  anchorIndex: number;
+  joinOffset?: SceneVector2;
+  refreshFill?: (instance: SceneObjectInstance) => SceneFill;
+}
+
+export const createJoinedPolygonGpuPrimitive = (
+  instance: SceneObjectInstance,
+  options: {
+    vertices: SceneVector2[];
+    fill: SceneFill;
+  } & JoinedGpuPrimitiveOptions
+): DynamicPrimitive | null => {
+  if (!options.vertices || options.vertices.length < 3) {
+    return null;
+  }
+  const vertexCount = options.vertices.length;
+  const packedVertices = buildPackedVertices(options.vertices);
+  const geometry = computePolygonGeometry(options.vertices);
+
+  const fillScratch = new Float32Array(FILL_COMPONENTS);
+  let fillData: Float32Array | null = null;
+  let cachedFill: SceneFill = options.fill;
+  let prevInstanceFillRef: SceneFill | undefined =
+    typeof options.refreshFill === "function" ? instance.data.fill : undefined;
+
+  let gl = getAnimationGpuContext();
+  let fillBuffer: WebGLBuffer | null = null;
+  let positionBuffer: WebGLBuffer | null = null;
+  let renderHandle: JoinedPolygonGpuHandle | null = null;
+
+  const ensureResources = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    if (!positionBuffer) {
+      positionBuffer = gl.createBuffer();
+      if (!positionBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        packedVertices,
+        gl.STATIC_DRAW
+      );
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    if (!fillBuffer) {
+      fillBuffer = gl.createBuffer();
+      if (!fillBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        vertexCount * FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+        gl.DYNAMIC_DRAW
+      );
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    joinedPolygonGpuRenderer.setContext(gl);
+    if (!renderHandle) {
+      renderHandle = joinedPolygonGpuRenderer.acquireHandle({
+        positionBuffer,
+        fillBuffer,
+        vertexCount,
+        anchorIndex: options.anchorIndex,
+        joinOffset: options.joinOffset ?? { x: 0, y: 0 },
+      });
+      if (!renderHandle) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureResources() || !gl || !fillBuffer || !renderHandle) {
+        return null;
+      }
+
+      let fillRefChanged = false;
+      if (typeof options.refreshFill === "function") {
+        if (target.data.fill !== prevInstanceFillRef) {
+          prevInstanceFillRef = target.data.fill;
+          cachedFill = options.refreshFill(target);
+          fillRefChanged = true;
+        }
+      }
+
+      if (fillRefChanged) {
+        const fillComponents = writeFillVertexComponents(fillScratch, {
+          fill: cachedFill,
+          center: geometry.centerOffset,
+          rotation: 0,
+          size: geometry.size,
+        });
+        fillData = buildFillBufferData(vertexCount, fillComponents, fillData ?? undefined);
+        gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, fillData);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+      } else if (!fillData) {
+        const fillComponents = writeFillVertexComponents(fillScratch, {
+          fill: cachedFill,
+          center: geometry.centerOffset,
+          rotation: 0,
+          size: geometry.size,
+        });
+        fillData = buildFillBufferData(vertexCount, fillComponents, fillData ?? undefined);
+        gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, fillData);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+      }
+
+      const pos = getInstanceRenderPosition(target);
+      renderHandle.instancePosition.x = pos.x;
+      renderHandle.instancePosition.y = pos.y;
+      renderHandle.instanceRotation = target.data.rotation ?? 0;
+      return null;
+    },
+    dispose() {
+      if (!gl) {
+        return;
+      }
+      if (renderHandle) {
+        joinedPolygonGpuRenderer.releaseHandle(renderHandle);
+        renderHandle = null;
+      }
+      if (fillBuffer) {
+        gl.deleteBuffer(fillBuffer);
+        fillBuffer = null;
+      }
+      if (positionBuffer) {
+        gl.deleteBuffer(positionBuffer);
+        positionBuffer = null;
+      }
+    },
+  };
+
+  return primitive;
+};
+
+export const createJoinedCircleGpuPrimitive = (
+  instance: SceneObjectInstance,
+  options: {
+    radius: number;
+    segments?: number;
+    fill: SceneFill;
+  } & JoinedGpuPrimitiveOptions
+): DynamicPrimitive | null => {
+  const vertices = buildCircleFanVertices(options.radius, options.segments ?? 24);
+  const vertexCount = vertices.length;
+  const packedVertices = buildPackedVertices(vertices);
+
+  const size = { width: options.radius * 2, height: options.radius * 2 };
+  const centerOffset = { x: 0, y: 0 };
+
+  const fillScratch = new Float32Array(FILL_COMPONENTS);
+  let fillData: Float32Array | null = null;
+  let cachedFill: SceneFill = options.fill;
+  let prevInstanceFillRef: SceneFill | undefined =
+    typeof options.refreshFill === "function" ? instance.data.fill : undefined;
+
+  let gl = getAnimationGpuContext();
+  let fillBuffer: WebGLBuffer | null = null;
+  let positionBuffer: WebGLBuffer | null = null;
+  let renderHandle: JoinedPolygonGpuHandle | null = null;
+
+  const ensureResources = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    if (!positionBuffer) {
+      positionBuffer = gl.createBuffer();
+      if (!positionBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, packedVertices, gl.STATIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    if (!fillBuffer) {
+      fillBuffer = gl.createBuffer();
+      if (!fillBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        vertexCount * FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+        gl.DYNAMIC_DRAW
+      );
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    joinedPolygonGpuRenderer.setContext(gl);
+    if (!renderHandle) {
+      renderHandle = joinedPolygonGpuRenderer.acquireHandle({
+        positionBuffer,
+        fillBuffer,
+        vertexCount,
+        anchorIndex: options.anchorIndex,
+        joinOffset: options.joinOffset ?? { x: 0, y: 0 },
+      });
+      if (!renderHandle) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureResources() || !gl || !fillBuffer || !renderHandle) {
+        return null;
+      }
+
+      let fillRefChanged = false;
+      if (typeof options.refreshFill === "function") {
+        if (target.data.fill !== prevInstanceFillRef) {
+          prevInstanceFillRef = target.data.fill;
+          cachedFill = options.refreshFill(target);
+          fillRefChanged = true;
+        }
+      }
+
+      if (fillRefChanged || !fillData) {
+        const fillComponents = writeFillVertexComponents(fillScratch, {
+          fill: cachedFill,
+          center: centerOffset,
+          rotation: 0,
+          size,
+          radius: options.radius,
+        });
+        fillData = buildFillBufferData(vertexCount, fillComponents, fillData ?? undefined);
+        gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, fillData);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+      }
+
+      const pos = getInstanceRenderPosition(target);
+      renderHandle.instancePosition.x = pos.x;
+      renderHandle.instancePosition.y = pos.y;
+      renderHandle.instanceRotation = target.data.rotation ?? 0;
+      return null;
+    },
+    dispose() {
+      if (!gl) {
+        return;
+      }
+      if (renderHandle) {
+        joinedPolygonGpuRenderer.releaseHandle(renderHandle);
+        renderHandle = null;
+      }
+      if (fillBuffer) {
+        gl.deleteBuffer(fillBuffer);
+        fillBuffer = null;
+      }
+      if (positionBuffer) {
+        gl.deleteBuffer(positionBuffer);
+        positionBuffer = null;
+      }
+    },
+  };
+
+  return primitive;
+};

--- a/src/ui/renderers/primitives/basic/CirclePrimitive.ts
+++ b/src/ui/renderers/primitives/basic/CirclePrimitive.ts
@@ -30,6 +30,7 @@ interface CirclePrimitiveOptions {
 interface DynamicCircleOptions {
   segments?: number;
   offset?: SceneVector2;
+  getOffset?: (instance: SceneObjectInstance) => SceneVector2 | undefined;
   radius?: number;
   getRadius?: (instance: SceneObjectInstance, previousRadius: number) => number;
   fill?: SceneFill;
@@ -104,6 +105,16 @@ const resolveFill = (
     return options.fill;
   }
   return instance.data.fill;
+};
+
+const resolveOffset = (
+  options: DynamicCircleOptions,
+  instance: SceneObjectInstance
+): SceneVector2 | undefined => {
+  if (typeof options.getOffset === "function") {
+    return options.getOffset(instance);
+  }
+  return options.offset;
 };
 
 const pushVertex = (
@@ -266,7 +277,8 @@ export const createDynamicCirclePrimitive = (
   // refreshFill tracks instance.data.fill reference changes for visual effects
   const hasRefreshFill = typeof options.refreshFill === "function";
   // Can only fast-path if fill doesn't need refresh tracking
-  const canFastPath = isStaticFill && isStaticRadius && !hasRefreshFill;
+  const canFastPath =
+    isStaticFill && isStaticRadius && !hasRefreshFill && !options.getOffset;
   
   // For solid fills, components don't depend on center/rotation
   const staticFill = isStaticFill ? options.fill : null;
@@ -274,7 +286,7 @@ export const createDynamicCirclePrimitive = (
   
   const segments = Math.max(3, Math.floor(options.segments ?? DEFAULT_SEGMENTS));
   const trig = getCircleTrigLut(segments);
-  const initialCenter = getCenter(instance, options.offset);
+  const initialCenter = getCenter(instance, options);
   let radius = Math.max(
     resolveRadius(options, instance, getRadiusFromSize(instance.data.size, 0)),
     0
@@ -307,6 +319,8 @@ export const createDynamicCirclePrimitive = (
   previousFill.set(initialFillComponents);
   let previousCenterX = initialCenter.x;
   let previousCenterY = initialCenter.y;
+  let previousOffsetX = resolveOffset(options, instance)?.x ?? 0;
+  let previousOffsetY = resolveOffset(options, instance)?.y ?? 0;
   // Cache raw position for fast-path
   let prevPosX = getInstanceRenderPosition(instance).x;
   let prevPosY = getInstanceRenderPosition(instance).y;
@@ -317,6 +331,9 @@ export const createDynamicCirclePrimitive = (
     update(target: SceneObjectInstance) {
       const pos = getInstanceRenderPosition(target);
       const nextRotation = target.data.rotation ?? 0;
+      const nextOffset = resolveOffset(options, target);
+      const nextOffsetX = nextOffset?.x ?? 0;
+      const nextOffsetY = nextOffset?.y ?? 0;
       
       // Check if instance.data.fill reference changed (visual effect applied)
       let fillRefChanged = false;
@@ -330,11 +347,13 @@ export const createDynamicCirclePrimitive = (
       if (canFastPath &&
           pos.x === prevPosX &&
           pos.y === prevPosY &&
-          nextRotation === prevRotation) {
+          nextRotation === prevRotation &&
+          nextOffsetX === previousOffsetX &&
+          nextOffsetY === previousOffsetY) {
         return null;
       }
       
-      const nextCenter = getCenter(target, options.offset);
+      const nextCenter = getCenter(target, options);
       const nextRadius = Math.max(
         resolveRadius(options, target, getRadiusFromSize(target.data.size, radius)),
         0
@@ -389,6 +408,8 @@ export const createDynamicCirclePrimitive = (
         prevPosX = pos.x;
         prevPosY = pos.y;
         prevRotation = nextRotation;
+        previousOffsetX = nextOffsetX;
+        previousOffsetY = nextOffsetY;
         return null;
       }
       radius = nextRadius;
@@ -397,6 +418,8 @@ export const createDynamicCirclePrimitive = (
       prevPosX = pos.x;
       prevPosY = pos.y;
       prevRotation = nextRotation;
+      previousOffsetX = nextOffsetX;
+      previousOffsetY = nextOffsetY;
       if (fillChanged) {
         previousFill.set(fillComponents);
       }
@@ -405,11 +428,16 @@ export const createDynamicCirclePrimitive = (
     updatePositionOnly(target: SceneObjectInstance) {
       const pos = getInstanceRenderPosition(target);
       const nextRotation = target.data.rotation ?? 0;
-      const nextCenter = getCenter(target, options.offset);
+      const nextOffset = resolveOffset(options, target);
+      const nextOffsetX = nextOffset?.x ?? 0;
+      const nextOffsetY = nextOffset?.y ?? 0;
+      const nextCenter = getCenter(target, options);
       const centerChanged =
         nextCenter.x !== previousCenterX || nextCenter.y !== previousCenterY;
       const rotationChanged = nextRotation !== prevRotation;
-      if (!centerChanged && !rotationChanged) {
+      const offsetChanged =
+        nextOffsetX !== previousOffsetX || nextOffsetY !== previousOffsetY;
+      if (!centerChanged && !rotationChanged && !offsetChanged) {
         return null;
       }
       prevPosX = pos.x;
@@ -417,6 +445,8 @@ export const createDynamicCirclePrimitive = (
       prevRotation = nextRotation;
       previousCenterX = nextCenter.x;
       previousCenterY = nextCenter.y;
+      previousOffsetX = nextOffsetX;
+      previousOffsetY = nextOffsetY;
 
       const shouldUpdateFill =
         cachedFill.fillType !== 0 ||
@@ -455,11 +485,11 @@ export const createDynamicCirclePrimitive = (
 
 const getCenter = (
   instance: SceneObjectInstance,
-  offset: SceneVector2 | undefined
+  options: DynamicCircleOptions
 ): SceneVector2 => {
   return transformObjectPoint(
     getInstanceRenderPosition(instance),
     instance.data.rotation,
-    offset
+    resolveOffset(options, instance)
   );
 };

--- a/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
+++ b/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
@@ -33,6 +33,7 @@ interface DynamicPolygonPrimitiveOptions {
   fill?: SceneFill;
   getFill?: (instance: SceneObjectInstance) => SceneFill;
   offset?: SceneVector2;
+  getOffset?: (instance: SceneObjectInstance) => SceneVector2 | undefined;
   /**
    * Callback to refresh fill when instance.data.fill reference changes.
    * Used for "base" fills in composite renderers that depend on visual effects.
@@ -111,6 +112,16 @@ const resolveFill = (
     return options.fill;
   }
   return instance.data.fill;
+};
+
+const resolveOffset = (
+  options: { offset?: SceneVector2; getOffset?: (instance: SceneObjectInstance) => SceneVector2 | undefined },
+  instance: SceneObjectInstance
+): SceneVector2 | undefined => {
+  if (typeof options.getOffset === "function") {
+    return options.getOffset(instance);
+  }
+  return options.offset;
 };
 
 // OPTIMIZATION: Reusable geometry object to avoid per-frame allocations
@@ -455,7 +466,8 @@ export const createDynamicPolygonPrimitive = (
   // refreshFill tracks instance.data.fill reference changes for visual effects
   const hasRefreshFill = typeof options.refreshFill === "function";
   // Can only fast-path if fill doesn't need refresh tracking
-  const canFastPath = isStaticVertices && isStaticFill && !hasRefreshFill;
+  const canFastPath =
+    isStaticVertices && isStaticFill && !hasRefreshFill && !options.getOffset;
   
   const initialVertices = resolveVertices(options, instance);
   let vertexCount = initialVertices.length;
@@ -464,7 +476,7 @@ export const createDynamicPolygonPrimitive = (
     transformObjectPoint(
       getInstanceRenderPosition(target),
       target.data.rotation,
-      options.offset
+      resolveOffset(options, target)
     );
 
   let origin = getCenter(instance);
@@ -490,6 +502,8 @@ export const createDynamicPolygonPrimitive = (
   let prevPosX = getInstanceRenderPosition(instance).x;
   let prevPosY = getInstanceRenderPosition(instance).y;
   let prevRotation = rotation;
+  let prevOffsetX = resolveOffset(options, instance)?.x ?? 0;
+  let prevOffsetY = resolveOffset(options, instance)?.y ?? 0;
 
   const primitive: DynamicPrimitive = {
     get data() {
@@ -498,13 +512,18 @@ export const createDynamicPolygonPrimitive = (
     update(target: SceneObjectInstance) {
       const pos = getInstanceRenderPosition(target);
       const nextRotation = target.data.rotation ?? 0;
+      const nextOffset = resolveOffset(options, target);
+      const nextOffsetX = nextOffset?.x ?? 0;
+      const nextOffsetY = nextOffset?.y ?? 0;
       
       // Fast path: skip expensive computations if nothing changed
       // For static vertices/fill, only position and rotation matter
       if (canFastPath &&
           pos.x === prevPosX &&
           pos.y === prevPosY &&
-          nextRotation === prevRotation) {
+          nextRotation === prevRotation &&
+          nextOffsetX === prevOffsetX &&
+          nextOffsetY === prevOffsetY) {
         return null;
       }
       
@@ -513,6 +532,8 @@ export const createDynamicPolygonPrimitive = (
       prevPosX = pos.x;
       prevPosY = pos.y;
       prevRotation = rotation;
+      prevOffsetX = nextOffsetX;
+      prevOffsetY = nextOffsetY;
       
       // Skip expensive geometry/vertices work for static vertices
       let nextVertices: PolygonVertices;
@@ -582,10 +603,15 @@ export const createDynamicPolygonPrimitive = (
     updatePositionOnly(target: SceneObjectInstance) {
       const pos = getInstanceRenderPosition(target);
       const nextRotation = target.data.rotation ?? 0;
+      const nextOffset = resolveOffset(options, target);
+      const nextOffsetX = nextOffset?.x ?? 0;
+      const nextOffsetY = nextOffset?.y ?? 0;
       if (
         pos.x === prevPosX &&
         pos.y === prevPosY &&
-        nextRotation === prevRotation
+        nextRotation === prevRotation &&
+        nextOffsetX === prevOffsetX &&
+        nextOffsetY === prevOffsetY
       ) {
         return null;
       }
@@ -594,6 +620,8 @@ export const createDynamicPolygonPrimitive = (
       prevPosX = pos.x;
       prevPosY = pos.y;
       prevRotation = rotation;
+      prevOffsetX = nextOffsetX;
+      prevOffsetY = nextOffsetY;
 
       const expectedSize = Math.max(currentVertices.length - 2, 0) * 3 * VERTEX_COMPONENTS;
       if (data.length !== expectedSize) {
@@ -628,6 +656,7 @@ interface DynamicPolygonStrokePrimitiveOptions {
   getVertices?: (instance: SceneObjectInstance) => SceneVector2[];
   stroke: SceneStroke;
   offset?: SceneVector2;
+  getOffset?: (instance: SceneObjectInstance) => SceneVector2 | undefined;
   /**
    * Callback to refresh stroke when instance.data.stroke reference changes.
    * Used for "base" strokes in composite renderers that depend on visual effects.
@@ -995,6 +1024,7 @@ export const createDynamicPolygonStrokePrimitive = (
 ): DynamicPrimitive => {
   // Check if vertices are static (not animated)
   const isStaticVertices = !options.getVertices && !!options.vertices;
+  const hasDynamicOffset = typeof options.getOffset === "function";
   const hasRefreshStroke = typeof options.refreshStroke === "function";
   
   const resolveVerts = (target: SceneObjectInstance): PolygonVertices => {
@@ -1011,7 +1041,7 @@ export const createDynamicPolygonStrokePrimitive = (
     transformObjectPoint(
       getInstanceRenderPosition(target),
       target.data.rotation,
-      options.offset
+      resolveOffset(options, target)
     );
 
   let inner = resolveVerts(instance);
@@ -1039,6 +1069,8 @@ export const createDynamicPolygonStrokePrimitive = (
   let prevPosX = getInstanceRenderPosition(instance).x;
   let prevPosY = getInstanceRenderPosition(instance).y;
   let prevRotation = rotation;
+  let prevOffsetX = resolveOffset(options, instance)?.x ?? 0;
+  let prevOffsetY = resolveOffset(options, instance)?.y ?? 0;
 
   const primitive: DynamicPrimitive = {
     get data() {
@@ -1047,6 +1079,9 @@ export const createDynamicPolygonStrokePrimitive = (
     update(target: SceneObjectInstance) {
       const pos = getInstanceRenderPosition(target);
       const nextRotation = target.data.rotation ?? 0;
+      const nextOffset = resolveOffset(options, target);
+      const nextOffsetX = nextOffset?.x ?? 0;
+      const nextOffsetY = nextOffset?.y ?? 0;
       
       // Check if stroke reference changed (visual effect applied)
       let strokeRefChanged = false;
@@ -1059,10 +1094,13 @@ export const createDynamicPolygonStrokePrimitive = (
       
       // Fast path: skip update if position/rotation unchanged, vertices are static, and stroke didn't change
       if (isStaticVertices &&
+          !hasDynamicOffset &&
           !strokeRefChanged &&
           pos.x === prevPosX &&
           pos.y === prevPosY &&
-          nextRotation === prevRotation) {
+          nextRotation === prevRotation &&
+          nextOffsetX === prevOffsetX &&
+          nextOffsetY === prevOffsetY) {
         return null;
       }
       
@@ -1071,6 +1109,8 @@ export const createDynamicPolygonStrokePrimitive = (
       prevPosX = pos.x;
       prevPosY = pos.y;
       prevRotation = rotation;
+      prevOffsetX = nextOffsetX;
+      prevOffsetY = nextOffsetY;
       
       // Skip expensive geometry/vertices work for static vertices
       if (!isStaticVertices) {
@@ -1112,10 +1152,15 @@ export const createDynamicPolygonStrokePrimitive = (
     updatePositionOnly(target: SceneObjectInstance) {
       const pos = getInstanceRenderPosition(target);
       const nextRotation = target.data.rotation ?? 0;
+      const nextOffset = resolveOffset(options, target);
+      const nextOffsetX = nextOffset?.x ?? 0;
+      const nextOffsetY = nextOffset?.y ?? 0;
       if (
         pos.x === prevPosX &&
         pos.y === prevPosY &&
-        nextRotation === prevRotation
+        nextRotation === prevRotation &&
+        nextOffsetX === prevOffsetX &&
+        nextOffsetY === prevOffsetY
       ) {
         return null;
       }
@@ -1124,6 +1169,8 @@ export const createDynamicPolygonStrokePrimitive = (
       prevPosX = pos.x;
       prevPosY = pos.y;
       prevRotation = rotation;
+      prevOffsetX = nextOffsetX;
+      prevOffsetY = nextOffsetY;
 
       const n = Math.min(inner.length, outer.length);
       const expectedSize = n * 2 * 3 * VERTEX_COMPONENTS;

--- a/src/ui/renderers/primitives/basic/SpritePrimitive.ts
+++ b/src/ui/renderers/primitives/basic/SpritePrimitive.ts
@@ -56,6 +56,7 @@ interface DynamicSpriteOptions {
   getWidth?: (instance: SceneObjectInstance) => number | undefined;
   getHeight?: (instance: SceneObjectInstance) => number | undefined;
   offset?: SceneVector2;
+  getOffset?: (instance: SceneObjectInstance) => SceneVector2 | undefined;
 }
 
 /**
@@ -195,6 +196,16 @@ const updateSpritePositions = (
   return changed;
 };
 
+const resolveOffset = (
+  options: DynamicSpriteOptions,
+  instance: SceneObjectInstance
+): SceneVector2 | undefined => {
+  if (typeof options.getOffset === "function") {
+    return options.getOffset(instance);
+  }
+  return options.offset;
+};
+
 /**
  * Creates a dynamic sprite primitive with texture support
  * Automatically starts loading the texture asynchronously
@@ -225,7 +236,7 @@ export const createDynamicSpritePrimitive = (
   const center = transformObjectPoint(
     getInstanceRenderPosition(instance),
     rotation,
-    options.offset
+    resolveOffset(options, instance)
   );
   const halfWidth = width / 2;
   const halfHeight = height / 2;
@@ -273,15 +284,20 @@ export const createDynamicSpritePrimitive = (
   let prevWidth = width;
   let prevHeight = height;
   let prevRotation = rotation;
+  let prevOffsetX = resolveOffset(options, instance)?.x ?? 0;
+  let prevOffsetY = resolveOffset(options, instance)?.y ?? 0;
 
   return {
     data,
     update(target: SceneObjectInstance) {
       const nextRotation = target.data.rotation ?? 0;
+      const nextOffset = resolveOffset(options, target);
+      const nextOffsetX = nextOffset?.x ?? 0;
+      const nextOffsetY = nextOffset?.y ?? 0;
       const nextCenter = transformObjectPoint(
         getInstanceRenderPosition(target),
         nextRotation,
-        options.offset
+        resolveOffset(options, target)
       );
       const nextWidth = options.getWidth?.(target) ?? 32;
       const nextHeight = options.getHeight?.(target) ?? 32;
@@ -292,13 +308,17 @@ export const createDynamicSpritePrimitive = (
         nextCenter.y !== prevCenterY ||
         nextWidth !== prevWidth ||
         nextHeight !== prevHeight ||
-        nextRotation !== prevRotation
+        nextRotation !== prevRotation ||
+        nextOffsetX !== prevOffsetX ||
+        nextOffsetY !== prevOffsetY
       ) {
         prevCenterX = nextCenter.x;
         prevCenterY = nextCenter.y;
         prevWidth = nextWidth;
         prevHeight = nextHeight;
         prevRotation = nextRotation;
+        prevOffsetX = nextOffsetX;
+        prevOffsetY = nextOffsetY;
 
         const halfW = nextWidth / 2;
         const halfH = nextHeight / 2;
@@ -332,16 +352,21 @@ export const createDynamicSpritePrimitive = (
     },
     updatePositionOnly(target: SceneObjectInstance) {
       const nextRotation = target.data.rotation ?? 0;
+      const nextOffset = resolveOffset(options, target);
+      const nextOffsetX = nextOffset?.x ?? 0;
+      const nextOffsetY = nextOffset?.y ?? 0;
       const nextCenter = transformObjectPoint(
         getInstanceRenderPosition(target),
         nextRotation,
-        options.offset
+        resolveOffset(options, target)
       );
 
       if (
         nextCenter.x === prevCenterX &&
         nextCenter.y === prevCenterY &&
-        nextRotation === prevRotation
+        nextRotation === prevRotation &&
+        nextOffsetX === prevOffsetX &&
+        nextOffsetY === prevOffsetY
       ) {
         return null;
       }
@@ -349,6 +374,8 @@ export const createDynamicSpritePrimitive = (
       prevCenterX = nextCenter.x;
       prevCenterY = nextCenter.y;
       prevRotation = nextRotation;
+      prevOffsetX = nextOffsetX;
+      prevOffsetY = nextOffsetY;
 
       const changed = updateSpritePositions(
         data,

--- a/src/ui/renderers/primitives/gpu/joined/JoinedPolygonGpuRenderer.ts
+++ b/src/ui/renderers/primitives/gpu/joined/JoinedPolygonGpuRenderer.ts
@@ -38,6 +38,7 @@ export type JoinedPolygonGpuHandle = {
   joinOffset: { x: number; y: number };
   instancePosition: { x: number; y: number };
   instanceRotation: number;
+  drawMode: number;
 };
 
 export type AnchorTextureInfo = {
@@ -178,6 +179,7 @@ class JoinedPolygonGpuRenderer {
     vertexCount: number;
     anchorIndex: number;
     joinOffset: { x: number; y: number };
+    drawMode?: number;
   }): JoinedPolygonGpuHandle | null {
     const gl = this.gl;
     if (!gl || !this.program) {
@@ -218,6 +220,7 @@ class JoinedPolygonGpuRenderer {
       joinOffset: options.joinOffset,
       instancePosition: { x: 0, y: 0 },
       instanceRotation: 0,
+      drawMode: options.drawMode ?? gl.TRIANGLE_FAN,
     };
     this.handles.add(handle);
     return handle;
@@ -381,7 +384,7 @@ class JoinedPolygonGpuRenderer {
         gl.uniform1f(this.instanceRotationLocation, handle.instanceRotation);
       }
       gl.bindVertexArray(handle.vao);
-      gl.drawArrays(gl.TRIANGLE_FAN, 0, handle.vertexCount);
+      gl.drawArrays(handle.drawMode, 0, handle.vertexCount);
       drawCalls += 1;
     });
     gl.bindVertexArray(null);

--- a/src/ui/renderers/primitives/gpu/joined/JoinedPolygonGpuRenderer.ts
+++ b/src/ui/renderers/primitives/gpu/joined/JoinedPolygonGpuRenderer.ts
@@ -1,0 +1,480 @@
+import type { SceneCameraState } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import { compileShader, linkProgram } from "@ui/renderers/utils/webglProgram";
+import {
+  SCENE_VERTEX_SHADER_HEADER,
+  createSceneFragmentShader,
+} from "@ui/renderers/shaders/fillEffects.glsl";
+import { TO_CLIP_GLSL } from "@ui/renderers/shaders/common.glsl";
+import {
+  POSITION_COMPONENTS,
+  FILL_COMPONENTS,
+  FILL_INFO_COMPONENTS,
+  FILL_PARAMS0_COMPONENTS,
+  FILL_PARAMS1_COMPONENTS,
+  FILL_FILAMENTS0_COMPONENTS,
+  FILL_FILAMENTS1_COMPONENTS,
+  STOP_OFFSETS_COMPONENTS,
+  STOP_COLOR_COMPONENTS,
+  CRACK_UV_COMPONENTS,
+  CRACK_MASK_COMPONENTS,
+  CRACK_EFFECTS_COMPONENTS,
+} from "@ui/renderers/objects";
+import { textureAtlasRegistry } from "@ui/renderers/textures/TextureAtlasRegistry";
+import { textureResourceManager } from "@ui/renderers/textures/TextureResourceManager";
+import { loadSpriteTexture } from "@ui/renderers/primitives/basic/SpritePrimitive";
+
+interface AttributeConfig {
+  location: number;
+  size: number;
+  offset: number;
+}
+
+export type JoinedPolygonGpuHandle = {
+  vao: WebGLVertexArrayObject;
+  positionBuffer: WebGLBuffer;
+  fillBuffer: WebGLBuffer;
+  vertexCount: number;
+  anchorIndex: number;
+  joinOffset: { x: number; y: number };
+  instancePosition: { x: number; y: number };
+  instanceRotation: number;
+};
+
+export type AnchorTextureInfo = {
+  texture: WebGLTexture;
+  width: number;
+};
+
+const FRAGMENT_SHADER = createSceneFragmentShader();
+
+const JOINED_VERTEX_SHADER = `${SCENE_VERTEX_SHADER_HEADER}
+uniform sampler2D u_anchorTexture;
+uniform float u_anchorTexWidth;
+uniform float u_anchorIndex;
+uniform vec2 u_joinOffset;
+uniform vec2 u_instancePosition;
+uniform float u_instanceRotation;
+
+vec2 rotateVec(vec2 v, float r) {
+  float c = cos(r);
+  float s = sin(r);
+  return vec2(v.x * c - v.y * s, v.x * s + v.y * c);
+}
+
+vec2 fetchAnchor() {
+  int idx = int(u_anchorIndex + 0.5);
+  return texelFetch(u_anchorTexture, ivec2(idx, 0), 0).rg;
+}
+
+${TO_CLIP_GLSL}
+void main() {
+  vec2 anchorPos = fetchAnchor();
+  vec2 anchorOffset = anchorPos + u_joinOffset;
+  vec2 localPos = a_position + anchorOffset;
+  vec2 rotatedPos = rotateVec(localPos, u_instanceRotation);
+  vec2 worldPos = u_instancePosition + rotatedPos;
+
+  float fillType = a_fillInfo.x;
+  vec4 fillParams0 = a_fillParams0;
+  vec4 fillParams1 = a_fillParams1;
+
+  if (fillType > 0.5 && fillType < 1.5) {
+    vec2 startLocal = a_fillParams0.xy + anchorOffset;
+    vec2 endLocal = a_fillParams0.zw + anchorOffset;
+    vec2 startWorld = u_instancePosition + rotateVec(startLocal, u_instanceRotation);
+    vec2 endWorld = u_instancePosition + rotateVec(endLocal, u_instanceRotation);
+    vec2 dir = endWorld - startWorld;
+    float lenSq = dot(dir, dir);
+    fillParams0 = vec4(startWorld, endWorld);
+    fillParams1 = vec4(dir, lenSq > 0.0 ? 1.0 / lenSq : 0.0, fillParams1.w);
+  } else if (fillType < 3.5) {
+    vec2 centerLocal = a_fillParams0.xy + anchorOffset;
+    vec2 centerWorld = u_instancePosition + rotateVec(centerLocal, u_instanceRotation);
+    fillParams0.xy = centerWorld;
+  }
+
+  gl_Position = vec4(toClip(worldPos), 0.0, 1.0);
+  v_worldPosition = worldPos;
+  v_uv = fillParams0.xy;
+  v_fillInfo = a_fillInfo;
+  v_fillParams0 = fillParams0;
+  v_fillParams1 = fillParams1;
+  v_filaments0 = a_filaments0;
+  v_filamentEdgeBlur = a_filamentEdgeBlur;
+  v_stopOffsets = a_stopOffsets;
+  v_stopColor0 = a_stopColor0;
+  v_stopColor1 = a_stopColor1;
+  v_stopColor2 = a_stopColor2;
+  v_crackUv = a_crackUv;
+  v_crackMask = a_crackMask;
+  v_crackEffects = a_crackEffects;
+}
+`;
+
+class JoinedPolygonGpuRenderer {
+  private gl: WebGL2RenderingContext | null = null;
+  private program: WebGLProgram | null = null;
+  private vertexShader: WebGLShader | null = null;
+  private fragmentShader: WebGLShader | null = null;
+  private handles = new Set<JoinedPolygonGpuHandle>();
+  private positionLocation = -1;
+  private fillAttributeConfigs: AttributeConfig[] = [];
+  private fillStride = 0;
+  private cameraPositionLocation: WebGLUniformLocation | null = null;
+  private viewportSizeLocation: WebGLUniformLocation | null = null;
+  private spriteTextureLocation: WebGLUniformLocation | null = null;
+  private crackAtlasIndexLocation: WebGLUniformLocation | null = null;
+  private crackAtlasGridLocation: WebGLUniformLocation | null = null;
+  private crackAtlasSamplerLocation: WebGLUniformLocation | null = null;
+  private anchorTextureLocation: WebGLUniformLocation | null = null;
+  private anchorTexWidthLocation: WebGLUniformLocation | null = null;
+  private anchorIndexLocation: WebGLUniformLocation | null = null;
+  private joinOffsetLocation: WebGLUniformLocation | null = null;
+  private instancePositionLocation: WebGLUniformLocation | null = null;
+  private instanceRotationLocation: WebGLUniformLocation | null = null;
+  private lastDrawCalls = 0;
+  private lastRenderMs = 0;
+  private lastAnchorUploadMs = 0;
+
+  public setContext(gl: WebGL2RenderingContext | null): void {
+    if (this.gl === gl) {
+      return;
+    }
+    this.dispose();
+    this.gl = gl;
+    if (!gl) {
+      return;
+    }
+
+    this.vertexShader = compileShader(gl, gl.VERTEX_SHADER, JOINED_VERTEX_SHADER);
+    this.fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+    this.program = linkProgram(gl, this.vertexShader, this.fragmentShader);
+
+    this.positionLocation = gl.getAttribLocation(this.program, "a_position");
+    if (this.positionLocation < 0) {
+      throw new Error("[JoinedPolygonGpuRenderer] Unable to resolve position attribute");
+    }
+
+    this.fillAttributeConfigs = this.createFillAttributeConfigs(gl, this.program);
+    this.fillStride = FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+
+    this.cameraPositionLocation = gl.getUniformLocation(this.program, "u_cameraPosition");
+    this.viewportSizeLocation = gl.getUniformLocation(this.program, "u_viewportSize");
+    this.spriteTextureLocation = gl.getUniformLocation(this.program, "u_spriteTexture");
+    this.crackAtlasIndexLocation = gl.getUniformLocation(this.program, "u_crackAtlasIndex");
+    this.crackAtlasGridLocation = gl.getUniformLocation(this.program, "u_crackAtlasGrid");
+    this.crackAtlasSamplerLocation = gl.getUniformLocation(this.program, "u_cracksAtlas");
+    this.anchorTextureLocation = gl.getUniformLocation(this.program, "u_anchorTexture");
+    this.anchorTexWidthLocation = gl.getUniformLocation(this.program, "u_anchorTexWidth");
+    this.anchorIndexLocation = gl.getUniformLocation(this.program, "u_anchorIndex");
+    this.joinOffsetLocation = gl.getUniformLocation(this.program, "u_joinOffset");
+    this.instancePositionLocation = gl.getUniformLocation(this.program, "u_instancePosition");
+    this.instanceRotationLocation = gl.getUniformLocation(this.program, "u_instanceRotation");
+  }
+
+  public acquireHandle(options: {
+    positionBuffer: WebGLBuffer;
+    fillBuffer: WebGLBuffer;
+    vertexCount: number;
+    anchorIndex: number;
+    joinOffset: { x: number; y: number };
+  }): JoinedPolygonGpuHandle | null {
+    const gl = this.gl;
+    if (!gl || !this.program) {
+      return null;
+    }
+    const vao = gl.createVertexArray();
+    if (!vao) {
+      return null;
+    }
+    gl.bindVertexArray(vao);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, options.positionBuffer);
+    gl.enableVertexAttribArray(this.positionLocation);
+    gl.vertexAttribPointer(
+      this.positionLocation,
+      POSITION_COMPONENTS,
+      gl.FLOAT,
+      false,
+      POSITION_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+      0
+    );
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, options.fillBuffer);
+    this.fillAttributeConfigs.forEach(({ location, size, offset }) => {
+      gl.enableVertexAttribArray(location);
+      gl.vertexAttribPointer(location, size, gl.FLOAT, false, this.fillStride, offset);
+    });
+
+    gl.bindVertexArray(null);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+    const handle: JoinedPolygonGpuHandle = {
+      vao,
+      positionBuffer: options.positionBuffer,
+      fillBuffer: options.fillBuffer,
+      vertexCount: options.vertexCount,
+      anchorIndex: options.anchorIndex,
+      joinOffset: options.joinOffset,
+      instancePosition: { x: 0, y: 0 },
+      instanceRotation: 0,
+    };
+    this.handles.add(handle);
+    return handle;
+  }
+
+  public updateHandle(handle: JoinedPolygonGpuHandle, vertexCount: number): void {
+    handle.vertexCount = vertexCount;
+  }
+
+  public releaseHandle(handle: JoinedPolygonGpuHandle): void {
+    if (!this.gl) {
+      return;
+    }
+    if (this.handles.has(handle)) {
+      this.handles.delete(handle);
+    }
+    this.gl.deleteVertexArray(handle.vao);
+  }
+
+  public hasHandles(): boolean {
+    return this.handles.size > 0;
+  }
+
+  public setAnchorUploadMs(ms: number): void {
+    this.lastAnchorUploadMs = ms;
+  }
+
+  public getStats(): {
+    handles: number;
+    drawCalls: number;
+    renderMs: number;
+    anchorUploadMs: number;
+  } {
+    return {
+      handles: this.handles.size,
+      drawCalls: this.lastDrawCalls,
+      renderMs: this.lastRenderMs,
+      anchorUploadMs: this.lastAnchorUploadMs,
+    };
+  }
+
+  public render(
+    gl: WebGL2RenderingContext,
+    cameraState: SceneCameraState,
+    anchorTexture: AnchorTextureInfo
+  ): void {
+    if (!this.program || this.handles.size === 0) {
+      return;
+    }
+    const renderStart = performance.now();
+    let drawCalls = 0;
+    gl.useProgram(this.program);
+    if (this.cameraPositionLocation) {
+      gl.uniform2f(
+        this.cameraPositionLocation,
+        cameraState.position.x,
+        cameraState.position.y
+      );
+    }
+    if (this.viewportSizeLocation) {
+      gl.uniform2f(
+        this.viewportSizeLocation,
+        cameraState.viewportSize.width,
+        cameraState.viewportSize.height
+      );
+    }
+
+    if (this.crackAtlasIndexLocation !== null || this.crackAtlasGridLocation !== null) {
+      const crackAtlasIndex = textureAtlasRegistry.getAtlasIndex("cracks");
+      const crackAtlasGrid = textureAtlasRegistry.getAtlasGrid("cracks");
+      if (this.crackAtlasIndexLocation !== null) {
+        gl.uniform1i(this.crackAtlasIndexLocation, crackAtlasIndex);
+      }
+      if (this.crackAtlasGridLocation !== null) {
+        gl.uniform2f(this.crackAtlasGridLocation, crackAtlasGrid.cols, crackAtlasGrid.rows);
+      }
+    }
+
+    if (this.crackAtlasSamplerLocation !== null) {
+      gl.activeTexture(gl.TEXTURE1);
+      gl.uniform1i(this.crackAtlasSamplerLocation, 1);
+
+      const crackPath = "images/sprites/cracks/cracks_atlas.png";
+      const crackTexture = textureResourceManager.getTexture(crackPath);
+      if (crackTexture?.texture && crackTexture.gl === gl) {
+        gl.bindTexture(gl.TEXTURE_2D, crackTexture.texture);
+      } else {
+        if (!crackTexture || crackTexture.gl !== gl) {
+          loadSpriteTexture(gl, crackPath).catch(() => {});
+        }
+        const dummyTexture = gl.createTexture();
+        if (dummyTexture) {
+          gl.bindTexture(gl.TEXTURE_2D, dummyTexture);
+          gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA,
+            1,
+            1,
+            0,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            new Uint8Array([255, 255, 255, 255])
+          );
+        }
+      }
+    }
+
+    if (this.spriteTextureLocation !== null) {
+      gl.activeTexture(gl.TEXTURE0);
+      gl.uniform1i(this.spriteTextureLocation, 0);
+      const firstTexture = textureResourceManager.getAnyTexture();
+      if (firstTexture?.texture) {
+        gl.bindTexture(gl.TEXTURE_2D, firstTexture.texture);
+      } else {
+        const dummyTexture = gl.createTexture();
+        if (dummyTexture) {
+          gl.bindTexture(gl.TEXTURE_2D, dummyTexture);
+          gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA,
+            1,
+            1,
+            0,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            new Uint8Array([255, 255, 255, 255])
+          );
+        }
+      }
+    }
+
+    if (this.anchorTextureLocation) {
+      gl.activeTexture(gl.TEXTURE2);
+      gl.bindTexture(gl.TEXTURE_2D, anchorTexture.texture);
+      gl.uniform1i(this.anchorTextureLocation, 2);
+    }
+    if (this.anchorTexWidthLocation) {
+      gl.uniform1f(this.anchorTexWidthLocation, anchorTexture.width);
+    }
+
+    this.handles.forEach((handle) => {
+      if (handle.vertexCount < 3) {
+        return;
+      }
+      if (this.anchorIndexLocation) {
+        gl.uniform1f(this.anchorIndexLocation, handle.anchorIndex);
+      }
+      if (this.joinOffsetLocation) {
+        gl.uniform2f(this.joinOffsetLocation, handle.joinOffset.x, handle.joinOffset.y);
+      }
+      if (this.instancePositionLocation) {
+        gl.uniform2f(
+          this.instancePositionLocation,
+          handle.instancePosition.x,
+          handle.instancePosition.y
+        );
+      }
+      if (this.instanceRotationLocation) {
+        gl.uniform1f(this.instanceRotationLocation, handle.instanceRotation);
+      }
+      gl.bindVertexArray(handle.vao);
+      gl.drawArrays(gl.TRIANGLE_FAN, 0, handle.vertexCount);
+      drawCalls += 1;
+    });
+    gl.bindVertexArray(null);
+    this.lastDrawCalls = drawCalls;
+    this.lastRenderMs = performance.now() - renderStart;
+  }
+
+  private createFillAttributeConfigs(
+    gl: WebGL2RenderingContext,
+    program: WebGLProgram
+  ): AttributeConfig[] {
+    const fillInfoLocation = gl.getAttribLocation(program, "a_fillInfo");
+    const fillParams0Location = gl.getAttribLocation(program, "a_fillParams0");
+    const fillParams1Location = gl.getAttribLocation(program, "a_fillParams1");
+    const filaments0Location = gl.getAttribLocation(program, "a_filaments0");
+    const filamentEdgeBlurLocation = gl.getAttribLocation(program, "a_filamentEdgeBlur");
+    const stopOffsetsLocation = gl.getAttribLocation(program, "a_stopOffsets");
+    const stopColor0Location = gl.getAttribLocation(program, "a_stopColor0");
+    const stopColor1Location = gl.getAttribLocation(program, "a_stopColor1");
+    const stopColor2Location = gl.getAttribLocation(program, "a_stopColor2");
+    const crackUvLocation = gl.getAttribLocation(program, "a_crackUv");
+    const crackMaskLocation = gl.getAttribLocation(program, "a_crackMask");
+    const crackEffectsLocation = gl.getAttribLocation(program, "a_crackEffects");
+
+    const attributeLocations = [
+      fillInfoLocation,
+      fillParams0Location,
+      fillParams1Location,
+      filaments0Location,
+      filamentEdgeBlurLocation,
+      stopOffsetsLocation,
+      stopColor0Location,
+      stopColor1Location,
+      stopColor2Location,
+      crackUvLocation,
+      crackMaskLocation,
+      crackEffectsLocation,
+    ];
+
+    if (attributeLocations.some((location) => location < 0)) {
+      throw new Error("[JoinedPolygonGpuRenderer] Unable to resolve fill attribute locations");
+    }
+
+    let offset = 0;
+    const configs: AttributeConfig[] = [];
+    configs.push({ location: fillInfoLocation, size: FILL_INFO_COMPONENTS, offset });
+    offset += FILL_INFO_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: fillParams0Location, size: FILL_PARAMS0_COMPONENTS, offset });
+    offset += FILL_PARAMS0_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: fillParams1Location, size: FILL_PARAMS1_COMPONENTS, offset });
+    offset += FILL_PARAMS1_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: filaments0Location, size: FILL_FILAMENTS0_COMPONENTS, offset });
+    offset += FILL_FILAMENTS0_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: filamentEdgeBlurLocation, size: FILL_FILAMENTS1_COMPONENTS, offset });
+    offset += FILL_FILAMENTS1_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: stopOffsetsLocation, size: STOP_OFFSETS_COMPONENTS, offset });
+    offset += STOP_OFFSETS_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: stopColor0Location, size: STOP_COLOR_COMPONENTS, offset });
+    offset += STOP_COLOR_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: stopColor1Location, size: STOP_COLOR_COMPONENTS, offset });
+    offset += STOP_COLOR_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: stopColor2Location, size: STOP_COLOR_COMPONENTS, offset });
+    offset += STOP_COLOR_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: crackUvLocation, size: CRACK_UV_COMPONENTS, offset });
+    offset += CRACK_UV_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: crackMaskLocation, size: CRACK_MASK_COMPONENTS, offset });
+    offset += CRACK_MASK_COMPONENTS * Float32Array.BYTES_PER_ELEMENT;
+    configs.push({ location: crackEffectsLocation, size: CRACK_EFFECTS_COMPONENTS, offset });
+
+    return configs;
+  }
+
+  private dispose(): void {
+    if (!this.gl) {
+      return;
+    }
+    this.handles.forEach((handle) => {
+      this.gl?.deleteVertexArray(handle.vao);
+    });
+    this.handles.clear();
+    if (this.program) {
+      this.gl.deleteProgram(this.program);
+    }
+    if (this.vertexShader) {
+      this.gl.deleteShader(this.vertexShader);
+    }
+    if (this.fragmentShader) {
+      this.gl.deleteShader(this.fragmentShader);
+    }
+    this.program = null;
+    this.vertexShader = null;
+    this.fragmentShader = null;
+  }
+}
+
+export const joinedPolygonGpuRenderer = new JoinedPolygonGpuRenderer();

--- a/src/ui/renderers/primitives/gpu/joined/index.ts
+++ b/src/ui/renderers/primitives/gpu/joined/index.ts
@@ -1,0 +1,5 @@
+export {
+  joinedPolygonGpuRenderer,
+  type JoinedPolygonGpuHandle,
+  type AnchorTextureInfo,
+} from "./JoinedPolygonGpuRenderer";

--- a/src/ui/renderers/primitives/index.ts
+++ b/src/ui/renderers/primitives/index.ts
@@ -20,6 +20,9 @@ export { createPolygonGpuPrimitive } from "./PolygonGpuPrimitive";
 export {
   createJoinedPolygonGpuPrimitive,
   createJoinedCircleGpuPrimitive,
+  createJoinedPolygonStrokeGpuPrimitive,
+  createJoinedCircleStrokeGpuPrimitive,
+  createJoinedSpriteGpuPrimitive,
 } from "./JoinedPolygonGpuPrimitive";
 export { createParticleEmitterPrimitive } from "./ParticleEmitterPrimitive";
 export { createParticleSystemPrimitive } from "./ParticleSystemPrimitive";

--- a/src/ui/renderers/primitives/index.ts
+++ b/src/ui/renderers/primitives/index.ts
@@ -17,6 +17,10 @@ export {
   createDynamicPolygonStrokePrimitive,
 } from "./basic/PolygonPrimitive";
 export { createPolygonGpuPrimitive } from "./PolygonGpuPrimitive";
+export {
+  createJoinedPolygonGpuPrimitive,
+  createJoinedCircleGpuPrimitive,
+} from "./JoinedPolygonGpuPrimitive";
 export { createParticleEmitterPrimitive } from "./ParticleEmitterPrimitive";
 export { createParticleSystemPrimitive } from "./ParticleSystemPrimitive";
 export { createFireRingPrimitive } from "./FireRingPrimitive";

--- a/src/ui/renderers/utils/WebGLSceneRenderer.ts
+++ b/src/ui/renderers/utils/WebGLSceneRenderer.ts
@@ -25,7 +25,9 @@ import { textureAtlasRegistry } from "../textures/TextureAtlasRegistry";
 import { loadSpriteTexture } from "../primitives/basic/SpritePrimitive";
 import { textureResourceManager } from "../textures/TextureResourceManager";
 import { setAnimationGpuContext, disposeAnimationGpuResources } from "../objects/shared/animation-gpu";
+import { disposeAnchorsGpuResources, updateAnchorsGpuTexture } from "../objects/shared/anchors-gpu";
 import { polygonGpuRenderer } from "../primitives/gpu/polygon";
+import { joinedPolygonGpuRenderer } from "../primitives/gpu/joined";
 
 const VERTEX_SHADER = SCENE_VERTEX_SHADER;
 const FRAGMENT_SHADER = createSceneFragmentShader();
@@ -313,6 +315,17 @@ export class WebGLSceneRenderer {
     this.drawBuffer(this.dynamicBuffer, this.objectsRenderer.getDynamicVertexCount());
     polygonGpuRenderer.setContext(this.gl);
     polygonGpuRenderer.render(this.gl, cameraState);
+    joinedPolygonGpuRenderer.setContext(this.gl);
+    if (joinedPolygonGpuRenderer.hasHandles()) {
+      const uploadStart = performance.now();
+      const anchorTexture = updateAnchorsGpuTexture(this.gl);
+      joinedPolygonGpuRenderer.setAnchorUploadMs(performance.now() - uploadStart);
+      if (anchorTexture) {
+        joinedPolygonGpuRenderer.render(this.gl, cameraState, anchorTexture);
+      }
+    } else {
+      joinedPolygonGpuRenderer.setAnchorUploadMs(0);
+    }
   }
 
   /**
@@ -374,8 +387,10 @@ export class WebGLSceneRenderer {
    */
   public dispose(): void {
     disposeAnimationGpuResources(this.gl);
+    disposeAnchorsGpuResources(this.gl);
     setAnimationGpuContext(null);
     polygonGpuRenderer.setContext(null);
+    joinedPolygonGpuRenderer.setContext(null);
     this.gl.deleteBuffer(this.staticBuffer);
     this.gl.deleteBuffer(this.dynamicBuffer);
     this.gl.deleteProgram(this.program);

--- a/src/ui/screens/Scene/SceneScreen.css
+++ b/src/ui/screens/Scene/SceneScreen.css
@@ -24,3 +24,19 @@
   -moz-user-select: none;
   -ms-user-select: none;
 }
+
+.scene-debug-banner {
+  position: absolute;
+  top: 0.75rem;
+  right: 1rem;
+  z-index: 15;
+  padding: 0.4rem 0.8rem;
+  border-radius: 0.6rem;
+  background: rgba(8, 18, 32, 0.8);
+  color: #d9e8ff;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  border: 1px solid rgba(120, 160, 255, 0.4);
+  box-shadow: 0 8px 20px rgba(10, 20, 40, 0.45);
+  pointer-events: none;
+}

--- a/src/ui/screens/Scene/SceneScreen.tsx
+++ b/src/ui/screens/Scene/SceneScreen.tsx
@@ -39,6 +39,8 @@ import type { SceneUiApi, SceneVector2 } from "@core/logic/provided/services/sce
 import type { GameLoopUiApi } from "@core/logic/provided/services/game-loop/game-loop.types";
 import { SceneTutorialBridgeMonitor } from "./components/tutorial/SceneTutorialBridgeMonitor";
 import { SceneSummoningPanelContainer } from "./components/summoning/SceneSummoningPanelContainer";
+import { createJoinedDebugRendererConfig } from "./components/debug/joinedDebugConfig";
+import { FILL_TYPES } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.const";
 
 const EMPTY_SPAWN_OPTIONS: NecromancerSpawnOption[] = [];
 const DEFAULT_MAP_EFFECTS_STATE = { radioactivity: null };
@@ -111,6 +113,14 @@ export const SceneScreen: React.FC<SceneScreenProps> = ({
   const [tutorialSummonDone, setTutorialSummonDone] = useState(false);
   const [tutorialSpellCastDone, setTutorialSpellCastDone] = useState(false);
   const [canAdvancePlayStep, setCanAdvancePlayStep] = useState(false);
+  const joinedDebugEnabled = useMemo(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    const params = new URLSearchParams(window.location.search);
+    return params.get("joinedDebug") === "1";
+  }, []);
+  const joinedDebugSpawnedRef = useRef(false);
   const spellCastTokenRef = useRef(0);
   const [spellCastPulse, setSpellCastPulse] = useState<{ id: SpellId; token: number } | null>(
     null
@@ -371,6 +381,49 @@ export const SceneScreen: React.FC<SceneScreenProps> = ({
     handleLeaveToMapSelect();
   }, [handleLeaveToMapSelect]);
 
+  useEffect(() => {
+    if (!joinedDebugEnabled || joinedDebugSpawnedRef.current) {
+      return;
+    }
+    joinedDebugSpawnedRef.current = true;
+    const debugRenderer = createJoinedDebugRendererConfig();
+    const gridSize = 32;
+    const spacing = 40;
+    const originX = -((gridSize - 1) * spacing) / 2;
+    const originY = -((gridSize - 1) * spacing) / 2;
+    const ids: string[] = [];
+
+    scene.setMapSize({
+      width: gridSize * spacing + 200,
+      height: gridSize * spacing + 200,
+    });
+    scene.setCameraPosition(0, 0);
+
+    for (let y = 0; y < gridSize; y += 1) {
+      for (let x = 0; x < gridSize; x += 1) {
+        const position = {
+          x: originX + x * spacing,
+          y: originY + y * spacing,
+        };
+        const id = scene.addObject("playerUnit", {
+          position,
+          size: { width: 24, height: 24 },
+          fill: { fillType: FILL_TYPES.SOLID, color: { r: 0.2, g: 0.6, b: 1, a: 1 } },
+          customData: {
+            renderer: debugRenderer,
+            baseFillColor: debugRenderer.fill,
+          },
+        });
+        ids.push(id);
+      }
+    }
+
+    return () => {
+      const api = scene as unknown as { removeObject?: (id: string) => void };
+      ids.forEach((id) => api.removeObject?.(id));
+    };
+  }, [joinedDebugEnabled, scene]);
+
   // Handle page unload (refresh/close) - cleanup logic modules
   // NOTE: We use beforeunload instead of useEffect cleanup because React StrictMode
   // in dev mode double-invokes effects, which would incorrectly call leaveCurrentMap
@@ -413,7 +466,12 @@ export const SceneScreen: React.FC<SceneScreenProps> = ({
       />
       <SceneControlHintsPanel />
       <SceneTooltipBridgePanel contentOverride={summoningTooltipContent} />
-      {/*<SceneDebugPanel bridge={bridge} />*/}
+      {joinedDebugEnabled && (
+        <div className="scene-debug-banner">
+          Joined GPU Debug (joinedDebug=1) — showing 1024 joined elements
+        </div>
+      )}
+      {joinedDebugEnabled && <SceneDebugPanel bridge={bridge} />}
       <SceneTutorialBridgeMonitor
         bridge={bridge}
         showTutorial={showTutorial}

--- a/src/ui/screens/Scene/components/debug/SceneDebugPanel.tsx
+++ b/src/ui/screens/Scene/components/debug/SceneDebugPanel.tsx
@@ -23,11 +23,15 @@ const SceneDebugPanelInner: React.FC<SceneDebugPanelProps> = ({ bridge }) => {
   const vboRef = useRef<HTMLDivElement | null>(null);
   const particlesRef = useRef<HTMLDivElement | null>(null);
   const movableRef = useRef<HTMLDivElement | null>(null);
+  const joinedRef = useRef<HTMLDivElement | null>(null);
+  const joinedTimingRef = useRef<HTMLDivElement | null>(null);
   const lastDisplayedTime = useRef<string | null>(null);
   const lastDisplayedFps = useRef<number | null>(null);
   const lastDisplayedVbo = useRef<string | null>(null);
   const lastDisplayedParticles = useRef<string | null>(null);
   const lastDisplayedMovable = useRef<string | null>(null);
+  const lastDisplayedJoined = useRef<string | null>(null);
+  const lastDisplayedJoinedTiming = useRef<string | null>(null);
 
   useEffect(() => {
     const update = () => {
@@ -73,6 +77,22 @@ const SceneDebugPanelInner: React.FC<SceneDebugPanelProps> = ({ bridge }) => {
           movableRef.current.textContent = next;
         }
       }
+
+      if (joinedRef.current) {
+        const next = `Joined GPU: ${debugStats.joinedHandles} handles / ${debugStats.joinedDrawCalls} draws`;
+        if (lastDisplayedJoined.current !== next) {
+          lastDisplayedJoined.current = next;
+          joinedRef.current.textContent = next;
+        }
+      }
+
+      if (joinedTimingRef.current) {
+        const next = `Joined GPU timing: render ${debugStats.joinedRenderMs.toFixed(2)}ms, upload ${debugStats.joinedUploadMs.toFixed(2)}ms`;
+        if (lastDisplayedJoinedTiming.current !== next) {
+          lastDisplayedJoinedTiming.current = next;
+          joinedTimingRef.current.textContent = next;
+        }
+      }
     };
 
     update();
@@ -90,6 +110,8 @@ const SceneDebugPanelInner: React.FC<SceneDebugPanelProps> = ({ bridge }) => {
       <div className="scene-debug-panel__item" ref={vboRef} />
       <div className="scene-debug-panel__item" ref={particlesRef} />
       <div className="scene-debug-panel__item" ref={movableRef} />
+      <div className="scene-debug-panel__item" ref={joinedRef} />
+      <div className="scene-debug-panel__item" ref={joinedTimingRef} />
     </div>
   );
 };

--- a/src/ui/screens/Scene/components/debug/debugStats.ts
+++ b/src/ui/screens/Scene/components/debug/debugStats.ts
@@ -13,6 +13,10 @@ export interface DebugStats {
   particleCapacity: number;
   particleEmitters: number;
   movableObjects: number;
+  joinedHandles: number;
+  joinedDrawCalls: number;
+  joinedRenderMs: number;
+  joinedUploadMs: number;
   // FPS tracking - updated by render loop
   frameCount: number;
   lastFpsUpdate: number;
@@ -27,6 +31,10 @@ export const debugStats: DebugStats = {
   particleCapacity: 0,
   particleEmitters: 0,
   movableObjects: 0,
+  joinedHandles: 0,
+  joinedDrawCalls: 0,
+  joinedRenderMs: 0,
+  joinedUploadMs: 0,
   frameCount: 0,
   lastFpsUpdate: 0,
   currentFps: 0,
@@ -52,6 +60,18 @@ export const updateParticleStats = (
 /** Update movable objects count (called from useSceneCanvas) */
 export const updateMovableStats = (count: number): void => {
   debugStats.movableObjects = count;
+};
+
+export const updateJoinedStats = (stats: {
+  handles: number;
+  drawCalls: number;
+  renderMs: number;
+  uploadMs: number;
+}): void => {
+  debugStats.joinedHandles = stats.handles;
+  debugStats.joinedDrawCalls = stats.drawCalls;
+  debugStats.joinedRenderMs = stats.renderMs;
+  debugStats.joinedUploadMs = stats.uploadMs;
 };
 
 /** 

--- a/src/ui/screens/Scene/components/debug/joinedDebugConfig.ts
+++ b/src/ui/screens/Scene/components/debug/joinedDebugConfig.ts
@@ -1,0 +1,41 @@
+import type { PlayerUnitRendererConfig } from "@db/player-units-db";
+import { FILL_TYPES } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.const";
+
+export const createJoinedDebugRendererConfig = (): PlayerUnitRendererConfig => ({
+  kind: "composite",
+  fill: { r: 0.2, g: 0.6, b: 1, a: 1 },
+  layers: [
+    {
+      shape: "polygon",
+      vertices: [
+        { x: -6, y: -4 },
+        { x: 6, y: -4 },
+        { x: 0, y: 8 },
+      ],
+      fill: {
+        type: "solid",
+        fill: { fillType: FILL_TYPES.SOLID, color: { r: 0.18, g: 0.62, b: 1, a: 0.9 } },
+      },
+      anim: {
+        type: "sway",
+        periodMs: 1200,
+        amplitude: 2.5,
+        axis: "normal",
+        phase: 0,
+        executionMode: "gpu",
+      },
+      groupId: "debugAnchor",
+      anchors: [{ id: "debugJoin", mode: "vertex", index: 2 }],
+    },
+    {
+      shape: "circle",
+      radius: 6,
+      segments: 24,
+      fill: {
+        type: "solid",
+        fill: { fillType: FILL_TYPES.SOLID, color: { r: 0.95, g: 0.45, b: 0.2, a: 0.85 } },
+      },
+      join: { anchorId: "debugJoin", targetGroupId: "debugAnchor" },
+    },
+  ],
+});

--- a/src/ui/screens/Scene/hooks/useSceneCanvas.ts
+++ b/src/ui/screens/Scene/hooks/useSceneCanvas.ts
@@ -33,8 +33,10 @@ import {
   updateVboStats,
   updateParticleStats,
   updateMovableStats,
+  updateJoinedStats,
   tickFrame,
 } from "../components/debug/debugStats";
+import { joinedPolygonGpuRenderer } from "@ui/renderers/primitives/gpu/joined";
 import { RadiationPostProcess } from "@ui/renderers/utils/RadiationPostProcess";
 
 const EDGE_THRESHOLD = 48;
@@ -119,6 +121,7 @@ export const useSceneCanvas = ({
   const spellcastingRef = useRef(spellcasting);
   const onSpellCastRef = useRef(onSpellCast);
   const onInspectTargetRef = useRef(onInspectTarget);
+  const joinedStatsLastUpdateRef = useRef(0);
   const getInterpolatedUnitPositionsRef = useRef(getInterpolatedUnitPositions);
   const getInterpolatedBulletPositionsRef = useRef(getInterpolatedBulletPositions);
   const getInterpolatedBrickPositionsRef = useRef(getInterpolatedBrickPositions);
@@ -477,6 +480,17 @@ export const useSceneCanvas = ({
           }
         } else {
           particleStatsRef.current = stats;
+        }
+
+        if (now - joinedStatsLastUpdateRef.current >= 500) {
+          joinedStatsLastUpdateRef.current = now;
+          const joinedStats = joinedPolygonGpuRenderer.getStats();
+          updateJoinedStats({
+            handles: joinedStats.handles,
+            drawCalls: joinedStats.drawCalls,
+            renderMs: joinedStats.renderMs,
+            uploadMs: joinedStats.anchorUploadMs,
+          });
         }
 
         // Update camera/scale state


### PR DESCRIPTION
### Motivation
- Provide a developer/debug surface for profiling the GPU "join" path (anchors → joined primitives) when many joined instances are present.
- Expose runtime metrics (joined handles, draw calls, render/upload timings) so regressions and fallback behavior can be observed in real time.
- Document and make it easy to reproduce a heavy joined workload (1k+ anchors) for manual investigation and perf tuning.

### Description
- Added a query-flag driven debug mode on the Scene screen (`?joinedDebug=1`) that spawns a 32×32 grid (1024) of joined primitives for stress testing and shows a small banner and the debug panel when enabled (`src/ui/screens/Scene/*`).
- Implemented GPU anchor transform/texture infrastructure and GPU joined primitives: new GPU anchor manager (`anchors-gpu.ts`), joined GPU renderer (`primitives/gpu/joined/*`) and GPU-backed joined circle/polygon primitives (`JoinedPolygonGpuPrimitive.ts`), wired into WebGL scene renderer for anchor texture uploads and renderer timing.
- Extended debug stats and UI: added joined metrics to `debugStats` and `SceneDebugPanel` (handles, draw calls, render ms, anchor upload ms) and updated `useSceneCanvas` to poll and publish these metrics.
- Docs and helper: added `docs/technology/joined-gpu-debug.md` with usage and checklist, and a small debug renderer config to create representative joined elements.

### Testing
- Ran the TypeScript tests via `npm test`; the test suite completed successfully with `67 tests passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983780f81d483209ccf800990982761)