### PR TITLE
Attach tail joins to spine tips, add circle/sprite anchor modes, and enable GPU-joined stroke/sprite primitives

### DIFF
--- a/src/db/player-units-db.ts
+++ b/src/db/player-units-db.ts
@@ -432,7 +432,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
             fill: { type: "solid", fill: { fillType: FILL_TYPES.SOLID, color: { r: 1, g: 0.6, b: 0.24, a: 0.75 } } },
             anim: { type: "sway", periodMs: 1650, amplitude: 5.6, falloff: "tip", axis: "normal", phase: 0.42 },
             groupId: "burningTail-glow",
-            connectionSlots: [{ id: "tailEnd", mode: "spine", index: 1 }],
+            connectionSlots: [{ id: "tailEnd", mode: "spine", t: 1 }],
           },
           { epsilon: 0.2, winding: "CCW" }
         ),
@@ -510,7 +510,7 @@ const PLAYER_UNITS_DB: Record<PlayerUnitType, PlayerUnitConfig> = {
             fill: { type: "solid", fill: { fillType: FILL_TYPES.SOLID, color: { r: 0.66, g: 0.95, b: 1, a: 0.78 } } },
             anim: { type: "sway", periodMs: 1880, amplitude: 5.4, falloff: "tip", axis: "normal", phase: 0.48 },
             groupId: "freezingTail-glow",
-            connectionSlots: [{ id: "tailEnd", mode: "spine", index: 1 }],
+            connectionSlots: [{ id: "tailEnd", mode: "spine", t: 1 }],
           },
           { epsilon: 0.2, winding: "CCW" }
         ),

--- a/src/shared/types/renderer.types.ts
+++ b/src/shared/types/renderer.types.ts
@@ -20,13 +20,27 @@ export interface RendererLayerAnimationConfig {
   executionMode?: "gpu" | "cpu" | "auto";
 }
 
-export type RendererLayerAnchorMode = "vertex" | "spine";
+export type RendererLayerAnchorMode = "vertex" | "spine" | "circle" | "sprite";
+
+export type RendererSpriteAnchorName =
+  | "center"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+  | "top"
+  | "bottom"
+  | "left"
+  | "right";
 
 export interface RendererLayerAnchorConfig {
   id: string;
   mode: RendererLayerAnchorMode;
   index?: number;
   t?: number;
+  angleRad?: number;
+  spriteAnchor?: RendererSpriteAnchorName;
+  uv?: SceneVector2;
 }
 
 export interface RendererLayerJoinConfig {

--- a/src/ui/renderers/objects/implementations/enemy/composite-helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-helpers.ts
@@ -6,6 +6,7 @@ import type {
 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import type { EnemyRendererCompositeConfig } from "@db/enemies-db";
 import type { RendererFillConfig, RendererStrokeConfig } from "@shared/types/renderer-config";
+import type { RendererLayerAnchorConfig } from "@shared/types/renderer.types";
 import {
   type CompositeRendererLayerFill,
   type CompositeRendererLayerStroke,
@@ -58,8 +59,8 @@ export const sanitizeCompositeLayer = (
     segmentIndex?: number;
     buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
     groupId?: string;
-    anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
-    connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+    anchors?: RendererLayerAnchorConfig[];
+    connectionSlots?: RendererLayerAnchorConfig[];
     join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
   }
 ): {
@@ -78,8 +79,8 @@ export const sanitizeCompositeLayer = (
   segmentIndex?: number;
   buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
   groupId?: string;
-  anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
-  connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+  anchors?: RendererLayerAnchorConfig[];
+  connectionSlots?: RendererLayerAnchorConfig[];
   join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
 } | null => {
   return sanitizeEnemyCompositeLayer(layer);
@@ -92,8 +93,8 @@ type EnemyLayerExtras = {
   segmentIndex?: number;
   buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
   groupId?: string;
-  anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
-  connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+  anchors?: RendererLayerAnchorConfig[];
+  connectionSlots?: RendererLayerAnchorConfig[];
   join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
 };
 
@@ -114,8 +115,8 @@ const sanitizeEnemyCompositeLayer = createCompositeLayerSanitizer<
     segmentIndex?: number;
     buildOpts?: { epsilon?: number; minSegmentLength?: number; winding?: "CW" | "CCW" };
     groupId?: string;
-    anchors?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
-    connectionSlots?: { id: string; mode: "vertex" | "spine"; index?: number; t?: number }[];
+    anchors?: RendererLayerAnchorConfig[];
+    connectionSlots?: RendererLayerAnchorConfig[];
     join?: { anchorId: string; targetGroupId?: string; offset?: { x: number; y: number } };
   },
   EnemyLayerExtras

--- a/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
@@ -11,6 +11,9 @@ import {
   createPolygonGpuPrimitive,
   createJoinedPolygonGpuPrimitive,
   createJoinedCircleGpuPrimitive,
+  createJoinedPolygonStrokeGpuPrimitive,
+  createJoinedCircleStrokeGpuPrimitive,
+  createJoinedSpriteGpuPrimitive,
 } from "../../../primitives";
 import type { DynamicPrimitive } from "../../ObjectRenderer";
 import type { EnemyRendererCompositeConfig } from "@db/enemies-db";
@@ -134,9 +137,7 @@ export const createCompositePrimitives = (
           joinOffset: joinOffsetForGpu,
           refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
         });
-        if (fillPrimitive) {
-          dynamicPrimitives.push(fillPrimitive);
-        }
+        let strokeGpuPrimitive: DynamicPrimitive | null = null;
         if (layer.stroke) {
           const strokeColor =
             layer.stroke.kind === "solid"
@@ -146,18 +147,38 @@ export const createCompositePrimitives = (
             width: layer.stroke.width,
             color: strokeColor,
           };
-          const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
+          strokeGpuPrimitive = createJoinedPolygonStrokeGpuPrimitive(instance, {
             vertices: layer.vertices,
             stroke: sceneStroke,
-            offset: staticOffset,
-            getOffset,
+            anchorIndex,
+            joinOffset: joinOffsetForGpu,
+            refreshStroke: layer.stroke.kind === "base"
+              ? (inst) => ({
+                  width: layer.stroke!.width,
+                  color: resolveStrokeColor(inst, renderer.stroke?.color, renderer.fill),
+                })
+              : undefined,
           });
-          if (getOffset) {
-            strokePrimitive.autoAnimate = true;
+          if (!strokeGpuPrimitive) {
+            const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
+              vertices: layer.vertices,
+              stroke: sceneStroke,
+              offset: staticOffset,
+              getOffset,
+            });
+            if (getOffset) {
+              strokePrimitive.autoAnimate = true;
+            }
+            dynamicPrimitives.push(strokePrimitive);
           }
-          dynamicPrimitives.push(strokePrimitive);
         }
         if (fillPrimitive) {
+          dynamicPrimitives.push(fillPrimitive);
+        }
+        if (strokeGpuPrimitive) {
+          dynamicPrimitives.push(strokeGpuPrimitive);
+        }
+        if (fillPrimitive || strokeGpuPrimitive) {
           return;
         }
       }
@@ -195,12 +216,12 @@ export const createCompositePrimitives = (
         const sampleVertices = () => {
           const quadVerts = sampler.getVertices();
           if (hasAnchors && needsCpuAnchors) {
-            const resolved = resolveLayerAnchors(
-              anchorConfigs,
-              quadVerts,
-              sampler.getDeformedSpine(),
-              staticOffset
-            );
+            const resolved = resolveLayerAnchors({
+              anchors: anchorConfigs,
+              vertices: quadVerts,
+              spine: sampler.getDeformedSpine(),
+              offset: staticOffset,
+            });
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return quadVerts;
@@ -262,7 +283,11 @@ export const createCompositePrimitives = (
         const getDeformedVertices = () => {
           const deformed = sampler ? sampler.getVertices() : baseVertices;
           if (hasAnchors && needsCpuAnchors) {
-            const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
+            const resolved = resolveLayerAnchors({
+              anchors: anchorConfigs,
+              vertices: deformed,
+              offset: staticOffset,
+            });
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return deformed;
@@ -316,7 +341,11 @@ export const createCompositePrimitives = (
                 autoAnimate: true,
                 update: () => {
                   const deformed = sampler.getVertices();
-                  const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
+                  const resolved = resolveLayerAnchors({
+                    anchors: anchorConfigs,
+                    vertices: deformed,
+                    offset: staticOffset,
+                  });
                   writeAnchorsForLayer(instance.id, layer.groupId, resolved);
                   return null;
                 },
@@ -370,7 +399,12 @@ export const createCompositePrimitives = (
         const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
         const anchorConfigs = collectAnchors(layer);
         if (anchorConfigs.length > 0 && needsCpuAnchors) {
-          const resolved = resolveLayerAnchors(anchorConfigs, layer.vertices, layer.spine, staticOffset);
+          const resolved = resolveLayerAnchors({
+            anchors: anchorConfigs,
+            vertices: layer.vertices,
+            spine: layer.spine,
+            offset: staticOffset,
+          });
           writeAnchorsForLayer(instance.id, layer.groupId, resolved);
         }
         const primitive = createDynamicPolygonPrimitive(instance, {
@@ -391,6 +425,16 @@ export const createCompositePrimitives = (
       const joinOffset = resolveJoinOffsetForLayer(layer);
       const getOffset = joinOffset ? joinOffset : undefined;
       const staticOffset = joinOffset ? undefined : layer.offset;
+      const needsCpuAnchors = joinTargets.has(normalizeGroupId(layer.groupId));
+      const anchorConfigs = collectAnchors(layer);
+      if (anchorConfigs.length > 0 && needsCpuAnchors) {
+        const resolved = resolveLayerAnchors({
+          anchors: anchorConfigs,
+          offset: staticOffset,
+          circle: { radius: layer.radius!, segments: layer.segments },
+        });
+        writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+      }
       const anchorIndex = layer.join && supportsGpuJoin(layer)
         ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
         : null;
@@ -400,7 +444,7 @@ export const createCompositePrimitives = (
             y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
           }
         : undefined;
-      if (layer.join && anchorIndex !== null && !layer.stroke) {
+      if (layer.join && anchorIndex !== null) {
         const fillPrimitive = createJoinedCircleGpuPrimitive(instance, {
           radius: layer.radius!,
           segments: layer.segments,
@@ -409,8 +453,51 @@ export const createCompositePrimitives = (
           joinOffset: joinOffsetForGpu,
           refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
         });
+        let strokeGpuPrimitive: DynamicPrimitive | null = null;
+        if (layer.stroke) {
+          const strokeColor =
+            layer.stroke.kind === "solid"
+              ? layer.stroke.color
+              : resolveStrokeColor(instance, renderer.stroke?.color, renderer.fill);
+          const sceneStroke: SceneStroke = {
+            width: layer.stroke.width,
+            color: strokeColor,
+          };
+          strokeGpuPrimitive = createJoinedCircleStrokeGpuPrimitive(instance, {
+            radius: layer.radius!,
+            segments: layer.segments,
+            stroke: sceneStroke,
+            anchorIndex,
+            joinOffset: joinOffsetForGpu,
+            refreshStroke: layer.stroke.kind === "base"
+              ? (inst) => ({
+                  width: layer.stroke!.width,
+                  color: resolveStrokeColor(inst, renderer.stroke?.color, renderer.fill),
+                })
+              : undefined,
+          });
+          if (!strokeGpuPrimitive) {
+            const cachedStrokeFill = resolveLayerStrokeFill(instance, layer.stroke, renderer);
+            const strokePrimitive = createDynamicCirclePrimitive(instance, {
+              segments: layer.segments,
+              offset: staticOffset,
+              getOffset,
+              radius: layer.radius! + layer.stroke.width,
+              fill: cachedStrokeFill,
+            });
+            if (getOffset) {
+              strokePrimitive.autoAnimate = true;
+            }
+            dynamicPrimitives.push(strokePrimitive);
+          }
+        }
         if (fillPrimitive) {
           dynamicPrimitives.push(fillPrimitive);
+        }
+        if (strokeGpuPrimitive) {
+          dynamicPrimitives.push(strokeGpuPrimitive);
+        }
+        if (fillPrimitive || strokeGpuPrimitive) {
           return;
         }
       }
@@ -448,9 +535,41 @@ export const createCompositePrimitives = (
       const joinOffset = resolveJoinOffsetForLayer(layer);
       const getOffset = joinOffset ? joinOffset : undefined;
       const staticOffset = joinOffset ? undefined : layer.offset;
+      const needsCpuAnchors = joinTargets.has(normalizeGroupId(layer.groupId));
+      const anchorConfigs = collectAnchors(layer);
+      if (anchorConfigs.length > 0 && needsCpuAnchors) {
+        const resolved = resolveLayerAnchors({
+          anchors: anchorConfigs,
+          offset: staticOffset,
+          sprite: { width: layer.width!, height: layer.height! },
+        });
+        writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+      }
+      const anchorIndex = layer.join
+        ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
+        : null;
+      const joinOffsetForGpu = layer.join
+        ? {
+            x: (layer.offset?.x ?? 0) + (layer.join.offset?.x ?? 0),
+            y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
+          }
+        : undefined;
       // Sprite layer - uses RectanglePrimitive as fallback until texture support is added
       if (!layer.spritePath || typeof layer.width !== "number" || typeof layer.height !== "number") {
         return; // Skip invalid sprite layers
+      }
+      if (layer.join && anchorIndex !== null) {
+        const spritePrimitive = createJoinedSpriteGpuPrimitive(instance, {
+          spritePath: layer.spritePath,
+          width: layer.width!,
+          height: layer.height!,
+          anchorIndex,
+          joinOffset: joinOffsetForGpu,
+        });
+        if (spritePrimitive) {
+          dynamicPrimitives.push(spritePrimitive);
+          return;
+        }
       }
       const spritePrimitive = createDynamicSpritePrimitive(instance, {
         spritePath: layer.spritePath,

--- a/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
@@ -11,6 +11,9 @@ import {
   createPolygonGpuPrimitive,
   createJoinedPolygonGpuPrimitive,
   createJoinedCircleGpuPrimitive,
+  createJoinedPolygonStrokeGpuPrimitive,
+  createJoinedCircleStrokeGpuPrimitive,
+  createJoinedSpriteGpuPrimitive,
 } from "../../../primitives";
 import { getInstanceRenderPosition } from "../../ObjectRenderer";
 import type { DynamicPrimitive } from "../../ObjectRenderer";
@@ -202,12 +205,7 @@ export const createCompositePrimitives = (
           joinOffset: joinOffsetForGpu,
           refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
         });
-        if (fillPrimitive) {
-          dynamicPrimitives.push(fillPrimitive);
-        } else {
-          // Fallback to CPU path if GPU primitive could not be created
-          // Continue with regular handling below.
-        }
+        let strokeGpuPrimitive: DynamicPrimitive | null = null;
         if (layer.stroke) {
           const strokeColor =
             layer.stroke.kind === "solid"
@@ -217,18 +215,38 @@ export const createCompositePrimitives = (
             width: layer.stroke.width,
             color: strokeColor,
           };
-          const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
+          strokeGpuPrimitive = createJoinedPolygonStrokeGpuPrimitive(instance, {
             vertices: layer.vertices,
             stroke: sceneStroke,
-            offset: staticOffset,
-            getOffset,
+            anchorIndex,
+            joinOffset: joinOffsetForGpu,
+            refreshStroke: layer.stroke.kind === "base"
+              ? (inst) => ({
+                  width: layer.stroke!.width,
+                  color: resolveStrokeColor(inst, renderer.baseStrokeColor, renderer.baseFillColor),
+                })
+              : undefined,
           });
-          if (getOffset) {
-            strokePrimitive.autoAnimate = true;
+          if (!strokeGpuPrimitive) {
+            const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
+              vertices: layer.vertices,
+              stroke: sceneStroke,
+              offset: staticOffset,
+              getOffset,
+            });
+            if (getOffset) {
+              strokePrimitive.autoAnimate = true;
+            }
+            dynamicPrimitives.push(strokePrimitive);
           }
-          dynamicPrimitives.push(strokePrimitive);
         }
         if (fillPrimitive) {
+          dynamicPrimitives.push(fillPrimitive);
+        }
+        if (strokeGpuPrimitive) {
+          dynamicPrimitives.push(strokeGpuPrimitive);
+        }
+        if (fillPrimitive || strokeGpuPrimitive) {
           return;
         }
       }
@@ -265,12 +283,12 @@ export const createCompositePrimitives = (
         const sampleVertices = () => {
           const quadVerts = sampler.getVertices();
           if (hasAnchors && needsCpuAnchors) {
-            const resolved = resolveLayerAnchors(
-              anchorConfigs,
-              quadVerts,
-              sampler.getDeformedSpine(),
-              staticOffset
-            );
+            const resolved = resolveLayerAnchors({
+              anchors: anchorConfigs,
+              vertices: quadVerts,
+              spine: sampler.getDeformedSpine(),
+              offset: staticOffset,
+            });
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return quadVerts;
@@ -343,7 +361,11 @@ export const createCompositePrimitives = (
         const getDeformedVertices = () => {
           const deformed = sampler ? sampler.getVertices() : layer.vertices;
           if (hasAnchors && needsCpuAnchors) {
-            const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
+            const resolved = resolveLayerAnchors({
+              anchors: anchorConfigs,
+              vertices: deformed,
+              offset: staticOffset,
+            });
             writeAnchorsForLayer(instance.id, layer.groupId, resolved);
           }
           return deformed;
@@ -410,7 +432,11 @@ export const createCompositePrimitives = (
                 autoAnimate: true,
                 update: () => {
                   const deformed = sampler.getVertices();
-                  const resolved = resolveLayerAnchors(anchorConfigs, deformed, undefined, staticOffset);
+                  const resolved = resolveLayerAnchors({
+                    anchors: anchorConfigs,
+                    vertices: deformed,
+                    offset: staticOffset,
+                  });
                   writeAnchorsForLayer(instance.id, layer.groupId, resolved);
                   return null;
                 },
@@ -475,7 +501,12 @@ export const createCompositePrimitives = (
         const layerFillForStatic = layer.fill;
         const anchorConfigs = collectAnchors(layer);
         if (anchorConfigs.length > 0 && needsCpuAnchors) {
-          const resolved = resolveLayerAnchors(anchorConfigs, layer.vertices, layer.spine, staticOffset);
+          const resolved = resolveLayerAnchors({
+            anchors: anchorConfigs,
+            vertices: layer.vertices,
+            spine: layer.spine,
+            offset: staticOffset,
+          });
           writeAnchorsForLayer(instance.id, layer.groupId, resolved);
         }
         const primitive = createDynamicPolygonPrimitive(instance, {
@@ -497,6 +528,16 @@ export const createCompositePrimitives = (
       const joinOffset = resolveJoinOffsetForLayer(layer);
       const getOffset = joinOffset ? joinOffset : undefined;
       const staticOffset = joinOffset ? undefined : layer.offset;
+      const needsCpuAnchors = joinTargets.has(normalizeGroupId(layer.groupId));
+      const anchorConfigs = collectAnchors(layer);
+      if (anchorConfigs.length > 0 && needsCpuAnchors) {
+        const resolved = resolveLayerAnchors({
+          anchors: anchorConfigs,
+          offset: staticOffset,
+          circle: { radius: layer.radius, segments: layer.segments },
+        });
+        writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+      }
       const anchorIndex = layer.join && supportsGpuJoin(layer)
         ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
         : null;
@@ -506,7 +547,7 @@ export const createCompositePrimitives = (
             y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
           }
         : undefined;
-      if (layer.join && anchorIndex !== null && !layer.stroke) {
+      if (layer.join && anchorIndex !== null) {
         const fillPrimitive = createJoinedCircleGpuPrimitive(instance, {
           radius: layer.radius,
           segments: layer.segments,
@@ -515,8 +556,55 @@ export const createCompositePrimitives = (
           joinOffset: joinOffsetForGpu,
           refreshFill: (inst) => resolveLayerFill(inst, layer.fill, renderer),
         });
+        let strokeGpuPrimitive: DynamicPrimitive | null = null;
+        if (layer.stroke) {
+          const strokeColor =
+            layer.stroke.kind === "solid"
+              ? layer.stroke.color
+              : resolveStrokeColor(instance, renderer.baseStrokeColor, renderer.baseFillColor);
+          const sceneStroke: SceneStroke = {
+            width: layer.stroke.width,
+            color: strokeColor,
+          };
+          strokeGpuPrimitive = createJoinedCircleStrokeGpuPrimitive(instance, {
+            radius: layer.radius,
+            segments: layer.segments,
+            stroke: sceneStroke,
+            anchorIndex,
+            joinOffset: joinOffsetForGpu,
+            refreshStroke: layer.stroke.kind === "base"
+              ? (inst) => ({
+                  width: layer.stroke!.width,
+                  color: resolveStrokeColor(inst, renderer.baseStrokeColor, renderer.baseFillColor),
+                })
+              : undefined,
+          });
+          if (!strokeGpuPrimitive) {
+            const layerStrokeForCircle = layer.stroke;
+            const cachedStrokeFill = resolveLayerStrokeFill(instance, layer.stroke, renderer);
+            const strokePrimitive = createDynamicCirclePrimitive(instance, {
+              segments: layer.segments,
+              offset: staticOffset,
+              getOffset,
+              radius: layer.radius + layer.stroke.width,
+              fill: cachedStrokeFill,
+              refreshFill: layerStrokeForCircle.kind === "base"
+                ? (inst) => resolveLayerStrokeFill(inst, layerStrokeForCircle, renderer)
+                : undefined,
+            });
+            if (getOffset) {
+              strokePrimitive.autoAnimate = true;
+            }
+            dynamicPrimitives.push(strokePrimitive);
+          }
+        }
         if (fillPrimitive) {
           dynamicPrimitives.push(fillPrimitive);
+        }
+        if (strokeGpuPrimitive) {
+          dynamicPrimitives.push(strokeGpuPrimitive);
+        }
+        if (fillPrimitive || strokeGpuPrimitive) {
           return;
         }
       }
@@ -561,6 +649,38 @@ export const createCompositePrimitives = (
       const joinOffset = resolveJoinOffsetForLayer(layer);
       const getOffset = joinOffset ? joinOffset : undefined;
       const staticOffset = joinOffset ? undefined : layer.offset;
+      const needsCpuAnchors = joinTargets.has(normalizeGroupId(layer.groupId));
+      const anchorConfigs = collectAnchors(layer);
+      if (anchorConfigs.length > 0 && needsCpuAnchors) {
+        const resolved = resolveLayerAnchors({
+          anchors: anchorConfigs,
+          offset: staticOffset,
+          sprite: { width: layer.width, height: layer.height },
+        });
+        writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+      }
+      const anchorIndex = layer.join
+        ? getGpuAnchorIndex(instance.id, layer.join.targetGroupId, layer.join.anchorId)
+        : null;
+      const joinOffsetForGpu = layer.join
+        ? {
+            x: (layer.offset?.x ?? 0) + (layer.join.offset?.x ?? 0),
+            y: (layer.offset?.y ?? 0) + (layer.join.offset?.y ?? 0),
+          }
+        : undefined;
+      if (layer.join && anchorIndex !== null && layer.spritePath) {
+        const spritePrimitive = createJoinedSpriteGpuPrimitive(instance, {
+          spritePath: layer.spritePath,
+          width: layer.width,
+          height: layer.height,
+          anchorIndex,
+          joinOffset: joinOffsetForGpu,
+        });
+        if (spritePrimitive) {
+          dynamicPrimitives.push(spritePrimitive);
+          return;
+        }
+      }
       // Sprite layer - uses RectanglePrimitive as fallback until texture support is added
       const spritePrimitive = createDynamicSpritePrimitive(instance, {
         spritePath: layer.spritePath,

--- a/src/ui/renderers/objects/shared/anchors.ts
+++ b/src/ui/renderers/objects/shared/anchors.ts
@@ -128,20 +128,23 @@ const sampleSpineByT = (spine: SceneVector2[], t: number): SceneVector2 | null =
   return spine[spine.length - 1] ?? null;
 };
 
-export const resolveLayerAnchors = (
-  anchors: RendererLayerAnchorConfig[] | undefined,
-  vertices: SceneVector2[] | undefined,
-  spine: SceneVector2[] | undefined,
-  offset: SceneVector2 | undefined
-): RendererAnchorRecord[] => {
-  if (!anchors || anchors.length === 0) {
+export const resolveLayerAnchors = (options: {
+  anchors: RendererLayerAnchorConfig[] | undefined;
+  vertices?: SceneVector2[];
+  spine?: SceneVector2[];
+  offset?: SceneVector2;
+  circle?: { radius: number; segments?: number };
+  sprite?: { width: number; height: number };
+}): RendererAnchorRecord[] => {
+  if (!options.anchors || options.anchors.length === 0) {
     return [];
   }
   const resolved: RendererAnchorRecord[] = [];
-  const offsetX = offset?.x ?? 0;
-  const offsetY = offset?.y ?? 0;
-  anchors.forEach((anchor) => {
+  const offsetX = options.offset?.x ?? 0;
+  const offsetY = options.offset?.y ?? 0;
+  options.anchors.forEach((anchor) => {
     if (anchor.mode === "vertex") {
+      const vertices = options.vertices;
       if (!vertices || vertices.length === 0 || typeof anchor.index !== "number") {
         return;
       }
@@ -155,22 +158,110 @@ export const resolveLayerAnchors = (
       });
       return;
     }
-    if (!spine || spine.length === 0) {
+    if (anchor.mode === "spine") {
+      const spine = options.spine;
+      if (!spine || spine.length === 0) {
+        return;
+      }
+      let point: SceneVector2 | null = null;
+      if (typeof anchor.index === "number") {
+        point = spine[Math.max(0, Math.min(spine.length - 1, anchor.index))] ?? null;
+      } else if (typeof anchor.t === "number") {
+        point = sampleSpineByT(spine, anchor.t);
+      }
+      if (!point) {
+        return;
+      }
+      resolved.push({
+        id: anchor.id,
+        position: { x: point.x + offsetX, y: point.y + offsetY },
+      });
       return;
     }
-    let point: SceneVector2 | null = null;
-    if (typeof anchor.index === "number") {
-      point = spine[Math.max(0, Math.min(spine.length - 1, anchor.index))] ?? null;
-    } else if (typeof anchor.t === "number") {
-      point = sampleSpineByT(spine, anchor.t);
-    }
-    if (!point) {
+    if (anchor.mode === "circle") {
+      const circle = options.circle;
+      if (!circle || circle.radius <= 0) {
+        return;
+      }
+      const segments = Math.max(3, Math.floor(circle.segments ?? 24));
+      let angle = anchor.angleRad;
+      if (typeof angle !== "number") {
+        if (typeof anchor.t === "number") {
+          angle = anchor.t * Math.PI * 2;
+        } else if (typeof anchor.index === "number") {
+          angle = (anchor.index / segments) * Math.PI * 2;
+        }
+      }
+      if (typeof angle !== "number") {
+        return;
+      }
+      resolved.push({
+        id: anchor.id,
+        position: {
+          x: Math.cos(angle) * circle.radius + offsetX,
+          y: Math.sin(angle) * circle.radius + offsetY,
+        },
+      });
       return;
     }
-    resolved.push({
-      id: anchor.id,
-      position: { x: point.x + offsetX, y: point.y + offsetY },
-    });
+    if (anchor.mode === "sprite") {
+      const sprite = options.sprite;
+      if (!sprite) {
+        return;
+      }
+      const halfWidth = sprite.width * 0.5;
+      const halfHeight = sprite.height * 0.5;
+      let x = 0;
+      let y = 0;
+      if (anchor.uv) {
+        x = (anchor.uv.x - 0.5) * sprite.width;
+        y = (anchor.uv.y - 0.5) * sprite.height;
+      } else {
+        switch (anchor.spriteAnchor ?? "center") {
+          case "top-left":
+            x = -halfWidth;
+            y = -halfHeight;
+            break;
+          case "top-right":
+            x = halfWidth;
+            y = -halfHeight;
+            break;
+          case "bottom-left":
+            x = -halfWidth;
+            y = halfHeight;
+            break;
+          case "bottom-right":
+            x = halfWidth;
+            y = halfHeight;
+            break;
+          case "top":
+            x = 0;
+            y = -halfHeight;
+            break;
+          case "bottom":
+            x = 0;
+            y = halfHeight;
+            break;
+          case "left":
+            x = -halfWidth;
+            y = 0;
+            break;
+          case "right":
+            x = halfWidth;
+            y = 0;
+            break;
+          case "center":
+          default:
+            x = 0;
+            y = 0;
+            break;
+        }
+      }
+      resolved.push({
+        id: anchor.id,
+        position: { x: x + offsetX, y: y + offsetY },
+      });
+    }
   });
   return resolved;
 };

--- a/src/ui/renderers/primitives/JoinedPolygonGpuPrimitive.ts
+++ b/src/ui/renderers/primitives/JoinedPolygonGpuPrimitive.ts
@@ -1,6 +1,7 @@
 import type {
   SceneFill,
   SceneObjectInstance,
+  SceneStroke,
   SceneVector2,
 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import {
@@ -12,6 +13,18 @@ import { computePolygonGeometry } from "@ui/renderers/primitives/basic/PolygonPr
 import { joinedPolygonGpuRenderer, type JoinedPolygonGpuHandle } from "@ui/renderers/primitives/gpu/joined/JoinedPolygonGpuRenderer";
 import { getAnimationGpuContext } from "@ui/renderers/objects/shared/animation-gpu";
 import { FILL_COMPONENTS } from "@ui/renderers/objects/ObjectRenderer";
+import { createSpriteFill } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.helpers";
+import { FILL_TYPES } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.const";
+
+const createStrokeFill = (stroke: SceneStroke): SceneFill => ({
+  fillType: FILL_TYPES.SOLID,
+  color: {
+    r: stroke.color.r,
+    g: stroke.color.g,
+    b: stroke.color.b,
+    a: typeof stroke.color.a === "number" ? stroke.color.a : 1,
+  },
+});
 
 const buildPackedVertices = (vertices: SceneVector2[]): Float32Array => {
   const packed = new Float32Array(vertices.length * 2);
@@ -47,6 +60,37 @@ const buildCircleFanVertices = (radius: number, segments: number): SceneVector2[
     verts.push({ x: Math.cos(angle) * radius, y: Math.sin(angle) * radius });
   }
   return verts;
+};
+
+const buildStrokeBandVertices = (
+  inner: SceneVector2[],
+  outer: SceneVector2[]
+): SceneVector2[] => {
+  const n = Math.min(inner.length, outer.length);
+  if (n < 3) {
+    return [];
+  }
+  const verts: SceneVector2[] = [];
+  for (let i = 0; i < n; i += 1) {
+    const j = (i + 1) % n;
+    const outerI = outer[i]!;
+    const outerJ = outer[j]!;
+    const innerI = inner[i]!;
+    const innerJ = inner[j]!;
+    verts.push(outerI, outerJ, innerI, innerI, outerJ, innerJ);
+  }
+  return verts;
+};
+
+const buildSpriteQuadVertices = (width: number, height: number): SceneVector2[] => {
+  const halfWidth = width * 0.5;
+  const halfHeight = height * 0.5;
+  return [
+    { x: -halfWidth, y: halfHeight },
+    { x: halfWidth, y: halfHeight },
+    { x: halfWidth, y: -halfHeight },
+    { x: -halfWidth, y: -halfHeight },
+  ];
 };
 
 export interface JoinedGpuPrimitiveOptions {
@@ -297,6 +341,435 @@ export const createJoinedCircleGpuPrimitive = (
           rotation: 0,
           size,
           radius: options.radius,
+        });
+        fillData = buildFillBufferData(vertexCount, fillComponents, fillData ?? undefined);
+        gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, fillData);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+      }
+
+      const pos = getInstanceRenderPosition(target);
+      renderHandle.instancePosition.x = pos.x;
+      renderHandle.instancePosition.y = pos.y;
+      renderHandle.instanceRotation = target.data.rotation ?? 0;
+      return null;
+    },
+    dispose() {
+      if (!gl) {
+        return;
+      }
+      if (renderHandle) {
+        joinedPolygonGpuRenderer.releaseHandle(renderHandle);
+        renderHandle = null;
+      }
+      if (fillBuffer) {
+        gl.deleteBuffer(fillBuffer);
+        fillBuffer = null;
+      }
+      if (positionBuffer) {
+        gl.deleteBuffer(positionBuffer);
+        positionBuffer = null;
+      }
+    },
+  };
+
+  return primitive;
+};
+
+export const createJoinedPolygonStrokeGpuPrimitive = (
+  instance: SceneObjectInstance,
+  options: {
+    vertices: SceneVector2[];
+    stroke: SceneStroke;
+    refreshStroke?: (instance: SceneObjectInstance) => SceneStroke;
+  } & JoinedGpuPrimitiveOptions
+): DynamicPrimitive | null => {
+  if (!options.vertices || options.vertices.length < 3) {
+    return null;
+  }
+  const geometry = computePolygonGeometry(options.vertices);
+  const inner = options.vertices;
+  let outer = inner.map((vertex) => {
+    const dirX = vertex.x - geometry.centerOffset.x;
+    const dirY = vertex.y - geometry.centerOffset.y;
+    const length = Math.hypot(dirX, dirY) || 1;
+    const scale = (length + options.stroke.width) / length;
+    return {
+      x: geometry.centerOffset.x + dirX * scale,
+      y: geometry.centerOffset.y + dirY * scale,
+    };
+  });
+  let vertices = buildStrokeBandVertices(inner, outer);
+  if (vertices.length === 0) {
+    return null;
+  }
+  let packedVertices = buildPackedVertices(vertices);
+
+  const fillScratch = new Float32Array(FILL_COMPONENTS);
+  let fillData: Float32Array | null = null;
+  let cachedStroke: SceneStroke = options.stroke;
+  let prevInstanceStrokeRef: SceneStroke | undefined =
+    typeof options.refreshStroke === "function" ? instance.data.stroke : undefined;
+
+  let gl = getAnimationGpuContext();
+  let fillBuffer: WebGLBuffer | null = null;
+  let positionBuffer: WebGLBuffer | null = null;
+  let renderHandle: JoinedPolygonGpuHandle | null = null;
+
+  const writeFill = () => {
+    const fillComponents = writeFillVertexComponents(fillScratch, {
+      fill: createStrokeFill(cachedStroke),
+      center: geometry.centerOffset,
+      rotation: 0,
+      size: geometry.size,
+    });
+    fillData = buildFillBufferData(vertices.length, fillComponents, fillData ?? undefined);
+    gl!.bindBuffer(gl!.ARRAY_BUFFER, fillBuffer);
+    gl!.bufferSubData(gl!.ARRAY_BUFFER, 0, fillData);
+    gl!.bindBuffer(gl!.ARRAY_BUFFER, null);
+  };
+
+  const ensureResources = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    if (!positionBuffer) {
+      positionBuffer = gl.createBuffer();
+      if (!positionBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, packedVertices, gl.DYNAMIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    if (!fillBuffer) {
+      fillBuffer = gl.createBuffer();
+      if (!fillBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        vertices.length * FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+        gl.DYNAMIC_DRAW
+      );
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    joinedPolygonGpuRenderer.setContext(gl);
+    if (!renderHandle) {
+      renderHandle = joinedPolygonGpuRenderer.acquireHandle({
+        positionBuffer,
+        fillBuffer,
+        vertexCount: vertices.length,
+        anchorIndex: options.anchorIndex,
+        joinOffset: options.joinOffset ?? { x: 0, y: 0 },
+        drawMode: gl.TRIANGLES,
+      });
+      if (!renderHandle) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureResources() || !gl || !fillBuffer || !positionBuffer || !renderHandle) {
+        return null;
+      }
+
+      let strokeChanged = false;
+      if (typeof options.refreshStroke === "function") {
+        if (target.data.stroke !== prevInstanceStrokeRef) {
+          prevInstanceStrokeRef = target.data.stroke;
+          const nextStroke = options.refreshStroke(target);
+          if (nextStroke.width !== cachedStroke.width) {
+            cachedStroke = nextStroke;
+            outer = inner.map((vertex) => {
+              const dirX = vertex.x - geometry.centerOffset.x;
+              const dirY = vertex.y - geometry.centerOffset.y;
+              const length = Math.hypot(dirX, dirY) || 1;
+              const scale = (length + cachedStroke.width) / length;
+              return {
+                x: geometry.centerOffset.x + dirX * scale,
+                y: geometry.centerOffset.y + dirY * scale,
+              };
+            });
+            vertices = buildStrokeBandVertices(inner, outer);
+            packedVertices = buildPackedVertices(vertices);
+            gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+            gl.bufferSubData(gl.ARRAY_BUFFER, 0, packedVertices);
+            gl.bindBuffer(gl.ARRAY_BUFFER, null);
+            joinedPolygonGpuRenderer.updateHandle(renderHandle, vertices.length);
+          } else {
+            cachedStroke = nextStroke;
+          }
+          strokeChanged = true;
+        }
+      }
+
+      if (strokeChanged || !fillData) {
+        writeFill();
+      }
+
+      const pos = getInstanceRenderPosition(target);
+      renderHandle.instancePosition.x = pos.x;
+      renderHandle.instancePosition.y = pos.y;
+      renderHandle.instanceRotation = target.data.rotation ?? 0;
+      return null;
+    },
+    dispose() {
+      if (!gl) {
+        return;
+      }
+      if (renderHandle) {
+        joinedPolygonGpuRenderer.releaseHandle(renderHandle);
+        renderHandle = null;
+      }
+      if (fillBuffer) {
+        gl.deleteBuffer(fillBuffer);
+        fillBuffer = null;
+      }
+      if (positionBuffer) {
+        gl.deleteBuffer(positionBuffer);
+        positionBuffer = null;
+      }
+    },
+  };
+
+  return primitive;
+};
+
+export const createJoinedCircleStrokeGpuPrimitive = (
+  instance: SceneObjectInstance,
+  options: {
+    radius: number;
+    segments?: number;
+    stroke: SceneStroke;
+    refreshStroke?: (instance: SceneObjectInstance) => SceneStroke;
+  } & JoinedGpuPrimitiveOptions
+): DynamicPrimitive | null => {
+  const buildVertices = (radius: number) =>
+    buildCircleFanVertices(radius, options.segments ?? 24);
+  let cachedStroke: SceneStroke = options.stroke;
+  let vertices = buildVertices(options.radius + cachedStroke.width);
+  let packedVertices = buildPackedVertices(vertices);
+
+  const fillScratch = new Float32Array(FILL_COMPONENTS);
+  let fillData: Float32Array | null = null;
+  let prevInstanceStrokeRef: SceneStroke | undefined =
+    typeof options.refreshStroke === "function" ? instance.data.stroke : undefined;
+
+  let gl = getAnimationGpuContext();
+  let fillBuffer: WebGLBuffer | null = null;
+  let positionBuffer: WebGLBuffer | null = null;
+  let renderHandle: JoinedPolygonGpuHandle | null = null;
+
+  const ensureResources = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    if (!positionBuffer) {
+      positionBuffer = gl.createBuffer();
+      if (!positionBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, packedVertices, gl.DYNAMIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    if (!fillBuffer) {
+      fillBuffer = gl.createBuffer();
+      if (!fillBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        vertices.length * FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+        gl.DYNAMIC_DRAW
+      );
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    joinedPolygonGpuRenderer.setContext(gl);
+    if (!renderHandle) {
+      renderHandle = joinedPolygonGpuRenderer.acquireHandle({
+        positionBuffer,
+        fillBuffer,
+        vertexCount: vertices.length,
+        anchorIndex: options.anchorIndex,
+        joinOffset: options.joinOffset ?? { x: 0, y: 0 },
+      });
+      if (!renderHandle) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureResources() || !gl || !fillBuffer || !positionBuffer || !renderHandle) {
+        return null;
+      }
+      let strokeChanged = false;
+      if (typeof options.refreshStroke === "function") {
+        if (target.data.stroke !== prevInstanceStrokeRef) {
+          prevInstanceStrokeRef = target.data.stroke;
+          const nextStroke = options.refreshStroke(target);
+          if (nextStroke.width !== cachedStroke.width) {
+            cachedStroke = nextStroke;
+            vertices = buildVertices(options.radius + cachedStroke.width);
+            packedVertices = buildPackedVertices(vertices);
+            gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+            gl.bufferSubData(gl.ARRAY_BUFFER, 0, packedVertices);
+            gl.bindBuffer(gl.ARRAY_BUFFER, null);
+            joinedPolygonGpuRenderer.updateHandle(renderHandle, vertices.length);
+          } else {
+            cachedStroke = nextStroke;
+          }
+          strokeChanged = true;
+        }
+      }
+      if (strokeChanged || !fillData) {
+        const fillComponents = writeFillVertexComponents(fillScratch, {
+          fill: createStrokeFill(cachedStroke),
+          center: { x: 0, y: 0 },
+          rotation: 0,
+          size: { width: options.radius * 2, height: options.radius * 2 },
+        });
+        fillData = buildFillBufferData(vertices.length, fillComponents, fillData ?? undefined);
+        gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, fillData);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+      }
+      const pos = getInstanceRenderPosition(target);
+      renderHandle.instancePosition.x = pos.x;
+      renderHandle.instancePosition.y = pos.y;
+      renderHandle.instanceRotation = target.data.rotation ?? 0;
+      return null;
+    },
+    dispose() {
+      if (!gl) {
+        return;
+      }
+      if (renderHandle) {
+        joinedPolygonGpuRenderer.releaseHandle(renderHandle);
+        renderHandle = null;
+      }
+      if (fillBuffer) {
+        gl.deleteBuffer(fillBuffer);
+        fillBuffer = null;
+      }
+      if (positionBuffer) {
+        gl.deleteBuffer(positionBuffer);
+        positionBuffer = null;
+      }
+    },
+  };
+
+  return primitive;
+};
+
+export const createJoinedSpriteGpuPrimitive = (
+  instance: SceneObjectInstance,
+  options: {
+    spritePath: string;
+    width: number;
+    height: number;
+  } & JoinedGpuPrimitiveOptions
+): DynamicPrimitive | null => {
+  if (!options.spritePath || options.width <= 0 || options.height <= 0) {
+    return null;
+  }
+  const vertices = buildSpriteQuadVertices(options.width, options.height);
+  const vertexCount = vertices.length;
+  const packedVertices = buildPackedVertices(vertices);
+  const geometry = computePolygonGeometry(vertices);
+
+  const fillScratch = new Float32Array(FILL_COMPONENTS);
+  let fillData: Float32Array | null = null;
+  const spriteFill = createSpriteFill(options.spritePath);
+
+  let gl = getAnimationGpuContext();
+  let fillBuffer: WebGLBuffer | null = null;
+  let positionBuffer: WebGLBuffer | null = null;
+  let renderHandle: JoinedPolygonGpuHandle | null = null;
+
+  const ensureResources = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+    if (!positionBuffer) {
+      positionBuffer = gl.createBuffer();
+      if (!positionBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, packedVertices, gl.STATIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    if (!fillBuffer) {
+      fillBuffer = gl.createBuffer();
+      if (!fillBuffer) {
+        return false;
+      }
+      gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        vertexCount * FILL_COMPONENTS * Float32Array.BYTES_PER_ELEMENT,
+        gl.DYNAMIC_DRAW
+      );
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    joinedPolygonGpuRenderer.setContext(gl);
+    if (!renderHandle) {
+      renderHandle = joinedPolygonGpuRenderer.acquireHandle({
+        positionBuffer,
+        fillBuffer,
+        vertexCount,
+        anchorIndex: options.anchorIndex,
+        joinOffset: options.joinOffset ?? { x: 0, y: 0 },
+      });
+      if (!renderHandle) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureResources() || !gl || !fillBuffer || !renderHandle) {
+        return null;
+      }
+      if (!fillData) {
+        const fillComponents = writeFillVertexComponents(fillScratch, {
+          fill: spriteFill,
+          center: geometry.centerOffset,
+          rotation: 0,
+          size: geometry.size,
         });
         fillData = buildFillBufferData(vertexCount, fillComponents, fillData ?? undefined);
         gl.bindBuffer(gl.ARRAY_BUFFER, fillBuffer);

--- a/src/ui/renderers/primitives/gpu/joined/JoinedPolygonGpuRenderer.ts
+++ b/src/ui/renderers/primitives/gpu/joined/JoinedPolygonGpuRenderer.ts
@@ -38,6 +38,7 @@ export type JoinedPolygonGpuHandle = {
   joinOffset: { x: number; y: number };
   instancePosition: { x: number; y: number };
   instanceRotation: number;
+  drawMode: number;
 };
 
 export type AnchorTextureInfo = {
@@ -178,6 +179,7 @@ class JoinedPolygonGpuRenderer {
     vertexCount: number;
     anchorIndex: number;
     joinOffset: { x: number; y: number };
+    drawMode?: number;
   }): JoinedPolygonGpuHandle | null {
     const gl = this.gl;
     if (!gl || !this.program) {
@@ -218,6 +220,7 @@ class JoinedPolygonGpuRenderer {
       joinOffset: options.joinOffset,
       instancePosition: { x: 0, y: 0 },
       instanceRotation: 0,
+      drawMode: options.drawMode ?? gl.TRIANGLE_FAN,
     };
     this.handles.add(handle);
     return handle;
@@ -381,7 +384,7 @@ class JoinedPolygonGpuRenderer {
         gl.uniform1f(this.instanceRotationLocation, handle.instanceRotation);
       }
       gl.bindVertexArray(handle.vao);
-      gl.drawArrays(gl.TRIANGLE_FAN, 0, handle.vertexCount);
+      gl.drawArrays(handle.drawMode, 0, handle.vertexCount);
       drawCalls += 1;
     });
     gl.bindVertexArray(null);

--- a/src/ui/renderers/primitives/index.ts
+++ b/src/ui/renderers/primitives/index.ts
@@ -20,6 +20,9 @@ export { createPolygonGpuPrimitive } from "./PolygonGpuPrimitive";
 export {
   createJoinedPolygonGpuPrimitive,
   createJoinedCircleGpuPrimitive,
+  createJoinedPolygonStrokeGpuPrimitive,
+  createJoinedCircleStrokeGpuPrimitive,
+  createJoinedSpriteGpuPrimitive,
 } from "./JoinedPolygonGpuPrimitive";
 export { createParticleEmitterPrimitive } from "./ParticleEmitterPrimitive";
 export { createParticleSystemPrimitive } from "./ParticleSystemPrimitive";


### PR DESCRIPTION
### Motivation
- Ensure polygon (crystal) and circle (glow) layers attach to the tail tip by anchoring joins to the last point produced by `mapLineToPolygonShape`.
- Prefer the GPU path for primitives, animations and joins where possible to avoid CPU fallbacks and improve rendering performance.
- Support additional anchor modes (circle and sprite) and richer anchor attributes so joins and anchors can reference sprite UV/anchors and circle angles/segments.

### Description
- Attach tail-end connection slots to the spine tip by using `t: 1` in the glow connection slots in `src/db/player-units-db.ts` so joins sample the final spine point instead of a fixed index.
- Broaden anchor typing by adding `circle`/`sprite` modes and fields `angleRad`, `spriteAnchor`, and `uv` to `RendererLayerAnchorConfig` in `src/shared/types/renderer.types.ts`.
- Replace the old `resolveLayerAnchors` signature with an options object and implement support for `circle` and `sprite` anchor resolution (angle/index/t/uv/sprite anchors) in `src/ui/renderers/objects/shared/anchors.ts`.
- Add GPU-joined stroke and sprite primitives and per-handle draw mode support by extending `JoinedPolygonGpuPrimitive.ts`, exporting the new primitives from `src/ui/renderers/primitives/index.ts`, and adding `drawMode` to the joined GPU renderer handle so stroke bands can be drawn with `gl.TRIANGLES` (changes in `src/ui/renderers/primitives/gpu/joined/JoinedPolygonGpuRenderer.ts`).
- Update enemy and player-unit composite helpers to prefer GPU-joined primitives for polygon/circle strokes and sprite layers and to correctly write CPU anchors for circle/sprite layers when needed (changes in `src/ui/renderers/objects/implementations/*`).

### Testing
- Ran the test suite with `npm test` and all automated tests passed (`67 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698397980c288320a6fd5f4454585cbe)