### PR TITLE
Preserve player unit join anchors and surface joined GPU stats in stress test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   "private": true,
   "scripts": {
     "start": "webpack serve --mode development",
+    "start:stresstest": "node -e \"process.env.IS_STRESSTEST='1'; const { spawnSync } = require('child_process'); const result = spawnSync('webpack', ['serve', '--mode', 'development'], { stdio: 'inherit', shell: true, env: process.env }); process.exit(result.status ?? 0);\"",
     "start:demo": "node -e \"process.env.IS_DEMO='1'; const { spawnSync } = require('child_process'); const result = spawnSync('webpack', ['serve', '--mode', 'development'], { stdio: 'inherit', shell: true, env: process.env }); process.exit(result.status ?? 0);\"",
     "build": "webpack --mode production",
+    "build:stresstest": "node -e \"process.env.IS_STRESSTEST='1'; const { spawnSync } = require('child_process'); const result = spawnSync('webpack', ['--mode', 'production'], { stdio: 'inherit', shell: true, env: process.env }); process.exit(result.status ?? 0);\"",
     "build:demo": "node -e \"process.env.IS_DEMO='1'; const { spawnSync } = require('child_process'); const result = spawnSync('webpack', ['--mode', 'production'], { stdio: 'inherit', shell: true, env: process.env }); process.exit(result.status ?? 0);\"",
     "build:electron": "npm run build && electron-builder --config electron-builder.config.js --win",
     "build:electron:demo": "node -e \"process.env.IS_DEMO='1'; const { spawnSync } = require('child_process'); const result = spawnSync('npm', ['run', 'build:electron'], { stdio: 'inherit', shell: true, env: process.env }); process.exit(result.status ?? 0);\"",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,9 +6,11 @@ import { SaveSlotSelectScreen } from "./ui/screens/SaveSlotSelect/SaveSlotSelect
 import { VoidCampScreen } from "@screens/VoidCamp/VoidCampScreen";
 import { CampTabKey } from "@screens/VoidCamp/components/CampContent/CampContent";
 import { SceneScreen } from "./ui/screens/Scene/SceneScreen";
+import { StressTestScreen } from "./ui/screens/StressTest/StressTestScreen";
 import { SceneTutorialConfig } from "./ui/screens/Scene/components/overlay/SceneTutorialOverlay";
 import { SaveSlotSummary } from "@core/logic/provided/services/save-manager/SaveManager";
 import { readStoredAudioSettings } from "@logic/utils/audioSettings";
+import { isStressTestBuild } from "@shared/helpers/stresstest.helper";
 
 type Screen = "save-select" | "void-camp" | "scene";
 
@@ -19,13 +21,16 @@ function App(): JSX.Element {
   const [voidCampTab, setVoidCampTab] = useState<CampTabKey>("maps");
   const [slotSummaries, setSlotSummaries] = useState<Record<string, SaveSlotSummary>>({});
   const [sceneTutorial, setSceneTutorial] = useState<SceneTutorialConfig | null>(null);
+  const isStressTest = useMemo(() => isStressTestBuild(), []);
 
   const app = useMemo(() => new Application(), []);
   const uiApi = app.uiApi;
 
   useEffect(() => {
-    app.initialize();
-  }, [app]);
+    if (!isStressTest) {
+      app.initialize();
+    }
+  }, [app, isStressTest]);
 
   const refreshSlotSummaries = useCallback(() => {
     const entries: Record<string, SaveSlotSummary> = {};
@@ -36,8 +41,10 @@ function App(): JSX.Element {
   }, [uiApi]);
 
   useEffect(() => {
-    refreshSlotSummaries();
-  }, [refreshSlotSummaries]);
+    if (!isStressTest) {
+      refreshSlotSummaries();
+    }
+  }, [isStressTest, refreshSlotSummaries]);
 
   const handleSlotDelete = useCallback(
     (slot: string) => {
@@ -84,7 +91,8 @@ function App(): JSX.Element {
   return (
     <AppLogicContext.Provider value={appLogicValue}>
       <div className="app-root">
-        {screen === "save-select" && (
+        {isStressTest && <StressTestScreen />}
+        {!isStressTest && screen === "save-select" && (
           <SaveSlotSelectScreen
             slots={SAVE_SLOTS.map((slot) => ({
               id: slot,
@@ -96,7 +104,7 @@ function App(): JSX.Element {
             onSlotDelete={handleSlotDelete}
           />
         )}
-        {screen === "void-camp" && (
+        {!isStressTest && screen === "void-camp" && (
           <VoidCampScreen
             onStart={() => {
               uiApi.audio.playPlaylist("map");
@@ -111,7 +119,7 @@ function App(): JSX.Element {
             onTabChange={setVoidCampTab}
           />
         )}
-        {screen === "scene" && (
+        {!isStressTest && screen === "scene" && (
           <SceneScreen
             tutorial={sceneTutorial}
             onTutorialComplete={() => {

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -5,6 +5,7 @@ declare namespace NodeJS {
     readonly NODE_ENV: 'development' | 'production' | 'test';
     readonly PUBLIC_URL: string;
     readonly IS_DEMO?: string;
+    readonly IS_STRESSTEST?: string;
   }
 }
 

--- a/src/shared/helpers/stresstest.helper.ts
+++ b/src/shared/helpers/stresstest.helper.ts
@@ -1,0 +1,1 @@
+export const isStressTestBuild = (): boolean => process.env.IS_STRESSTEST === "1";

--- a/src/ui/renderers/objects/implementations/player-unit/PlayerUnitObjectRenderer.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/PlayerUnitObjectRenderer.ts
@@ -6,8 +6,7 @@ import {
 } from "../../ObjectRenderer";
 import type { SceneObjectInstance } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import {
-  createDynamicPolygonPrimitive,
-  createDynamicPolygonStrokePrimitive,
+  createPolygonGpuPrimitive,
 } from "../../../primitives";
 import { extractRendererData } from "./helpers";
 import { hasStroke, expandVerticesForStroke, createStrokeFill } from "@shared/helpers/stroke.helper";
@@ -27,6 +26,8 @@ import {
 import { createCompositePrimitives } from "./composite-primitives.helpers";
 import { createParticleEmitterPrimitive } from "../../../primitives/ParticleEmitterPrimitive";
 import type { PlayerUnitEmitterRenderConfig } from "./types";
+
+console.error("!!! PlayerUnitObjectRenderer MODULE LOADED !!!");
 
 /**
  * Updates aura instances positions
@@ -96,6 +97,11 @@ const createEmitterPrimitive = (
 export class PlayerUnitObjectRenderer extends ObjectRenderer {
   public register(instance: SceneObjectInstance): ObjectRegistration {
     const rendererData = extractRendererData(instance);
+    console.error("[PlayerUnitObjectRenderer] register", {
+      instanceId: instance.id,
+      rendererKind: rendererData.kind,
+      hasLayers: "layers" in rendererData ? rendererData.layers?.length : "N/A",
+    });
 
     const dynamicPrimitives: DynamicPrimitive[] = [];
 
@@ -105,6 +111,7 @@ export class PlayerUnitObjectRenderer extends ObjectRenderer {
     }
 
     if (rendererData.kind === "composite") {
+      console.log("[PlayerUnitObjectRenderer] calling createCompositePrimitives");
       createCompositePrimitives(instance, rendererData, dynamicPrimitives);
     } else {
       if (hasStroke(instance.data.stroke)) {
@@ -112,22 +119,26 @@ export class PlayerUnitObjectRenderer extends ObjectRenderer {
           rendererData.vertices,
           instance.data.stroke.width
         );
-        const strokePrimitive = createDynamicPolygonPrimitive(instance, {
+        const strokePrimitive = createPolygonGpuPrimitive(instance, {
           vertices: strokeVertices,
           fill: createStrokeFill(instance.data.stroke),
           offset: rendererData.offset,
         });
-        dynamicPrimitives.push(strokePrimitive);
+        if (strokePrimitive) {
+          dynamicPrimitives.push(strokePrimitive);
+        }
       }
 
-      dynamicPrimitives.push(
-        createDynamicPolygonPrimitive(instance, {
-          vertices: rendererData.vertices,
-          offset: rendererData.offset,
-          // Відстежуємо зміни fill для візуальних ефектів (freeze, burn тощо)
-          refreshFill: (target) => target.data.fill,
-        })
-      );
+      const fillPrimitive = createPolygonGpuPrimitive(instance, {
+        vertices: rendererData.vertices,
+        offset: rendererData.offset,
+        fill: instance.data.fill,
+        // Відстежуємо зміни fill для візуальних ефектів (freeze, burn тощо)
+        refreshFill: (target) => target.data.fill,
+      });
+      if (fillPrimitive) {
+        dynamicPrimitives.push(fillPrimitive);
+      }
     }
 
     return {

--- a/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
@@ -346,20 +346,52 @@ export const createCompositePrimitives = (
         });
         const anchorConfigs = collectAnchors(layer);
         const hasAnchors = anchorConfigs.length > 0;
-        const needsCpuVertices =
-          executionMode !== "gpu" || Boolean(layer.stroke) || (hasAnchors && needsCpuAnchors);
-        const sampler = needsCpuVertices
-          ? createPolygonAnimSampler({
-              vertices: layer.vertices,
-              anim: animCfg,
-              timeSource: getTentacleTimeMs,
-              enableMovementAxis: true,
-              phaseStep: POLYGON_SWAY_PHASE_STEP,
-              executionMode: "cpu",
-            })
-          : null;
+        const animatedLayerFill = resolveLayerFill(instance, layer.fill, renderer);
+        const layerFillForAnimated = layer.fill;
+        
+        // GPU path - skip stroke for performance
+        if (executionMode === "gpu") {
+          const gpuPrimitive = createPolygonGpuPrimitive(instance, {
+            vertices: layer.vertices,
+            anim: animCfg,
+            fill: animatedLayerFill,
+            offset: staticOffset,
+            phaseStep: POLYGON_SWAY_PHASE_STEP,
+            enableMovementAxis: true,
+            refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
+          });
+          if (gpuPrimitive) {
+            dynamicPrimitives.push(gpuPrimitive);
+            if (hasAnchors) {
+              const anchorGpuPrimitive = createPolygonAnchorGpuPrimitive({
+                instance,
+                groupId: layer.groupId,
+                anchors: anchorConfigs,
+                vertices: layer.vertices,
+                anim: animCfg,
+                offset: staticOffset,
+                phaseStep: POLYGON_SWAY_PHASE_STEP,
+                enableMovementAxis: true,
+              });
+              if (anchorGpuPrimitive) {
+                dynamicPrimitives.push(anchorGpuPrimitive);
+              }
+            }
+            return; // GPU path complete - no CPU stroke needed
+          }
+        }
+        
+        // CPU fallback path (with stroke support)
+        const sampler = createPolygonAnimSampler({
+          vertices: layer.vertices,
+          anim: animCfg,
+          timeSource: getTentacleTimeMs,
+          enableMovementAxis: true,
+          phaseStep: POLYGON_SWAY_PHASE_STEP,
+          executionMode: "cpu",
+        });
         const getDeformedVertices = () => {
-          const deformed = sampler ? sampler.getVertices() : layer.vertices;
+          const deformed = sampler.getVertices();
           if (hasAnchors && needsCpuAnchors) {
             const resolved = resolveLayerAnchors({
               anchors: anchorConfigs,
@@ -393,83 +425,47 @@ export const createCompositePrimitives = (
             })
           );
         }
-        // OPTIMIZATION: Cache fill for animated layers too - vertices change but fill is usually static
-        // Always add refreshFill to track visual effect changes
-        const animatedLayerFill = resolveLayerFill(instance, layer.fill, renderer);
-        const layerFillForAnimated = layer.fill;
-        if (executionMode === "gpu") {
+        const primitive = createDynamicPolygonPrimitive(instance, {
+          getVertices: () => getDeformedVertices(),
+          offset: staticOffset,
+          getOffset,
+          fill: animatedLayerFill,
+          refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
+        });
+        if (getOffset) {
+          primitive.autoAnimate = true;
+        }
+        dynamicPrimitives.push(primitive);
+      } else {
+        // OPTIMIZATION: Cache fill at registration time for static layers
+        const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
+        const layerFillForStatic = layer.fill;
+        const anchorConfigs = collectAnchors(layer);
+        if (anchorConfigs.length > 0 && needsCpuAnchors) {
+          const resolved = resolveLayerAnchors({
+            anchors: anchorConfigs,
+            vertices: layer.vertices,
+            spine: layer.spine,
+            offset: staticOffset,
+          });
+          writeAnchorsForLayer(instance.id, layer.groupId, resolved);
+        }
+        
+        // GPU path for static polygons without join offset (skip stroke for performance)
+        if (!getOffset && isAnimationGpuAvailable()) {
           const gpuPrimitive = createPolygonGpuPrimitive(instance, {
             vertices: layer.vertices,
-            anim: animCfg,
-            fill: animatedLayerFill,
             offset: staticOffset,
-            phaseStep: POLYGON_SWAY_PHASE_STEP,
-            enableMovementAxis: true,
-            refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
+            fill: cachedFill,
+            refreshFill: (inst) => resolveLayerFill(inst, layerFillForStatic, renderer),
           });
           if (gpuPrimitive) {
             dynamicPrimitives.push(gpuPrimitive);
-            if (hasAnchors) {
-              const anchorGpuPrimitive = createPolygonAnchorGpuPrimitive({
-                instance,
-                groupId: layer.groupId,
-                anchors: anchorConfigs,
-                vertices: layer.vertices,
-                anim: animCfg,
-                offset: staticOffset,
-                phaseStep: POLYGON_SWAY_PHASE_STEP,
-                enableMovementAxis: true,
-              });
-              if (anchorGpuPrimitive) {
-                dynamicPrimitives.push(anchorGpuPrimitive);
-              }
-            }
-            if (hasAnchors && sampler && needsCpuAnchors) {
-              const anchorPrimitive: DynamicPrimitive = {
-                get data() {
-                  return emptyData;
-                },
-                autoAnimate: true,
-                update: () => {
-                  const deformed = sampler.getVertices();
-                  const resolved = resolveLayerAnchors({
-                    anchors: anchorConfigs,
-                    vertices: deformed,
-                    offset: staticOffset,
-                  });
-                  writeAnchorsForLayer(instance.id, layer.groupId, resolved);
-                  return null;
-                },
-              };
-              dynamicPrimitives.push(anchorPrimitive);
-            }
-          } else {
-            const primitive = createDynamicPolygonPrimitive(instance, {
-              getVertices: () => getDeformedVertices(),
-              offset: staticOffset,
-              getOffset,
-              fill: animatedLayerFill,
-              refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
-            });
-            if (getOffset) {
-              primitive.autoAnimate = true;
-            }
-            dynamicPrimitives.push(primitive);
+            return; // GPU path complete - no CPU stroke needed
           }
-        } else {
-          const primitive = createDynamicPolygonPrimitive(instance, {
-            getVertices: () => getDeformedVertices(),
-            offset: staticOffset,
-            getOffset,
-            fill: animatedLayerFill,
-            refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
-          });
-          if (getOffset) {
-            primitive.autoAnimate = true;
-          }
-          dynamicPrimitives.push(primitive);
         }
-      } else {
+        
+        // CPU fallback path (for joined layers or if GPU unavailable)
         if (layer.stroke) {
           const layerStrokeForStatic = layer.stroke;
           const strokeColor =
@@ -494,20 +490,6 @@ export const createCompositePrimitives = (
                 : undefined,
             })
           );
-        }
-        // OPTIMIZATION: Cache fill at registration time for static layers
-        // Always add refreshFill to track visual effect changes
-        const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
-        const layerFillForStatic = layer.fill;
-        const anchorConfigs = collectAnchors(layer);
-        if (anchorConfigs.length > 0 && needsCpuAnchors) {
-          const resolved = resolveLayerAnchors({
-            anchors: anchorConfigs,
-            vertices: layer.vertices,
-            spine: layer.spine,
-            offset: staticOffset,
-          });
-          writeAnchorsForLayer(instance.id, layer.groupId, resolved);
         }
         const primitive = createDynamicPolygonPrimitive(instance, {
           vertices: layer.vertices,

--- a/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
@@ -5,8 +5,6 @@ import type {
 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import {
   createDynamicCirclePrimitive,
-  createDynamicPolygonPrimitive,
-  createDynamicPolygonStrokePrimitive,
   createDynamicSpritePrimitive,
   createPolygonGpuPrimitive,
   createJoinedPolygonGpuPrimitive,
@@ -14,6 +12,7 @@ import {
   createJoinedPolygonStrokeGpuPrimitive,
   createJoinedCircleStrokeGpuPrimitive,
   createJoinedSpriteGpuPrimitive,
+  createSpineGpuPrimitive,
 } from "../../../primitives";
 import { getInstanceRenderPosition } from "../../ObjectRenderer";
 import type { DynamicPrimitive } from "../../ObjectRenderer";
@@ -40,12 +39,6 @@ import {
   writeAuraInstance,
 } from "./aura.helpers";
 import { POLYGON_SWAY_PHASE_STEP } from "./constants";
-import { getTentacleTimeMs } from "./helpers";
-import {
-  createPolygonAnimSampler,
-  createSpineSwaySampler,
-  resolveAnimationExecutionMode,
-} from "../../shared/animation-pipeline";
 import { isAnimationGpuAvailable } from "../../shared/animation-gpu";
 import type { RendererLayerAnchorConfig } from "@shared/types/renderer.types";
 
@@ -227,18 +220,7 @@ export const createCompositePrimitives = (
                 })
               : undefined,
           });
-          if (!strokeGpuPrimitive) {
-            const strokePrimitive = createDynamicPolygonStrokePrimitive(instance, {
-              vertices: layer.vertices,
-              stroke: sceneStroke,
-              offset: staticOffset,
-              getOffset,
-            });
-            if (getOffset) {
-              strokePrimitive.autoAnimate = true;
-            }
-            dynamicPrimitives.push(strokePrimitive);
-          }
+          // GPU-only: no CPU fallback for stroke
         }
         if (fillPrimitive) {
           dynamicPrimitives.push(fillPrimitive);
@@ -250,24 +232,13 @@ export const createCompositePrimitives = (
           return;
         }
       }
-      // Sway animation for tentacle segments built from a line spine
+      // Sway animation for tentacle segments built from a line spine - GPU only
       if (Array.isArray(layer.spine) && layer.anim?.type === "sway") {
-        const executionMode = resolveAnimationExecutionMode({
-          requested: layer.anim.executionMode,
-          gpuAvailable: isAnimationGpuAvailable(),
-          warnKey: `player-unit:${instance.id}:spine:${layer.groupId ?? layerIndex}`,
-        });
-        const sampler = createSpineSwaySampler({
-          spine: layer.spine,
-          segmentIndex: typeof layer.segmentIndex === "number" ? layer.segmentIndex : 0,
-          buildOpts: layer.buildOpts,
-          anim: layer.anim,
-          timeSource: getTentacleTimeMs,
-          executionMode,
-        });
         const anchorConfigs = collectAnchors(layer);
         const hasAnchors = anchorConfigs.length > 0;
-        if (executionMode === "gpu" && hasAnchors) {
+        
+        // GPU anchors if needed
+        if (hasAnchors) {
           const gpuAnchorPrimitive = createSpineAnchorGpuPrimitive({
             instance,
             groupId: layer.groupId,
@@ -280,164 +251,64 @@ export const createCompositePrimitives = (
             dynamicPrimitives.push(gpuAnchorPrimitive);
           }
         }
-        const sampleVertices = () => {
-          const quadVerts = sampler.getVertices();
-          if (hasAnchors && needsCpuAnchors) {
-            const resolved = resolveLayerAnchors({
-              anchors: anchorConfigs,
-              vertices: quadVerts,
-              spine: sampler.getDeformedSpine(),
-              offset: staticOffset,
-            });
-            writeAnchorsForLayer(instance.id, layer.groupId, resolved);
-          }
-          return quadVerts;
-        };
 
-        if (layer.stroke) {
-          const layerStrokeForTentacle = layer.stroke;
-          const strokeColor =
-            layer.stroke.kind === "solid"
-              ? layer.stroke.color
-              : resolveStrokeColor(instance, renderer.baseStrokeColor, renderer.baseFillColor);
-          const sceneStroke: SceneStroke = {
-            width: layer.stroke.width,
-            color: strokeColor,
-          };
-          dynamicPrimitives.push(
-            createDynamicPolygonStrokePrimitive(instance, {
-              getVertices: sampleVertices,
-              stroke: sceneStroke,
-              offset: staticOffset,
-              getOffset,
-              refreshStroke: layerStrokeForTentacle.kind === "base"
-                ? (inst) => ({
-                    width: layerStrokeForTentacle.width,
-                    color: resolveStrokeColor(inst, renderer.baseStrokeColor, renderer.baseFillColor),
-                  })
-                : undefined,
-            })
-          );
-        }
-
-        // OPTIMIZATION: Cache fill for tentacle layers - vertices animate but fill is static
-        // Always add refreshFill to track visual effect changes
+        // GPU spine fill (stroke not supported in GPU spine renderer)
         const tentacleFill = resolveLayerFill(instance, layer.fill, renderer);
         const layerFillForTentacle = layer.fill;
-        dynamicPrimitives.push(
-          createDynamicPolygonPrimitive(instance, {
-            getVertices: sampleVertices,
-            offset: staticOffset,
-            getOffset,
-            fill: tentacleFill,
-            refreshFill: (inst) => resolveLayerFill(inst, layerFillForTentacle, renderer),
-          })
-        );
+        const spinePrimitive = createSpineGpuPrimitive(instance, {
+          spine: layer.spine,
+          anim: layer.anim,
+          fill: tentacleFill,
+          offset: staticOffset,
+          buildOpts: layer.buildOpts,
+          refreshFill: (inst) => resolveLayerFill(inst, layerFillForTentacle, renderer),
+        });
+        console.log("[composite] spinePrimitive created:", !!spinePrimitive);
+        if (spinePrimitive) {
+          dynamicPrimitives.push(spinePrimitive);
+        }
         return; // handled animated tentacle layer
       }
       // Generic polygon layer (no spine). If it has anim.sway/pulse, deform vertices per-frame.
       const animCfg = layer.anim;
 
       if (animCfg && (animCfg.type === "sway" || animCfg.type === "pulse")) {
-        const executionMode = resolveAnimationExecutionMode({
-          requested: animCfg.executionMode,
-          gpuAvailable: isAnimationGpuAvailable(),
-          warnKey: `player-unit:${instance.id}:polygon:${layer.groupId ?? layerIndex}`,
-        });
+        // GPU-only path for animated polygons
         const anchorConfigs = collectAnchors(layer);
         const hasAnchors = anchorConfigs.length > 0;
         const animatedLayerFill = resolveLayerFill(instance, layer.fill, renderer);
         const layerFillForAnimated = layer.fill;
         
-        // GPU path - skip stroke for performance
-        if (executionMode === "gpu") {
-          const gpuPrimitive = createPolygonGpuPrimitive(instance, {
-            vertices: layer.vertices,
-            anim: animCfg,
-            fill: animatedLayerFill,
-            offset: staticOffset,
-            phaseStep: POLYGON_SWAY_PHASE_STEP,
-            enableMovementAxis: true,
-            refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
-          });
-          if (gpuPrimitive) {
-            dynamicPrimitives.push(gpuPrimitive);
-            if (hasAnchors) {
-              const anchorGpuPrimitive = createPolygonAnchorGpuPrimitive({
-                instance,
-                groupId: layer.groupId,
-                anchors: anchorConfigs,
-                vertices: layer.vertices,
-                anim: animCfg,
-                offset: staticOffset,
-                phaseStep: POLYGON_SWAY_PHASE_STEP,
-                enableMovementAxis: true,
-              });
-              if (anchorGpuPrimitive) {
-                dynamicPrimitives.push(anchorGpuPrimitive);
-              }
-            }
-            return; // GPU path complete - no CPU stroke needed
-          }
-        }
-        
-        // CPU fallback path (with stroke support)
-        const sampler = createPolygonAnimSampler({
+        const gpuPrimitive = createPolygonGpuPrimitive(instance, {
           vertices: layer.vertices,
           anim: animCfg,
-          timeSource: getTentacleTimeMs,
-          enableMovementAxis: true,
-          phaseStep: POLYGON_SWAY_PHASE_STEP,
-          executionMode: "cpu",
-        });
-        const getDeformedVertices = () => {
-          const deformed = sampler.getVertices();
-          if (hasAnchors && needsCpuAnchors) {
-            const resolved = resolveLayerAnchors({
-              anchors: anchorConfigs,
-              vertices: deformed,
-              offset: staticOffset,
-            });
-            writeAnchorsForLayer(instance.id, layer.groupId, resolved);
-          }
-          return deformed;
-        };
-
-        if (layer.stroke) {
-          const layerStrokeForAnimated = layer.stroke;
-          const strokeColor =
-            layer.stroke.kind === "solid"
-              ? layer.stroke.color
-              : resolveStrokeColor(instance, renderer.baseStrokeColor, renderer.baseFillColor);
-          const sceneStroke: SceneStroke = { width: layer.stroke.width, color: strokeColor };
-          dynamicPrimitives.push(
-            createDynamicPolygonStrokePrimitive(instance, {
-              getVertices: () => getDeformedVertices(),
-              stroke: sceneStroke,
-              offset: staticOffset,
-              getOffset,
-              refreshStroke: layerStrokeForAnimated.kind === "base"
-                ? (inst) => ({
-                    width: layerStrokeForAnimated.width,
-                    color: resolveStrokeColor(inst, renderer.baseStrokeColor, renderer.baseFillColor),
-                  })
-                : undefined,
-            })
-          );
-        }
-        const primitive = createDynamicPolygonPrimitive(instance, {
-          getVertices: () => getDeformedVertices(),
-          offset: staticOffset,
-          getOffset,
           fill: animatedLayerFill,
+          offset: staticOffset,
+          phaseStep: POLYGON_SWAY_PHASE_STEP,
+          enableMovementAxis: true,
           refreshFill: (inst) => resolveLayerFill(inst, layerFillForAnimated, renderer),
         });
-        if (getOffset) {
-          primitive.autoAnimate = true;
+        if (gpuPrimitive) {
+          dynamicPrimitives.push(gpuPrimitive);
+          if (hasAnchors) {
+            const anchorGpuPrimitive = createPolygonAnchorGpuPrimitive({
+              instance,
+              groupId: layer.groupId,
+              anchors: anchorConfigs,
+              vertices: layer.vertices,
+              anim: animCfg,
+              offset: staticOffset,
+              phaseStep: POLYGON_SWAY_PHASE_STEP,
+              enableMovementAxis: true,
+            });
+            if (anchorGpuPrimitive) {
+              dynamicPrimitives.push(anchorGpuPrimitive);
+            }
+          }
         }
-        dynamicPrimitives.push(primitive);
+        return; // GPU-only, no CPU fallback
       } else {
-        // OPTIMIZATION: Cache fill at registration time for static layers
+        // GPU-only path for static polygons
         const cachedFill = resolveLayerFill(instance, layer.fill, renderer);
         const layerFillForStatic = layer.fill;
         const anchorConfigs = collectAnchors(layer);
@@ -451,57 +322,16 @@ export const createCompositePrimitives = (
           writeAnchorsForLayer(instance.id, layer.groupId, resolved);
         }
         
-        // GPU path for static polygons without join offset (skip stroke for performance)
-        if (!getOffset && isAnimationGpuAvailable()) {
-          const gpuPrimitive = createPolygonGpuPrimitive(instance, {
-            vertices: layer.vertices,
-            offset: staticOffset,
-            fill: cachedFill,
-            refreshFill: (inst) => resolveLayerFill(inst, layerFillForStatic, renderer),
-          });
-          if (gpuPrimitive) {
-            dynamicPrimitives.push(gpuPrimitive);
-            return; // GPU path complete - no CPU stroke needed
-          }
-        }
-        
-        // CPU fallback path (for joined layers or if GPU unavailable)
-        if (layer.stroke) {
-          const layerStrokeForStatic = layer.stroke;
-          const strokeColor =
-            layer.stroke.kind === "solid"
-              ? layer.stroke.color
-              : resolveStrokeColor(instance, renderer.baseStrokeColor, renderer.baseFillColor);
-          const sceneStroke: SceneStroke = {
-            width: layer.stroke.width,
-            color: strokeColor,
-          };
-          dynamicPrimitives.push(
-            createDynamicPolygonStrokePrimitive(instance, {
-              vertices: layer.vertices,
-              stroke: sceneStroke,
-              offset: staticOffset,
-              getOffset,
-              refreshStroke: layerStrokeForStatic.kind === "base"
-                ? (inst) => ({
-                    width: layerStrokeForStatic.width,
-                    color: resolveStrokeColor(inst, renderer.baseStrokeColor, renderer.baseFillColor),
-                  })
-                : undefined,
-            })
-          );
-        }
-        const primitive = createDynamicPolygonPrimitive(instance, {
+        // GPU-only: use regular GPU polygon (joined polygons already handled above)
+        const gpuPrimitive = createPolygonGpuPrimitive(instance, {
           vertices: layer.vertices,
-          offset: staticOffset,
-          getOffset,
+          offset: staticOffset ?? layer.offset,
           fill: cachedFill,
           refreshFill: (inst) => resolveLayerFill(inst, layerFillForStatic, renderer),
         });
-        if (getOffset) {
-          primitive.autoAnimate = true;
+        if (gpuPrimitive) {
+          dynamicPrimitives.push(gpuPrimitive);
         }
-        dynamicPrimitives.push(primitive);
       }
       return;
     }

--- a/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts
@@ -132,7 +132,7 @@ export const createCompositePrimitives = (
   };
   const joinTargets = new Set<string>();
   renderer.layers.forEach((layer) => {
-    if (layer.join && !supportsGpuJoin(layer)) {
+    if (layer.join) {
       joinTargets.add(normalizeGroupId(layer.join.targetGroupId));
     }
   });

--- a/src/ui/renderers/objects/implementations/player-unit/helpers.ts
+++ b/src/ui/renderers/objects/implementations/player-unit/helpers.ts
@@ -149,6 +149,8 @@ type PlayerLayerExtraFields = {
   buildOpts?: RendererLayer["buildOpts"];
   groupId?: RendererLayer["groupId"];
   anchors?: RendererLayer["anchors"];
+  connectionSlots?: RendererLayer["anchors"];
+  join?: RendererLayer["join"];
 };
 
 const sanitizePlayerCompositeLayer = createCompositeLayerSanitizer<
@@ -187,6 +189,8 @@ const sanitizePlayerCompositeLayer = createCompositeLayerSanitizer<
     buildOpts: layer.buildOpts,
     groupId: layer.groupId,
     anchors: layer.anchors,
+    connectionSlots: layer.connectionSlots,
+    join: layer.join,
   }),
 });
 

--- a/src/ui/renderers/objects/shared/composite-renderer-helpers.ts
+++ b/src/ui/renderers/objects/shared/composite-renderer-helpers.ts
@@ -267,21 +267,28 @@ export const applyBrightness = (component: number, brightness: number): number =
   return component;
 };
 
+// Reusable scratch color to avoid allocations in hot path
+const tintScratch: SceneColor = { r: 0, g: 0, b: 0, a: 1 };
+
 /**
- * Tints a color with brightness and alpha multiplier
+ * Tints a color with brightness and alpha multiplier.
+ * Returns a reusable scratch object - caller should NOT store the reference!
  */
 export const tintColor = (
   color: SceneColor,
   brightness: number,
   alphaMultiplier: number
 ): SceneColor => {
-  const r = clamp01(applyBrightness(color.r, brightness ?? 0));
-  const g = clamp01(applyBrightness(color.g, brightness ?? 0));
-  const b = clamp01(applyBrightness(color.b, brightness ?? 0));
+  tintScratch.r = clamp01(applyBrightness(color.r, brightness ?? 0));
+  tintScratch.g = clamp01(applyBrightness(color.g, brightness ?? 0));
+  tintScratch.b = clamp01(applyBrightness(color.b, brightness ?? 0));
   const baseAlpha = typeof color.a === "number" && Number.isFinite(color.a) ? color.a : 1;
-  const a = clamp01(baseAlpha * (alphaMultiplier ?? 1));
-  return { r, g, b, a };
+  tintScratch.a = clamp01(baseAlpha * (alphaMultiplier ?? 1));
+  return tintScratch;
 };
+
+// Cache for resolved fill colors to avoid repeated object creation
+const fillColorCache = new WeakMap<SceneFill, SceneColor>();
 
 /**
  * Resolves fill color from instance
@@ -292,14 +299,21 @@ export const resolveCompositeFillColor = (
 ): SceneColor => {
   const fill = instance.data.fill;
   if (fill?.fillType === FILL_TYPES.SOLID) {
+    // Check cache first
+    let cached = fillColorCache.get(fill);
+    if (cached) {
+      return cached;
+    }
     const solidFill = fill as SceneSolidFill;
     const color = solidFill.color;
-    return {
+    cached = {
       r: color.r,
       g: color.g,
       b: color.b,
       a: typeof color.a === "number" && Number.isFinite(color.a) ? color.a : 1,
     };
+    fillColorCache.set(fill, cached);
+    return cached;
   }
   return fallback;
 };

--- a/src/ui/renderers/primitives/JoinedPolygonGpuPrimitive.ts
+++ b/src/ui/renderers/primitives/JoinedPolygonGpuPrimitive.ts
@@ -485,18 +485,17 @@ export const createJoinedPolygonStrokeGpuPrimitive = (
         return null;
       }
 
-      let strokeChanged = false;
+      let strokeColorChanged = false;
       if (typeof options.refreshStroke === "function") {
         if (target.data.stroke !== prevInstanceStrokeRef) {
           prevInstanceStrokeRef = target.data.stroke;
           const nextStroke = options.refreshStroke(target);
           if (nextStroke.width !== cachedStroke.width) {
-            cachedStroke = nextStroke;
             outer = inner.map((vertex) => {
               const dirX = vertex.x - geometry.centerOffset.x;
               const dirY = vertex.y - geometry.centerOffset.y;
               const length = Math.hypot(dirX, dirY) || 1;
-              const scale = (length + cachedStroke.width) / length;
+              const scale = (length + nextStroke.width) / length;
               return {
                 x: geometry.centerOffset.x + dirX * scale,
                 y: geometry.centerOffset.y + dirY * scale,
@@ -508,14 +507,19 @@ export const createJoinedPolygonStrokeGpuPrimitive = (
             gl.bufferSubData(gl.ARRAY_BUFFER, 0, packedVertices);
             gl.bindBuffer(gl.ARRAY_BUFFER, null);
             joinedPolygonGpuRenderer.updateHandle(renderHandle, vertices.length);
-          } else {
-            cachedStroke = nextStroke;
           }
-          strokeChanged = true;
+          // Check if color actually changed
+          const prevColor = cachedStroke.color;
+          const nextColor = nextStroke.color;
+          if (prevColor.r !== nextColor.r || prevColor.g !== nextColor.g || 
+              prevColor.b !== nextColor.b || prevColor.a !== nextColor.a) {
+            strokeColorChanged = true;
+          }
+          cachedStroke = nextStroke;
         }
       }
 
-      if (strokeChanged || !fillData) {
+      if (strokeColorChanged || !fillData) {
         writeFill();
       }
 
@@ -626,26 +630,30 @@ export const createJoinedCircleStrokeGpuPrimitive = (
       if (!ensureResources() || !gl || !fillBuffer || !positionBuffer || !renderHandle) {
         return null;
       }
-      let strokeChanged = false;
+      let strokeColorChanged = false;
       if (typeof options.refreshStroke === "function") {
         if (target.data.stroke !== prevInstanceStrokeRef) {
           prevInstanceStrokeRef = target.data.stroke;
           const nextStroke = options.refreshStroke(target);
           if (nextStroke.width !== cachedStroke.width) {
-            cachedStroke = nextStroke;
-            vertices = buildVertices(options.radius + cachedStroke.width);
+            vertices = buildVertices(options.radius + nextStroke.width);
             packedVertices = buildPackedVertices(vertices);
             gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
             gl.bufferSubData(gl.ARRAY_BUFFER, 0, packedVertices);
             gl.bindBuffer(gl.ARRAY_BUFFER, null);
             joinedPolygonGpuRenderer.updateHandle(renderHandle, vertices.length);
-          } else {
-            cachedStroke = nextStroke;
           }
-          strokeChanged = true;
+          // Check if color actually changed
+          const prevColor = cachedStroke.color;
+          const nextColor = nextStroke.color;
+          if (prevColor.r !== nextColor.r || prevColor.g !== nextColor.g || 
+              prevColor.b !== nextColor.b || prevColor.a !== nextColor.a) {
+            strokeColorChanged = true;
+          }
+          cachedStroke = nextStroke;
         }
       }
-      if (strokeChanged || !fillData) {
+      if (strokeColorChanged || !fillData) {
         const fillComponents = writeFillVertexComponents(fillScratch, {
           fill: createStrokeFill(cachedStroke),
           center: { x: 0, y: 0 },

--- a/src/ui/renderers/primitives/PolygonGpuPrimitive.ts
+++ b/src/ui/renderers/primitives/PolygonGpuPrimitive.ts
@@ -18,7 +18,7 @@ import { computePolygonGeometry } from "@ui/renderers/primitives/basic/PolygonPr
 
 export interface PolygonGpuPrimitiveOptions {
   vertices: SceneVector2[];
-  anim: RendererLayerAnimationConfig;
+  anim?: RendererLayerAnimationConfig;
   fill: SceneFill;
   offset?: SceneVector2;
   phaseStep?: number;
@@ -88,14 +88,15 @@ export const createPolygonGpuPrimitive = (
   let prevRotation = instance.data.rotation ?? 0;
   let needsFillUpload = true;
 
-  // Pre-compute animation params from config
+  // Pre-compute animation params from config (optional - static polygon if undefined)
   const anim = options.anim;
-  const axis = anim.axis ?? "normal";
+  const hasAnim = !!anim;
+  const axis = anim?.axis ?? "normal";
   const axisType = axis === "tangent" ? 1 : axis === "movement-tangent" || axis === "movement-normal" ? 2 : 0;
-  const animType = anim.type === "pulse" ? 1 : 0;
-  const useVertexPhase = anim.type === "sway" && axisType !== 2 ? 1 : 0;
+  const animType = anim?.type === "pulse" ? 1 : 0;
+  const useVertexPhase = anim?.type === "sway" && axisType !== 2 ? 1 : 0;
   const amplitudePercent =
-    typeof anim.amplitudePercentage === "number" && Number.isFinite(anim.amplitudePercentage)
+    hasAnim && typeof anim?.amplitudePercentage === "number" && Number.isFinite(anim.amplitudePercentage)
       ? anim.amplitudePercentage
       : -1;
 
@@ -143,11 +144,11 @@ export const createPolygonGpuPrimitive = (
       if (!renderHandle) {
         return false;
       }
-      // Initialize animation params
-      renderHandle.anim.periodMs = Math.max(anim.periodMs ?? 1500, 1);
-      renderHandle.anim.phase = anim.phase ?? 0;
-      renderHandle.anim.amplitude = anim.amplitude ?? 6;
-      renderHandle.anim.amplitudePercent = amplitudePercent;
+      // Initialize animation params (static polygon if no anim: amplitude = 0)
+      renderHandle.anim.periodMs = Math.max(anim?.periodMs ?? 1500, 1);
+      renderHandle.anim.phase = anim?.phase ?? 0;
+      renderHandle.anim.amplitude = hasAnim ? (anim?.amplitude ?? 6) : 0;
+      renderHandle.anim.amplitudePercent = hasAnim ? amplitudePercent : 0;
       renderHandle.anim.phaseStep = options.phaseStep ?? 0.3;
       renderHandle.anim.animType = animType;
       renderHandle.anim.axisType = axisType;

--- a/src/ui/renderers/primitives/PolygonGpuPrimitive.ts
+++ b/src/ui/renderers/primitives/PolygonGpuPrimitive.ts
@@ -4,12 +4,7 @@ import type {
   SceneVector2,
 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import type { RendererLayerAnimationConfig } from "@shared/types/renderer.types";
-import {
-  createPolygonTransformFeedbackResources,
-  getAnimationGpuContext,
-  updatePolygonTransformFeedback,
-  type PolygonTransformFeedbackResources,
-} from "@ui/renderers/objects/shared/animation-gpu";
+import { getAnimationGpuContext } from "@ui/renderers/objects/shared/animation-gpu";
 import {
   FILL_COMPONENTS,
   DynamicPrimitive,
@@ -68,6 +63,7 @@ export const createPolygonGpuPrimitive = (
   const packedVertices = buildPackedVertices(options.vertices);
   const geometry = computePolygonGeometry(options.vertices);
 
+  // Compute center of polygon (in local coords)
   const center = options.vertices.reduce(
     (acc, v) => ({ x: acc.x + v.x, y: acc.y + v.y }),
     { x: 0, y: 0 }
@@ -82,8 +78,8 @@ export const createPolygonGpuPrimitive = (
   let prevInstanceFillRef: SceneFill | undefined =
     typeof options.refreshFill === "function" ? instance.data.fill : undefined;
 
-  let gl = getAnimationGpuContext();
-  let tfResources: PolygonTransformFeedbackResources | null = null;
+  let gl: WebGL2RenderingContext | null = getAnimationGpuContext();
+  let positionBuffer: WebGLBuffer | null = null;
   let fillBuffer: WebGLBuffer | null = null;
   let renderHandle: PolygonGpuHandle | null = null;
 
@@ -92,6 +88,17 @@ export const createPolygonGpuPrimitive = (
   let prevRotation = instance.data.rotation ?? 0;
   let needsFillUpload = true;
 
+  // Pre-compute animation params from config
+  const anim = options.anim;
+  const axis = anim.axis ?? "normal";
+  const axisType = axis === "tangent" ? 1 : axis === "movement-tangent" || axis === "movement-normal" ? 2 : 0;
+  const animType = anim.type === "pulse" ? 1 : 0;
+  const useVertexPhase = anim.type === "sway" && axisType !== 2 ? 1 : 0;
+  const amplitudePercent =
+    typeof anim.amplitudePercentage === "number" && Number.isFinite(anim.amplitudePercentage)
+      ? anim.amplitudePercentage
+      : -1;
+
   const ensureResources = (): boolean => {
     if (!gl) {
       gl = getAnimationGpuContext();
@@ -99,15 +106,18 @@ export const createPolygonGpuPrimitive = (
     if (!gl) {
       return false;
     }
-    if (!tfResources) {
-      tfResources = createPolygonTransformFeedbackResources({
-        vertexCount,
-        vertices: packedVertices,
-      });
-      if (!tfResources) {
+    
+    // Create position buffer with LOCAL vertices (animation done in vertex shader)
+    if (!positionBuffer) {
+      positionBuffer = gl.createBuffer();
+      if (!positionBuffer) {
         return false;
       }
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, packedVertices, gl.STATIC_DRAW);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
     }
+    
     if (!fillBuffer) {
       fillBuffer = gl.createBuffer();
       if (!fillBuffer) {
@@ -121,16 +131,27 @@ export const createPolygonGpuPrimitive = (
       );
       gl.bindBuffer(gl.ARRAY_BUFFER, null);
     }
+    
     polygonGpuRenderer.setContext(gl);
     if (!renderHandle) {
       renderHandle = polygonGpuRenderer.acquireHandle({
-        outputBuffer: tfResources.outputBuffer,
+        positionBuffer,
         fillBuffer,
         vertexCount,
+        center,
       });
       if (!renderHandle) {
         return false;
       }
+      // Initialize animation params
+      renderHandle.anim.periodMs = Math.max(anim.periodMs ?? 1500, 1);
+      renderHandle.anim.phase = anim.phase ?? 0;
+      renderHandle.anim.amplitude = anim.amplitude ?? 6;
+      renderHandle.anim.amplitudePercent = amplitudePercent;
+      renderHandle.anim.phaseStep = options.phaseStep ?? 0.3;
+      renderHandle.anim.animType = animType;
+      renderHandle.anim.axisType = axisType;
+      renderHandle.anim.useVertexPhase = useVertexPhase;
     }
     return true;
   };
@@ -141,7 +162,7 @@ export const createPolygonGpuPrimitive = (
     },
     autoAnimate: true,
     update(target: SceneObjectInstance): Float32Array | null {
-      if (!ensureResources() || !gl || !tfResources || !fillBuffer) {
+      if (!ensureResources() || !gl || !positionBuffer || !fillBuffer || !renderHandle) {
         return null;
       }
 
@@ -158,14 +179,12 @@ export const createPolygonGpuPrimitive = (
         }
       }
 
-      if (
-        needsFillUpload ||
-        fillRefChanged ||
-        pos.x !== prevPosX ||
-        pos.y !== prevPosY ||
-        rotation !== prevRotation
-      ) {
-        const fillCenter = transformObjectPoint(origin, rotation, geometry.centerOffset);
+      const fillCenter = transformObjectPoint(pos, rotation, {
+        x: (options.offset?.x ?? 0) + center.x,
+        y: (options.offset?.y ?? 0) + center.y,
+      });
+
+      if (needsFillUpload || fillRefChanged) {
         const fillComponents = writeFillVertexComponents(fillScratch, {
           fill: cachedFill,
           center: fillCenter,
@@ -179,22 +198,23 @@ export const createPolygonGpuPrimitive = (
         needsFillUpload = false;
       }
 
+      // Update animation params (read by renderer in beforeRender)
+      renderHandle.anim.timeMs = getSceneTimelineNow();
+      renderHandle.anim.origin.x = origin.x;
+      renderHandle.anim.origin.y = origin.y;
+      renderHandle.anim.rotation = rotation;
+
+      // Track movement for movement-axis modes
+      const dx = pos.x - prevPosX;
+      const dy = pos.y - prevPosY;
+      const moveLen = Math.sqrt(dx * dx + dy * dy);
+      if (moveLen > 0.01) {
+        renderHandle.anim.movementDir.x = dx / moveLen;
+        renderHandle.anim.movementDir.y = dy / moveLen;
+      }
       prevPosX = pos.x;
       prevPosY = pos.y;
       prevRotation = rotation;
-
-      updatePolygonTransformFeedback({
-        resources: tfResources,
-        vertices: packedVertices,
-        vertexCount,
-        anim: options.anim,
-        timeMs: getSceneTimelineNow(),
-        center,
-        origin,
-        rotation,
-        phaseStep: options.phaseStep ?? 0.3,
-        enableMovementAxis: Boolean(options.enableMovementAxis),
-      });
 
       return null;
     },
@@ -206,15 +226,13 @@ export const createPolygonGpuPrimitive = (
         polygonGpuRenderer.releaseHandle(renderHandle);
         renderHandle = null;
       }
+      if (positionBuffer) {
+        gl.deleteBuffer(positionBuffer);
+        positionBuffer = null;
+      }
       if (fillBuffer) {
         gl.deleteBuffer(fillBuffer);
         fillBuffer = null;
-      }
-      if (tfResources) {
-        gl.deleteBuffer(tfResources.inputBuffer);
-        gl.deleteBuffer(tfResources.outputBuffer);
-        gl.deleteVertexArray(tfResources.vao);
-        tfResources = null;
       }
     },
   };

--- a/src/ui/renderers/primitives/PolygonGpuPrimitive.ts
+++ b/src/ui/renderers/primitives/PolygonGpuPrimitive.ts
@@ -92,7 +92,7 @@ export const createPolygonGpuPrimitive = (
   const anim = options.anim;
   const hasAnim = !!anim;
   const axis = anim?.axis ?? "normal";
-  const axisType = axis === "tangent" ? 1 : axis === "movement-tangent" || axis === "movement-normal" ? 2 : 0;
+  const axisType = axis === "tangent" ? 1 : axis === "movement-tangent" ? 2 : axis === "movement-normal" ? 3 : 0;
   const animType = anim?.type === "pulse" ? 1 : 0;
   const useVertexPhase = anim?.type === "sway" && axisType !== 2 ? 1 : 0;
   const amplitudePercent =

--- a/src/ui/renderers/primitives/SpineGpuPrimitive.ts
+++ b/src/ui/renderers/primitives/SpineGpuPrimitive.ts
@@ -1,0 +1,160 @@
+import type {
+  SceneFill,
+  SceneObjectInstance,
+  SceneVector2,
+} from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { RendererLayerAnimationConfig } from "@shared/types/renderer.types";
+import { getAnimationGpuContext } from "@ui/renderers/objects/shared/animation-gpu";
+import {
+  DynamicPrimitive,
+  getInstanceRenderPosition,
+  transformObjectPoint,
+} from "@ui/renderers/objects/ObjectRenderer";
+import { spineGpuRenderer, type SpineGpuHandle } from "@ui/renderers/primitives/gpu/spine";
+import { getSceneTimelineNow } from "@ui/renderers/primitives/utils/sceneTimeline";
+import { FILL_TYPES } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.const";
+
+export interface SpinePoint {
+  x: number;
+  y: number;
+  width: number;
+}
+
+export interface SpineGpuPrimitiveOptions {
+  spine: SpinePoint[];
+  anim: RendererLayerAnimationConfig;
+  fill: SceneFill;
+  offset?: SceneVector2;
+  buildOpts?: {
+    epsilon?: number;
+    winding?: "CW" | "CCW";
+  };
+  refreshFill?: (instance: SceneObjectInstance) => SceneFill;
+}
+
+// Extract solid color from fill (fallback to white for gradients)
+const extractFillColor = (fill: SceneFill): { r: number; g: number; b: number; a: number } => {
+  if (fill.fillType === FILL_TYPES.SOLID) {
+    const color = (fill as { color: { r: number; g: number; b: number; a?: number } }).color;
+    return {
+      r: color.r,
+      g: color.g,
+      b: color.b,
+      a: typeof color.a === "number" ? color.a : 1,
+    };
+  }
+  // For gradients, use first stop color
+  const gradientFill = fill as { stops?: Array<{ color: { r: number; g: number; b: number; a?: number } }> };
+  if (gradientFill.stops && gradientFill.stops.length > 0) {
+    const color = gradientFill.stops[0]!.color;
+    return {
+      r: color.r,
+      g: color.g,
+      b: color.b,
+      a: typeof color.a === "number" ? color.a : 1,
+    };
+  }
+  return { r: 1, g: 1, b: 1, a: 1 };
+};
+
+export const createSpineGpuPrimitive = (
+  instance: SceneObjectInstance,
+  options: SpineGpuPrimitiveOptions
+): DynamicPrimitive | null => {
+  if (!options.spine || options.spine.length < 2) {
+    return null;
+  }
+
+  const spine = options.spine;
+  const anim = options.anim;
+  const buildOpts = options.buildOpts ?? {};
+  const epsilon = typeof buildOpts.epsilon === "number" ? buildOpts.epsilon : 0.2;
+  const winding = buildOpts.winding ?? "CCW";
+
+  let cachedFill: SceneFill = options.fill;
+  let cachedColor = extractFillColor(cachedFill);
+  let prevInstanceFillRef: SceneFill | undefined =
+    typeof options.refreshFill === "function" ? instance.data.fill : undefined;
+
+  let gl: WebGL2RenderingContext | null = getAnimationGpuContext();
+  let renderHandle: SpineGpuHandle | null = null;
+  let needsColorUpload = true;
+
+  const ensureResources = (): boolean => {
+    if (!gl) {
+      gl = getAnimationGpuContext();
+    }
+    if (!gl) {
+      return false;
+    }
+
+    spineGpuRenderer.setContext(gl);
+    if (!renderHandle) {
+      renderHandle = spineGpuRenderer.acquireHandle({
+        spinePoints: spine,
+        axis: anim.axis === "tangent" ? "tangent" : "normal",
+        falloff: anim.falloff === "root" ? "root" : anim.falloff === "none" ? "none" : "tip",
+        epsilon,
+        winding,
+      });
+      if (!renderHandle) {
+        return false;
+      }
+      // Initialize animation params
+      renderHandle.anim.periodMs = Math.max(anim.periodMs ?? 1400, 1);
+      renderHandle.anim.phase = anim.phase ?? 0;
+      renderHandle.anim.amplitude = anim.amplitude ?? 1;
+    }
+    return true;
+  };
+
+  const primitive: DynamicPrimitive = {
+    get data() {
+      return new Float32Array(0);
+    },
+    autoAnimate: true,
+    update(target: SceneObjectInstance): Float32Array | null {
+      if (!ensureResources() || !gl || !renderHandle) {
+        return null;
+      }
+
+      const pos = getInstanceRenderPosition(target);
+      const rotation = target.data.rotation ?? 0;
+      const origin = transformObjectPoint(pos, rotation, options.offset);
+
+      let fillRefChanged = false;
+      if (typeof options.refreshFill === "function") {
+        if (target.data.fill !== prevInstanceFillRef) {
+          prevInstanceFillRef = target.data.fill;
+          cachedFill = options.refreshFill(target);
+          cachedColor = extractFillColor(cachedFill);
+          fillRefChanged = true;
+        }
+      }
+
+      if (needsColorUpload || fillRefChanged) {
+        spineGpuRenderer.updateHandleFill(renderHandle, cachedColor);
+        needsColorUpload = false;
+      }
+
+      // Update animation params (read by renderer in beforeRender)
+      renderHandle.anim.timeMs = getSceneTimelineNow();
+      renderHandle.anim.origin.x = origin.x;
+      renderHandle.anim.origin.y = origin.y;
+      renderHandle.anim.rotation = rotation;
+
+      return null;
+    },
+    dispose() {
+      if (!gl) {
+        return;
+      }
+      if (renderHandle) {
+        spineGpuRenderer.releaseHandle(renderHandle);
+        renderHandle = null;
+      }
+    },
+  };
+
+  return primitive;
+};

--- a/src/ui/renderers/primitives/SpineGpuPrimitive.ts
+++ b/src/ui/renderers/primitives/SpineGpuPrimitive.ts
@@ -61,7 +61,13 @@ export const createSpineGpuPrimitive = (
   instance: SceneObjectInstance,
   options: SpineGpuPrimitiveOptions
 ): DynamicPrimitive | null => {
+  console.log("[SpineGpuPrimitive] createSpineGpuPrimitive called", {
+    instanceId: instance.id,
+    spineLength: options.spine?.length,
+    hasAnim: !!options.anim,
+  });
   if (!options.spine || options.spine.length < 2) {
+    console.warn("[SpineGpuPrimitive] Invalid spine - too few points");
     return null;
   }
 
@@ -85,11 +91,17 @@ export const createSpineGpuPrimitive = (
       gl = getAnimationGpuContext();
     }
     if (!gl) {
+      console.warn("[SpineGpuPrimitive] No GL context available");
       return false;
     }
 
     spineGpuRenderer.setContext(gl);
-    if (!renderHandle) {
+    // console.log("[SpineGpuPrimitive] ensure resources:", !!renderHandle);
+    // Check if handle exists AND is still registered in renderer
+    const handleValid = renderHandle && spineGpuRenderer.isHandleValid(renderHandle);
+    if (!handleValid) {
+      renderHandle = null; // Clear stale handle
+      console.log("[SpineGpuPrimitive] Acquiring handle for spine with", spine.length, "points");
       renderHandle = spineGpuRenderer.acquireHandle({
         spinePoints: spine,
         axis: anim.axis === "tangent" ? "tangent" : "normal",
@@ -98,12 +110,16 @@ export const createSpineGpuPrimitive = (
         winding,
       });
       if (!renderHandle) {
+        console.error("[SpineGpuPrimitive] Failed to acquire render handle");
         return false;
       }
+      console.log("[SpineGpuPrimitive] Got handle slot", renderHandle.slotIndex);
       // Initialize animation params
       renderHandle.anim.periodMs = Math.max(anim.periodMs ?? 1400, 1);
       renderHandle.anim.phase = anim.phase ?? 0;
       renderHandle.anim.amplitude = anim.amplitude ?? 1;
+    } else {
+      // console.log("[SpineGpuPrimitive] Reusing existing handle slot", renderHandle?.slotIndex);
     }
     return true;
   };
@@ -114,7 +130,8 @@ export const createSpineGpuPrimitive = (
     },
     autoAnimate: true,
     update(target: SceneObjectInstance): Float32Array | null {
-      if (!ensureResources() || !gl || !renderHandle) {
+      const resourcesOk = ensureResources();
+      if (!resourcesOk || !gl || !renderHandle) {
         return null;
       }
 

--- a/src/ui/renderers/primitives/basic/CirclePrimitive.ts
+++ b/src/ui/renderers/primitives/basic/CirclePrimitive.ts
@@ -360,24 +360,14 @@ export const createDynamicCirclePrimitive = (
       );
       
       // Skip fill computation for solid fills (color doesn't depend on position)
+      // For non-solid fills, use cachedFill (already resolved) instead of calling resolveFill again
       let fillComponents: Float32Array;
       if (isSolidFill && !fillRefChanged) {
         fillComponents = fillScratch; // Reuse cached solid fill
-      } else if (fillRefChanged) {
-        // refreshFill was triggered - use the newly cached fill
+      } else {
+        // Use cachedFill - it's already been resolved (either initially or via refreshFill)
         fillComponents = writeFillVertexComponents(fillScratch, {
           fill: cachedFill,
-          center: nextCenter,
-          rotation: target.data.rotation ?? 0,
-          size: {
-            width: nextRadius * 2,
-            height: nextRadius * 2,
-          },
-          radius: nextRadius,
-        });
-      } else {
-        fillComponents = writeFillVertexComponents(fillScratch, {
-          fill: resolveFill(options, target),
           center: nextCenter,
           rotation: target.data.rotation ?? 0,
           size: {

--- a/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
+++ b/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
@@ -575,8 +575,14 @@ export const createDynamicPolygonPrimitive = (
           rotation,
           size: geometry.size,
         });
+      } else if (cachedFill.fillType === FILL_TYPES.SOLID) {
+        // OPTIMIZATION: For solid fills, just update center position (indices 4,5)
+        // This avoids full writeFillVertexComponents call
+        fillScratch[4] = fillCenter.x;
+        fillScratch[5] = fillCenter.y;
+        fillComponents = fillScratch;
       } else {
-        // Just update center position in fill components
+        // Non-solid static fill (gradient) - need full recalculation for center/rotation
         fillComponents = writeFillVertexComponents(fillScratch, {
           fill: cachedFill,
           center: fillCenter,
@@ -1142,6 +1148,7 @@ export const createDynamicPolygonStrokePrimitive = (
       // For animated vertices or stroke changes, use fast path (no change detection overhead)
       // For static vertices without stroke changes, use change detection to skip GPU upload when possible
       if (!isStaticVertices || strokeRefChanged) {
+        console.log("updateStrokeBandDataFast", target.id, target);
         updateStrokeBandDataFast(data, origin, rotation, inner, outer, fillComponents);
         return data;
       }

--- a/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
+++ b/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
@@ -1149,6 +1149,8 @@ export const createDynamicPolygonStrokePrimitive = (
       // For static vertices without stroke changes, use change detection to skip GPU upload when possible
       if (!isStaticVertices || strokeRefChanged) {
         console.log("updateStrokeBandDataFast", target.id, target);
+        throw new Error("Not implemented");
+      
         updateStrokeBandDataFast(data, origin, rotation, inner, outer, fillComponents);
         return data;
       }

--- a/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
+++ b/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
@@ -1083,7 +1083,6 @@ export const createDynamicPolygonStrokePrimitive = (
       return data;
     },
     update(target: SceneObjectInstance) {
-      return null;
       const pos = getInstanceRenderPosition(target);
       const nextRotation = target.data.rotation ?? 0;
       const nextOffset = resolveOffset(options, target);

--- a/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
+++ b/src/ui/renderers/primitives/basic/PolygonPrimitive.ts
@@ -1083,6 +1083,7 @@ export const createDynamicPolygonStrokePrimitive = (
       return data;
     },
     update(target: SceneObjectInstance) {
+      return null;
       const pos = getInstanceRenderPosition(target);
       const nextRotation = target.data.rotation ?? 0;
       const nextOffset = resolveOffset(options, target);

--- a/src/ui/renderers/primitives/gpu/polygon/PolygonGpuRenderer.ts
+++ b/src/ui/renderers/primitives/gpu/polygon/PolygonGpuRenderer.ts
@@ -1,9 +1,10 @@
-import type { SceneCameraState } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { SceneCameraState, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import { compileShader, linkProgram } from "@ui/renderers/utils/webglProgram";
 import {
-  SCENE_VERTEX_SHADER,
+  SCENE_VERTEX_SHADER_HEADER,
   createSceneFragmentShader,
 } from "@ui/renderers/shaders/fillEffects.glsl";
+import { TO_CLIP_GLSL } from "@ui/renderers/shaders/common.glsl";
 import {
   POSITION_COMPONENTS,
   FILL_COMPONENTS,
@@ -21,6 +22,7 @@ import {
 import { textureAtlasRegistry } from "@ui/renderers/textures/TextureAtlasRegistry";
 import { textureResourceManager } from "@ui/renderers/textures/TextureResourceManager";
 import { loadSpriteTexture } from "@ui/renderers/primitives/basic/SpritePrimitive";
+import type { RendererLayerAnimationConfig } from "@shared/types/renderer.types";
 
 interface AttributeConfig {
   location: number;
@@ -28,12 +30,117 @@ interface AttributeConfig {
   offset: number;
 }
 
+export type PolygonAnimationParams = {
+  timeMs: number;
+  periodMs: number;
+  phase: number;
+  amplitude: number;
+  amplitudePercent: number;
+  phaseStep: number;
+  animType: number; // 0 = sway, 1 = pulse
+  axisType: number; // 0 = normal, 1 = tangent, 2 = movement
+  useVertexPhase: number;
+  center: SceneVector2;
+  origin: SceneVector2;
+  rotation: number;
+  movementDir: SceneVector2; // normalized movement direction
+};
+
 export type PolygonGpuHandle = {
   vao: WebGLVertexArrayObject;
-  outputBuffer: WebGLBuffer;
+  positionBuffer: WebGLBuffer; // Now stores LOCAL vertices (not TF output)
   fillBuffer: WebGLBuffer;
   vertexCount: number;
+  // Animation parameters (updated each frame)
+  anim: PolygonAnimationParams;
 };
+
+// Vertex shader with animation built-in (no Transform Feedback needed)
+const ANIMATED_VERTEX_SHADER = `${SCENE_VERTEX_SHADER_HEADER}
+// Animation uniforms
+uniform float u_timeMs;
+uniform float u_periodMs;
+uniform float u_phase;
+uniform float u_amplitude;
+uniform float u_amplitudePercent;
+uniform float u_phaseStep;
+uniform int u_animType; // 0 sway, 1 pulse
+uniform int u_axisType; // 0 normal, 1 tangent, 2 movement
+uniform int u_useVertexPhase;
+uniform vec2 u_center;
+uniform vec2 u_origin;
+uniform float u_rotation;
+uniform vec2 u_movementDir;
+
+vec2 resolveNormal(vec2 pos, vec2 center) {
+  vec2 d = pos - center;
+  float len = length(d);
+  if (len < 1e-6) {
+    return vec2(0.0, 0.0);
+  }
+  return d / len;
+}
+
+${TO_CLIP_GLSL}
+
+void main() {
+  // Animation calculation (moved from Transform Feedback)
+  vec2 basePos = a_position;
+  float omega = 6.28318530718 / max(u_periodMs, 1.0);
+  float baseAngle = omega * u_timeMs + u_phase;
+  float phaseOffset = (u_useVertexPhase == 1) ? (u_phaseStep * float(gl_VertexID)) : 0.0;
+  float angle = baseAngle + phaseOffset;
+  float s = sin(angle);
+
+  vec2 normal = resolveNormal(basePos, u_center);
+  vec2 tangent = vec2(-normal.y, normal.x);
+  vec2 axis;
+  if (u_axisType == 1) {
+    axis = tangent;
+  } else if (u_axisType == 2) {
+    // Movement-based axis - perpendicular to movement direction
+    axis = vec2(-u_movementDir.y, u_movementDir.x);
+  } else {
+    axis = normal;
+  }
+
+  float magnitude = u_amplitude;
+  if (u_amplitudePercent >= 0.0 && u_axisType == 0) {
+    float radius = length(basePos - u_center);
+    magnitude = radius * u_amplitudePercent;
+  }
+
+  vec2 offset = axis * (magnitude * s);
+  vec2 localPos = basePos + offset;
+  
+  // Apply rotation
+  float cosR = cos(u_rotation);
+  float sinR = sin(u_rotation);
+  vec2 rotated = vec2(
+    localPos.x * cosR - localPos.y * sinR,
+    localPos.x * sinR + localPos.y * cosR
+  );
+  
+  // Transform to world space
+  vec2 worldPos = u_origin + rotated;
+
+  gl_Position = vec4(toClip(worldPos), 0.0, 1.0);
+  v_worldPosition = worldPos;
+  v_uv = a_fillParams0.xy;
+  v_fillInfo = a_fillInfo;
+  v_fillParams0 = a_fillParams0;
+  v_fillParams1 = a_fillParams1;
+  v_filaments0 = a_filaments0;
+  v_filamentEdgeBlur = a_filamentEdgeBlur;
+  v_stopOffsets = a_stopOffsets;
+  v_stopColor0 = a_stopColor0;
+  v_stopColor1 = a_stopColor1;
+  v_stopColor2 = a_stopColor2;
+  v_crackUv = a_crackUv;
+  v_crackMask = a_crackMask;
+  v_crackEffects = a_crackEffects;
+}
+`;
 
 const FRAGMENT_SHADER = createSceneFragmentShader();
 
@@ -52,6 +159,20 @@ class PolygonGpuRenderer {
   private crackAtlasIndexLocation: WebGLUniformLocation | null = null;
   private crackAtlasGridLocation: WebGLUniformLocation | null = null;
   private crackAtlasSamplerLocation: WebGLUniformLocation | null = null;
+  // Animation uniform locations
+  private timeMsLocation: WebGLUniformLocation | null = null;
+  private periodMsLocation: WebGLUniformLocation | null = null;
+  private phaseLocation: WebGLUniformLocation | null = null;
+  private amplitudeLocation: WebGLUniformLocation | null = null;
+  private amplitudePercentLocation: WebGLUniformLocation | null = null;
+  private phaseStepLocation: WebGLUniformLocation | null = null;
+  private animTypeLocation: WebGLUniformLocation | null = null;
+  private axisTypeLocation: WebGLUniformLocation | null = null;
+  private useVertexPhaseLocation: WebGLUniformLocation | null = null;
+  private centerLocation: WebGLUniformLocation | null = null;
+  private originLocation: WebGLUniformLocation | null = null;
+  private rotationLocation: WebGLUniformLocation | null = null;
+  private movementDirLocation: WebGLUniformLocation | null = null;
 
   public setContext(gl: WebGL2RenderingContext | null): void {
     if (this.gl === gl) {
@@ -63,7 +184,7 @@ class PolygonGpuRenderer {
       return;
     }
 
-    this.vertexShader = compileShader(gl, gl.VERTEX_SHADER, SCENE_VERTEX_SHADER);
+    this.vertexShader = compileShader(gl, gl.VERTEX_SHADER, ANIMATED_VERTEX_SHADER);
     this.fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
     this.program = linkProgram(gl, this.vertexShader, this.fragmentShader);
 
@@ -81,12 +202,28 @@ class PolygonGpuRenderer {
     this.crackAtlasIndexLocation = gl.getUniformLocation(this.program, "u_crackAtlasIndex");
     this.crackAtlasGridLocation = gl.getUniformLocation(this.program, "u_crackAtlasGrid");
     this.crackAtlasSamplerLocation = gl.getUniformLocation(this.program, "u_cracksAtlas");
+    
+    // Animation uniforms
+    this.timeMsLocation = gl.getUniformLocation(this.program, "u_timeMs");
+    this.periodMsLocation = gl.getUniformLocation(this.program, "u_periodMs");
+    this.phaseLocation = gl.getUniformLocation(this.program, "u_phase");
+    this.amplitudeLocation = gl.getUniformLocation(this.program, "u_amplitude");
+    this.amplitudePercentLocation = gl.getUniformLocation(this.program, "u_amplitudePercent");
+    this.phaseStepLocation = gl.getUniformLocation(this.program, "u_phaseStep");
+    this.animTypeLocation = gl.getUniformLocation(this.program, "u_animType");
+    this.axisTypeLocation = gl.getUniformLocation(this.program, "u_axisType");
+    this.useVertexPhaseLocation = gl.getUniformLocation(this.program, "u_useVertexPhase");
+    this.centerLocation = gl.getUniformLocation(this.program, "u_center");
+    this.originLocation = gl.getUniformLocation(this.program, "u_origin");
+    this.rotationLocation = gl.getUniformLocation(this.program, "u_rotation");
+    this.movementDirLocation = gl.getUniformLocation(this.program, "u_movementDir");
   }
 
   public acquireHandle(options: {
-    outputBuffer: WebGLBuffer;
+    positionBuffer: WebGLBuffer;
     fillBuffer: WebGLBuffer;
     vertexCount: number;
+    center: SceneVector2;
   }): PolygonGpuHandle | null {
     const gl = this.gl;
     if (!gl || !this.program) {
@@ -98,7 +235,7 @@ class PolygonGpuRenderer {
     }
     gl.bindVertexArray(vao);
 
-    gl.bindBuffer(gl.ARRAY_BUFFER, options.outputBuffer);
+    gl.bindBuffer(gl.ARRAY_BUFFER, options.positionBuffer);
     gl.enableVertexAttribArray(this.positionLocation);
     gl.vertexAttribPointer(
       this.positionLocation,
@@ -120,9 +257,24 @@ class PolygonGpuRenderer {
 
     const handle: PolygonGpuHandle = {
       vao,
-      outputBuffer: options.outputBuffer,
+      positionBuffer: options.positionBuffer,
       fillBuffer: options.fillBuffer,
       vertexCount: options.vertexCount,
+      anim: {
+        timeMs: 0,
+        periodMs: 1500,
+        phase: 0,
+        amplitude: 6,
+        amplitudePercent: -1,
+        phaseStep: 0.3,
+        animType: 0,
+        axisType: 0,
+        useVertexPhase: 1,
+        center: { x: options.center.x, y: options.center.y },
+        origin: { x: 0, y: 0 },
+        rotation: 0,
+        movementDir: { x: 0, y: 1 },
+      },
     };
     this.handles.add(handle);
     return handle;
@@ -232,6 +384,49 @@ class PolygonGpuRenderer {
       if (handle.vertexCount < 3) {
         return;
       }
+      
+      // Set animation uniforms for this handle
+      const anim = handle.anim;
+      if (this.timeMsLocation !== null) {
+        gl.uniform1f(this.timeMsLocation, anim.timeMs);
+      }
+      if (this.periodMsLocation !== null) {
+        gl.uniform1f(this.periodMsLocation, anim.periodMs);
+      }
+      if (this.phaseLocation !== null) {
+        gl.uniform1f(this.phaseLocation, anim.phase);
+      }
+      if (this.amplitudeLocation !== null) {
+        gl.uniform1f(this.amplitudeLocation, anim.amplitude);
+      }
+      if (this.amplitudePercentLocation !== null) {
+        gl.uniform1f(this.amplitudePercentLocation, anim.amplitudePercent);
+      }
+      if (this.phaseStepLocation !== null) {
+        gl.uniform1f(this.phaseStepLocation, anim.phaseStep);
+      }
+      if (this.animTypeLocation !== null) {
+        gl.uniform1i(this.animTypeLocation, anim.animType);
+      }
+      if (this.axisTypeLocation !== null) {
+        gl.uniform1i(this.axisTypeLocation, anim.axisType);
+      }
+      if (this.useVertexPhaseLocation !== null) {
+        gl.uniform1i(this.useVertexPhaseLocation, anim.useVertexPhase);
+      }
+      if (this.centerLocation !== null) {
+        gl.uniform2f(this.centerLocation, anim.center.x, anim.center.y);
+      }
+      if (this.originLocation !== null) {
+        gl.uniform2f(this.originLocation, anim.origin.x, anim.origin.y);
+      }
+      if (this.rotationLocation !== null) {
+        gl.uniform1f(this.rotationLocation, anim.rotation);
+      }
+      if (this.movementDirLocation !== null) {
+        gl.uniform2f(this.movementDirLocation, anim.movementDir.x, anim.movementDir.y);
+      }
+      
       gl.bindVertexArray(handle.vao);
       gl.drawArrays(gl.TRIANGLE_FAN, 0, handle.vertexCount);
     });

--- a/src/ui/renderers/primitives/gpu/polygon/PolygonGpuRenderer.ts
+++ b/src/ui/renderers/primitives/gpu/polygon/PolygonGpuRenderer.ts
@@ -92,25 +92,26 @@ void main() {
   float angle = baseAngle + phaseOffset;
   float s = sin(angle);
 
-  vec2 normal = resolveNormal(basePos, u_center);
-  vec2 tangent = vec2(-normal.y, normal.x);
-  vec2 axis;
-  if (u_axisType == 1) {
-    axis = tangent;
-  } else if (u_axisType == 2) {
-    // Movement-based axis - perpendicular to movement direction
-    axis = vec2(-u_movementDir.y, u_movementDir.x);
+  vec2 offset;
+  if (u_axisType == 2 || u_axisType == 3) {
+    // Movement-based axis - vertices on opposite sides move in opposite directions (squeeze/expand)
+    // axisType 2 = movement-tangent: movePerp = {0, 1} (perpendicular to movement in local coords)
+    // axisType 3 = movement-normal: movePerp = {-1, 0} (along movement in local coords)
+    vec2 movePerp = (u_axisType == 2) ? vec2(0.0, 1.0) : vec2(-1.0, 0.0);
+    float signedDist = dot(basePos - u_center, movePerp);
+    float mag = u_amplitudePercent > 0.0 ? abs(signedDist) * u_amplitudePercent : u_amplitude;
+    float moveToward = signedDist > 0.0 ? -1.0 : (signedDist < 0.0 ? 1.0 : 0.0);
+    offset = movePerp * (mag * s * moveToward);
   } else {
-    axis = normal;
+    vec2 normal = resolveNormal(basePos, u_center);
+    vec2 axis = (u_axisType == 1) ? vec2(-normal.y, normal.x) : normal;
+    float magnitude = u_amplitude;
+    if (u_amplitudePercent > 0.0) {
+      float radius = length(basePos - u_center);
+      magnitude = radius * u_amplitudePercent;
+    }
+    offset = axis * (magnitude * s);
   }
-
-  float magnitude = u_amplitude;
-  if (u_amplitudePercent >= 0.0 && u_axisType == 0) {
-    float radius = length(basePos - u_center);
-    magnitude = radius * u_amplitudePercent;
-  }
-
-  vec2 offset = axis * (magnitude * s);
   vec2 localPos = basePos + offset;
   
   // Apply rotation

--- a/src/ui/renderers/primitives/gpu/polygon/index.ts
+++ b/src/ui/renderers/primitives/gpu/polygon/index.ts
@@ -1,1 +1,1 @@
-export { polygonGpuRenderer, type PolygonGpuHandle } from "./PolygonGpuRenderer";
+export { polygonGpuRenderer, type PolygonGpuHandle, type PolygonAnimationParams } from "./PolygonGpuRenderer";

--- a/src/ui/renderers/primitives/gpu/spine/SpineGpuRenderer.ts
+++ b/src/ui/renderers/primitives/gpu/spine/SpineGpuRenderer.ts
@@ -5,13 +5,16 @@ import { TO_CLIP_GLSL } from "@ui/renderers/shaders/common.glsl";
 // Maximum spine points supported (each point = x, y, width, axisX, axisY, falloff)
 const MAX_SPINE_POINTS = 8;
 // Maximum instances per batch
-const MAX_INSTANCES = 512;
+const MAX_INSTANCES = 2048;
 // Floats per spine point in texture: x, y, width, axisX, axisY, falloff, padding, padding = 8
 const SPINE_POINT_FLOATS = 8;
 // Total floats per spine in texture
 const SPINE_DATA_FLOATS = MAX_SPINE_POINTS * SPINE_POINT_FLOATS;
-// Texture width (each texel = RGBA = 4 floats)
-const SPINE_TEX_WIDTH = (SPINE_DATA_FLOATS / 4) * MAX_INSTANCES;
+// Texels per spine (each texel = RGBA = 4 floats)
+const TEXELS_PER_SPINE = SPINE_DATA_FLOATS / 4; // 16 texels per spine
+// Texture dimensions: 2D texture with each row = one spine
+const SPINE_TEX_WIDTH = TEXELS_PER_SPINE; // 16
+const SPINE_TEX_HEIGHT = MAX_INSTANCES; // 2048
 
 export type SpineAnimationParams = {
   timeMs: number;
@@ -69,9 +72,8 @@ out vec4 v_fillColor;
 ${TO_CLIP_GLSL}
 
 vec4 fetchSpineTexel(int spineSlot, int texelIndex) {
-  int texelsPerSpine = ${MAX_SPINE_POINTS} * 2;
-  int globalTexel = spineSlot * texelsPerSpine + texelIndex;
-  return texelFetch(u_spineDataTex, ivec2(globalTexel, 0), 0);
+  // 2D texture: row = spineSlot, col = texelIndex
+  return texelFetch(u_spineDataTex, ivec2(texelIndex, spineSlot), 0);
 }
 
 void getSpinePoint(int spineSlot, int pointIdx, out vec2 pos, out float width, out vec2 axis, out float falloff) {
@@ -200,7 +202,7 @@ class SpineGpuRenderer {
   
   // Data arrays
   private instanceData = new Float32Array(MAX_INSTANCES * INSTANCE_FLOATS);
-  private spineTextureData = new Float32Array(SPINE_TEX_WIDTH * 4);
+  private spineTextureData = new Float32Array(SPINE_TEX_WIDTH * SPINE_TEX_HEIGHT * 4);
   
   // Slot management
   private handles: SpineGpuHandle[] = [];
@@ -216,9 +218,11 @@ class SpineGpuRenderer {
   private spineDataTexLocation: WebGLUniformLocation | null = null;
 
   public setContext(gl: WebGL2RenderingContext | null): void {
+    // console.log("[SpineGpuRenderer] setContext called, same?", this.gl === gl, "activeCount before:", this.activeCount);
     if (this.gl === gl) {
       return;
     }
+    console.log("[SpineGpuRenderer] DIFFERENT GL - disposing! activeCount was:", this.activeCount);
     this.dispose();
     this.gl = gl;
     if (!gl) {
@@ -276,14 +280,14 @@ class SpineGpuRenderer {
     gl.bindVertexArray(null);
     gl.bindBuffer(gl.ARRAY_BUFFER, null);
     
-    // Create spine data texture
+    // Create spine data texture (2D: width=TEXELS_PER_SPINE, height=MAX_INSTANCES)
     this.spineDataTexture = gl.createTexture();
     if (!this.spineDataTexture) return;
     
     gl.bindTexture(gl.TEXTURE_2D, this.spineDataTexture);
     gl.texImage2D(
       gl.TEXTURE_2D, 0, gl.RGBA32F,
-      SPINE_TEX_WIDTH, 1, 0,
+      SPINE_TEX_WIDTH, SPINE_TEX_HEIGHT, 0,
       gl.RGBA, gl.FLOAT, this.spineTextureData
     );
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
@@ -306,7 +310,9 @@ class SpineGpuRenderer {
     epsilon: number;
     winding: "CW" | "CCW";
   }): SpineGpuHandle | null {
+    console.log("[SpineGpuRenderer] acquireHandle called, freeSlots:", this.freeSlots.length, "activeCount before:", this.activeCount);
     if (!this.gl || this.freeSlots.length === 0) {
+      console.warn("[SpineGpuRenderer] acquireHandle FAILED - no gl or no free slots");
       return null;
     }
     
@@ -318,10 +324,10 @@ class SpineGpuRenderer {
     const slotIndex = this.freeSlots.pop()!;
     const segmentCount = pointCount - 1;
     
-    // Write spine geometry to texture data
+    // Write spine geometry to texture data (2D layout: row = slotIndex)
     const texelsPerPoint = 2;
-    const texelsPerSpine = MAX_SPINE_POINTS * texelsPerPoint;
-    const baseTexel = slotIndex * texelsPerSpine;
+    // Base offset for this row in the texture data array
+    const rowOffset = slotIndex * SPINE_TEX_WIDTH * 4;
     
     for (let i = 0; i < pointCount; i++) {
       const p = options.spinePoints[i]!;
@@ -344,9 +350,10 @@ class SpineGpuRenderer {
           axisY = tangentX;
         }
       } else if (i > 0) {
-        const prevTexel = baseTexel + (i - 1) * texelsPerPoint;
-        axisX = this.spineTextureData[prevTexel * 4 + 3]!;
-        axisY = this.spineTextureData[(prevTexel + 1) * 4]!;
+        // Read previous point's axis from the same row
+        const prevTexelCol = (i - 1) * texelsPerPoint;
+        axisX = this.spineTextureData[rowOffset + prevTexelCol * 4 + 3]!;
+        axisY = this.spineTextureData[rowOffset + (prevTexelCol + 1) * 4]!;
       }
       
       // Compute falloff
@@ -362,21 +369,25 @@ class SpineGpuRenderer {
         falloff = 0;
       }
       
-      const texelIdx = baseTexel + i * texelsPerPoint;
-      this.spineTextureData[texelIdx * 4 + 0] = p.x;
-      this.spineTextureData[texelIdx * 4 + 1] = p.y;
-      this.spineTextureData[texelIdx * 4 + 2] = p.width;
-      this.spineTextureData[texelIdx * 4 + 3] = axisX;
-      this.spineTextureData[(texelIdx + 1) * 4 + 0] = axisY;
-      this.spineTextureData[(texelIdx + 1) * 4 + 1] = falloff;
-      this.spineTextureData[(texelIdx + 1) * 4 + 2] = 0;
-      this.spineTextureData[(texelIdx + 1) * 4 + 3] = 0;
+      // Column offset within the row
+      const texelCol = i * texelsPerPoint;
+      const baseIdx = rowOffset + texelCol * 4;
+      this.spineTextureData[baseIdx + 0] = p.x;
+      this.spineTextureData[baseIdx + 1] = p.y;
+      this.spineTextureData[baseIdx + 2] = p.width;
+      this.spineTextureData[baseIdx + 3] = axisX;
+      this.spineTextureData[baseIdx + 4] = axisY;
+      this.spineTextureData[baseIdx + 5] = falloff;
+      this.spineTextureData[baseIdx + 6] = 0;
+      this.spineTextureData[baseIdx + 7] = 0;
     }
     
+    // Zero out unused points in the row
     for (let i = pointCount; i < MAX_SPINE_POINTS; i++) {
-      const texelIdx = baseTexel + i * texelsPerPoint;
+      const texelCol = i * texelsPerPoint;
+      const baseIdx = rowOffset + texelCol * 4;
       for (let j = 0; j < 8; j++) {
-        this.spineTextureData[texelIdx * 4 + j] = 0;
+        this.spineTextureData[baseIdx + j] = 0;
       }
     }
     
@@ -401,10 +412,15 @@ class SpineGpuRenderer {
     
     this.handles[slotIndex] = handle;
     this.activeCount++;
+    console.log("[SpineGpuRenderer] acquireHandle SUCCESS - slot:", slotIndex, "activeCount now:", this.activeCount);
     
     return handle;
   }
   
+  public isHandleValid(handle: SpineGpuHandle): boolean {
+    return this.handles[handle.slotIndex] === handle;
+  }
+
   public updateHandleFill(handle: SpineGpuHandle, color: { r: number; g: number; b: number; a: number }): void {
     handle.fillColor.r = color.r;
     handle.fillColor.g = color.g;
@@ -415,6 +431,10 @@ class SpineGpuRenderer {
 
   public releaseHandle(handle: SpineGpuHandle): void {
     if (handle.slotIndex < 0 || handle.slotIndex >= MAX_INSTANCES) {
+      return;
+    }
+    // Only release if this handle is actually registered
+    if (this.handles[handle.slotIndex] !== handle) {
       return;
     }
     
@@ -470,7 +490,7 @@ class SpineGpuRenderer {
       gl.bindTexture(gl.TEXTURE_2D, this.spineDataTexture);
       gl.texSubImage2D(
         gl.TEXTURE_2D, 0, 0, 0,
-        SPINE_TEX_WIDTH, 1,
+        SPINE_TEX_WIDTH, SPINE_TEX_HEIGHT,
         gl.RGBA, gl.FLOAT, this.spineTextureData
       );
       gl.bindTexture(gl.TEXTURE_2D, null);
@@ -480,8 +500,10 @@ class SpineGpuRenderer {
 
   public render(gl: WebGL2RenderingContext, cameraState: SceneCameraState): void {
     if (!this.program || this.activeCount === 0 || !this.vao) {
+      // console.log("[SpineGpuRenderer] render skipped:", { hasProgram: !!this.program, activeCount: this.activeCount, hasVao: !!this.vao });
       return;
     }
+    // console.log("[SpineGpuRenderer] rendering", this.activeCount, "spines");
     
     this.beforeRender();
     
@@ -510,6 +532,7 @@ class SpineGpuRenderer {
   }
 
   private dispose(): void {
+    console.error("[SpineGpuRenderer] DISPOSE CALLED! activeCount was:", this.activeCount, "handles:", this.handles.length);
     const gl = this.gl;
     if (!gl) {
       return;

--- a/src/ui/renderers/primitives/gpu/spine/SpineGpuRenderer.ts
+++ b/src/ui/renderers/primitives/gpu/spine/SpineGpuRenderer.ts
@@ -1,0 +1,548 @@
+import type { SceneCameraState, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import { compileShader, linkProgram } from "@ui/renderers/utils/webglProgram";
+import { TO_CLIP_GLSL } from "@ui/renderers/shaders/common.glsl";
+
+// Maximum spine points supported (each point = x, y, width, axisX, axisY, falloff)
+const MAX_SPINE_POINTS = 8;
+// Maximum instances per batch
+const MAX_INSTANCES = 512;
+// Floats per spine point in texture: x, y, width, axisX, axisY, falloff, padding, padding = 8
+const SPINE_POINT_FLOATS = 8;
+// Total floats per spine in texture
+const SPINE_DATA_FLOATS = MAX_SPINE_POINTS * SPINE_POINT_FLOATS;
+// Texture width (each texel = RGBA = 4 floats)
+const SPINE_TEX_WIDTH = (SPINE_DATA_FLOATS / 4) * MAX_INSTANCES;
+
+export type SpineAnimationParams = {
+  timeMs: number;
+  periodMs: number;
+  phase: number;
+  amplitude: number;
+  origin: SceneVector2;
+  rotation: number;
+};
+
+export type SpineGpuHandle = {
+  slotIndex: number;
+  segmentCount: number;
+  epsilon: number;
+  winding: "CW" | "CCW";
+  // Animation parameters (updated each frame by primitive)
+  anim: SpineAnimationParams;
+  // Fill color (RGBA) - simplified for performance
+  fillColor: { r: number; g: number; b: number; a: number };
+  fillDirty: boolean;
+};
+
+// Simplified fragment shader for spine - solid color only for performance
+const SPINE_FRAGMENT_SHADER = `#version 300 es
+precision highp float;
+
+in vec4 v_fillColor;
+
+out vec4 fragColor;
+
+void main() {
+  fragColor = v_fillColor;
+}
+`;
+
+// Instanced vertex shader - reads spine data from texture, instance data from attributes
+const SPINE_VERTEX_SHADER_INSTANCED = `#version 300 es
+precision highp float;
+
+// Camera uniforms
+uniform vec2 u_cameraPosition;
+uniform vec2 u_viewportSize;
+
+// Per-instance attributes (using low locations to stay within limits)
+layout(location = 0) in vec4 a_instanceAnim0;  // originX, originY, rotation, timeMs
+layout(location = 1) in vec4 a_instanceAnim1;  // periodMs, phase, amplitude, epsilon
+layout(location = 2) in vec4 a_instanceMeta;   // segmentCount, winding, unused, unused
+layout(location = 3) in vec4 a_instanceColor;  // r, g, b, a
+
+// Spine geometry texture
+uniform sampler2D u_spineDataTex;
+
+out vec4 v_fillColor;
+
+${TO_CLIP_GLSL}
+
+vec4 fetchSpineTexel(int spineSlot, int texelIndex) {
+  int texelsPerSpine = ${MAX_SPINE_POINTS} * 2;
+  int globalTexel = spineSlot * texelsPerSpine + texelIndex;
+  return texelFetch(u_spineDataTex, ivec2(globalTexel, 0), 0);
+}
+
+void getSpinePoint(int spineSlot, int pointIdx, out vec2 pos, out float width, out vec2 axis, out float falloff) {
+  int texelBase = pointIdx * 2;
+  vec4 t0 = fetchSpineTexel(spineSlot, texelBase);
+  vec4 t1 = fetchSpineTexel(spineSlot, texelBase + 1);
+  pos = t0.xy;
+  width = t0.z;
+  axis = vec2(t0.w, t1.x);
+  falloff = t1.y;
+}
+
+vec2 deformSpinePoint(int spineSlot, int idx, float timeMs, float periodMs, float phase, float amplitude) {
+  vec2 pos;
+  float width;
+  vec2 axis;
+  float falloff;
+  getSpinePoint(spineSlot, idx, pos, width, axis, falloff);
+  
+  if (idx == 0) {
+    return pos;
+  }
+  float omega = 6.28318530718 / max(periodMs, 1.0);
+  float baseAngle = omega * timeMs + phase;
+  float segmentPhase = float(idx) * 0.5;
+  float s = sin(baseAngle + segmentPhase);
+  float displacement = amplitude * falloff * s;
+  return pos + axis * displacement;
+}
+
+void main() {
+  vec2 origin = a_instanceAnim0.xy;
+  float rotation = a_instanceAnim0.z;
+  float timeMs = a_instanceAnim0.w;
+  float periodMs = a_instanceAnim1.x;
+  float phase = a_instanceAnim1.y;
+  float amplitude = a_instanceAnim1.z;
+  float epsilon = a_instanceAnim1.w;
+  int segmentCount = int(a_instanceMeta.x + 0.5);
+  int winding = int(a_instanceMeta.y + 0.5);
+  int spineSlot = gl_InstanceID;
+  
+  int segmentIdx = gl_VertexID / 6;
+  int vertexInQuad = gl_VertexID % 6;
+  
+  if (segmentIdx >= segmentCount) {
+    gl_Position = vec4(0.0);
+    v_fillColor = vec4(0.0);
+    return;
+  }
+  
+  vec2 a = deformSpinePoint(spineSlot, segmentIdx, timeMs, periodMs, phase, amplitude);
+  vec2 b = deformSpinePoint(spineSlot, segmentIdx + 1, timeMs, periodMs, phase, amplitude);
+  
+  vec2 posA, posB;
+  float widthA, widthB;
+  vec2 axisA, axisB;
+  float falloffA, falloffB;
+  getSpinePoint(spineSlot, segmentIdx, posA, widthA, axisA, falloffA);
+  getSpinePoint(spineSlot, segmentIdx + 1, posB, widthB, axisB, falloffB);
+  
+  float wa = widthA * 0.5;
+  float wb = widthB * 0.5;
+  
+  vec2 dir = b - a;
+  float len = length(dir);
+  if (len < 0.0001) len = 1.0;
+  vec2 tangent = dir / len;
+  vec2 normal = vec2(-tangent.y, tangent.x);
+  
+  vec2 aCap = a - tangent * epsilon;
+  vec2 bCap = b + tangent * epsilon;
+  
+  vec2 aL = aCap + normal * wa;
+  vec2 aR = aCap - normal * wa;
+  vec2 bL = bCap + normal * wb;
+  vec2 bR = bCap - normal * wb;
+  
+  vec2 localPos;
+  if (winding == 0) {
+    if (vertexInQuad == 0) localPos = aL;
+    else if (vertexInQuad == 1) localPos = aR;
+    else if (vertexInQuad == 2) localPos = bL;
+    else if (vertexInQuad == 3) localPos = aR;
+    else if (vertexInQuad == 4) localPos = bR;
+    else localPos = bL;
+  } else {
+    if (vertexInQuad == 0) localPos = aR;
+    else if (vertexInQuad == 1) localPos = aL;
+    else if (vertexInQuad == 2) localPos = bR;
+    else if (vertexInQuad == 3) localPos = aL;
+    else if (vertexInQuad == 4) localPos = bL;
+    else localPos = bR;
+  }
+  
+  float cosR = cos(rotation);
+  float sinR = sin(rotation);
+  vec2 rotated = vec2(
+    localPos.x * cosR - localPos.y * sinR,
+    localPos.x * sinR + localPos.y * cosR
+  );
+  vec2 worldPos = origin + rotated;
+
+  gl_Position = vec4(toClip(worldPos), 0.0, 1.0);
+  v_fillColor = a_instanceColor;
+}
+`;
+
+// Instance data layout: 16 floats per instance
+// [0-3]: originX, originY, rotation, timeMs
+// [4-7]: periodMs, phase, amplitude, epsilon
+// [8-11]: segmentCount, winding, unused, unused
+// [12-15]: r, g, b, a
+const INSTANCE_FLOATS = 16;
+
+class SpineGpuRenderer {
+  private gl: WebGL2RenderingContext | null = null;
+  private program: WebGLProgram | null = null;
+  private vertexShader: WebGLShader | null = null;
+  private fragmentShader: WebGLShader | null = null;
+  
+  // Instancing resources
+  private vao: WebGLVertexArrayObject | null = null;
+  private instanceBuffer: WebGLBuffer | null = null;
+  private spineDataTexture: WebGLTexture | null = null;
+  
+  // Data arrays
+  private instanceData = new Float32Array(MAX_INSTANCES * INSTANCE_FLOATS);
+  private spineTextureData = new Float32Array(SPINE_TEX_WIDTH * 4);
+  
+  // Slot management
+  private handles: SpineGpuHandle[] = [];
+  private freeSlots: number[] = [];
+  private activeCount = 0;
+  private needsSpineTexUpload = false;
+  
+  private maxVerticesPerSpine = 0;
+  
+  // Uniform locations
+  private cameraPositionLocation: WebGLUniformLocation | null = null;
+  private viewportSizeLocation: WebGLUniformLocation | null = null;
+  private spineDataTexLocation: WebGLUniformLocation | null = null;
+
+  public setContext(gl: WebGL2RenderingContext | null): void {
+    if (this.gl === gl) {
+      return;
+    }
+    this.dispose();
+    this.gl = gl;
+    if (!gl) {
+      return;
+    }
+
+    this.vertexShader = compileShader(gl, gl.VERTEX_SHADER, SPINE_VERTEX_SHADER_INSTANCED);
+    this.fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, SPINE_FRAGMENT_SHADER);
+    this.program = linkProgram(gl, this.vertexShader, this.fragmentShader);
+
+    this.maxVerticesPerSpine = (MAX_SPINE_POINTS - 1) * 6;
+
+    this.cameraPositionLocation = gl.getUniformLocation(this.program, "u_cameraPosition");
+    this.viewportSizeLocation = gl.getUniformLocation(this.program, "u_viewportSize");
+    this.spineDataTexLocation = gl.getUniformLocation(this.program, "u_spineDataTex");
+    
+    this.initializeResources(gl);
+  }
+  
+  private initializeResources(gl: WebGL2RenderingContext): void {
+    this.vao = gl.createVertexArray();
+    if (!this.vao) return;
+    
+    gl.bindVertexArray(this.vao);
+    
+    // Create instance buffer
+    this.instanceBuffer = gl.createBuffer();
+    if (!this.instanceBuffer) return;
+    
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.instanceBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, this.instanceData, gl.DYNAMIC_DRAW);
+    
+    const instanceStride = INSTANCE_FLOATS * Float32Array.BYTES_PER_ELEMENT;
+    
+    // a_instanceAnim0 at location 0: vec4 (originX, originY, rotation, timeMs)
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 4, gl.FLOAT, false, instanceStride, 0);
+    gl.vertexAttribDivisor(0, 1);
+    
+    // a_instanceAnim1 at location 1: vec4 (periodMs, phase, amplitude, epsilon)
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 4, gl.FLOAT, false, instanceStride, 4 * Float32Array.BYTES_PER_ELEMENT);
+    gl.vertexAttribDivisor(1, 1);
+    
+    // a_instanceMeta at location 2: vec4 (segmentCount, winding, unused, unused)
+    gl.enableVertexAttribArray(2);
+    gl.vertexAttribPointer(2, 4, gl.FLOAT, false, instanceStride, 8 * Float32Array.BYTES_PER_ELEMENT);
+    gl.vertexAttribDivisor(2, 1);
+    
+    // a_instanceColor at location 3: vec4 (r, g, b, a)
+    gl.enableVertexAttribArray(3);
+    gl.vertexAttribPointer(3, 4, gl.FLOAT, false, instanceStride, 12 * Float32Array.BYTES_PER_ELEMENT);
+    gl.vertexAttribDivisor(3, 1);
+    
+    gl.bindVertexArray(null);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    
+    // Create spine data texture
+    this.spineDataTexture = gl.createTexture();
+    if (!this.spineDataTexture) return;
+    
+    gl.bindTexture(gl.TEXTURE_2D, this.spineDataTexture);
+    gl.texImage2D(
+      gl.TEXTURE_2D, 0, gl.RGBA32F,
+      SPINE_TEX_WIDTH, 1, 0,
+      gl.RGBA, gl.FLOAT, this.spineTextureData
+    );
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    
+    // Initialize free slots
+    this.freeSlots = [];
+    for (let i = MAX_INSTANCES - 1; i >= 0; i--) {
+      this.freeSlots.push(i);
+    }
+  }
+
+  public acquireHandle(options: {
+    spinePoints: Array<{ x: number; y: number; width: number }>;
+    axis: "normal" | "tangent";
+    falloff: "tip" | "root" | "none";
+    epsilon: number;
+    winding: "CW" | "CCW";
+  }): SpineGpuHandle | null {
+    if (!this.gl || this.freeSlots.length === 0) {
+      return null;
+    }
+    
+    const pointCount = Math.min(options.spinePoints.length, MAX_SPINE_POINTS);
+    if (pointCount < 2) {
+      return null;
+    }
+    
+    const slotIndex = this.freeSlots.pop()!;
+    const segmentCount = pointCount - 1;
+    
+    // Write spine geometry to texture data
+    const texelsPerPoint = 2;
+    const texelsPerSpine = MAX_SPINE_POINTS * texelsPerPoint;
+    const baseTexel = slotIndex * texelsPerSpine;
+    
+    for (let i = 0; i < pointCount; i++) {
+      const p = options.spinePoints[i]!;
+      
+      // Compute axis
+      let axisX = 0, axisY = 1;
+      if (i < segmentCount) {
+        const a = options.spinePoints[i]!;
+        const b = options.spinePoints[i + 1]!;
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+        const len = Math.hypot(dx, dy) || 1;
+        const tangentX = dx / len;
+        const tangentY = dy / len;
+        if (options.axis === "tangent") {
+          axisX = tangentX;
+          axisY = tangentY;
+        } else {
+          axisX = -tangentY;
+          axisY = tangentX;
+        }
+      } else if (i > 0) {
+        const prevTexel = baseTexel + (i - 1) * texelsPerPoint;
+        axisX = this.spineTextureData[prevTexel * 4 + 3]!;
+        axisY = this.spineTextureData[(prevTexel + 1) * 4]!;
+      }
+      
+      // Compute falloff
+      let falloff = 1;
+      if (pointCount > 1 && i > 0) {
+        const ratio = i / (pointCount - 1);
+        if (options.falloff === "tip") {
+          falloff = ratio;
+        } else if (options.falloff === "root") {
+          falloff = 1 - ratio;
+        }
+      } else {
+        falloff = 0;
+      }
+      
+      const texelIdx = baseTexel + i * texelsPerPoint;
+      this.spineTextureData[texelIdx * 4 + 0] = p.x;
+      this.spineTextureData[texelIdx * 4 + 1] = p.y;
+      this.spineTextureData[texelIdx * 4 + 2] = p.width;
+      this.spineTextureData[texelIdx * 4 + 3] = axisX;
+      this.spineTextureData[(texelIdx + 1) * 4 + 0] = axisY;
+      this.spineTextureData[(texelIdx + 1) * 4 + 1] = falloff;
+      this.spineTextureData[(texelIdx + 1) * 4 + 2] = 0;
+      this.spineTextureData[(texelIdx + 1) * 4 + 3] = 0;
+    }
+    
+    for (let i = pointCount; i < MAX_SPINE_POINTS; i++) {
+      const texelIdx = baseTexel + i * texelsPerPoint;
+      for (let j = 0; j < 8; j++) {
+        this.spineTextureData[texelIdx * 4 + j] = 0;
+      }
+    }
+    
+    this.needsSpineTexUpload = true;
+    
+    const handle: SpineGpuHandle = {
+      slotIndex,
+      segmentCount,
+      epsilon: options.epsilon,
+      winding: options.winding,
+      anim: {
+        timeMs: 0,
+        periodMs: 1400,
+        phase: 0,
+        amplitude: 1,
+        origin: { x: 0, y: 0 },
+        rotation: 0,
+      },
+      fillColor: { r: 1, g: 1, b: 1, a: 1 },
+      fillDirty: true,
+    };
+    
+    this.handles[slotIndex] = handle;
+    this.activeCount++;
+    
+    return handle;
+  }
+  
+  public updateHandleFill(handle: SpineGpuHandle, color: { r: number; g: number; b: number; a: number }): void {
+    handle.fillColor.r = color.r;
+    handle.fillColor.g = color.g;
+    handle.fillColor.b = color.b;
+    handle.fillColor.a = color.a;
+    handle.fillDirty = true;
+  }
+
+  public releaseHandle(handle: SpineGpuHandle): void {
+    if (handle.slotIndex < 0 || handle.slotIndex >= MAX_INSTANCES) {
+      return;
+    }
+    
+    const offset = handle.slotIndex * INSTANCE_FLOATS;
+    for (let i = 0; i < INSTANCE_FLOATS; i++) {
+      this.instanceData[offset + i] = 0;
+    }
+    
+    this.freeSlots.push(handle.slotIndex);
+    delete this.handles[handle.slotIndex];
+    this.activeCount--;
+  }
+  
+  private beforeRender(): void {
+    const gl = this.gl;
+    if (!gl) return;
+    
+    // Update instance data from handles
+    for (let i = 0; i < MAX_INSTANCES; i++) {
+      const handle = this.handles[i];
+      if (!handle) continue;
+      
+      const offset = i * INSTANCE_FLOATS;
+      const anim = handle.anim;
+      
+      this.instanceData[offset + 0] = anim.origin.x;
+      this.instanceData[offset + 1] = anim.origin.y;
+      this.instanceData[offset + 2] = anim.rotation;
+      this.instanceData[offset + 3] = anim.timeMs;
+      this.instanceData[offset + 4] = anim.periodMs;
+      this.instanceData[offset + 5] = anim.phase;
+      this.instanceData[offset + 6] = anim.amplitude;
+      this.instanceData[offset + 7] = handle.epsilon;
+      this.instanceData[offset + 8] = handle.segmentCount;
+      this.instanceData[offset + 9] = handle.winding === "CW" ? 1 : 0;
+      this.instanceData[offset + 10] = 0; // unused
+      this.instanceData[offset + 11] = 0; // unused
+      this.instanceData[offset + 12] = handle.fillColor.r;
+      this.instanceData[offset + 13] = handle.fillColor.g;
+      this.instanceData[offset + 14] = handle.fillColor.b;
+      this.instanceData[offset + 15] = handle.fillColor.a;
+    }
+    
+    // Upload instance buffer
+    if (this.instanceBuffer) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.instanceBuffer);
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, this.instanceData);
+      gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    }
+    
+    // Upload spine texture if needed
+    if (this.needsSpineTexUpload && this.spineDataTexture) {
+      gl.bindTexture(gl.TEXTURE_2D, this.spineDataTexture);
+      gl.texSubImage2D(
+        gl.TEXTURE_2D, 0, 0, 0,
+        SPINE_TEX_WIDTH, 1,
+        gl.RGBA, gl.FLOAT, this.spineTextureData
+      );
+      gl.bindTexture(gl.TEXTURE_2D, null);
+      this.needsSpineTexUpload = false;
+    }
+  }
+
+  public render(gl: WebGL2RenderingContext, cameraState: SceneCameraState): void {
+    if (!this.program || this.activeCount === 0 || !this.vao) {
+      return;
+    }
+    
+    this.beforeRender();
+    
+    gl.useProgram(this.program);
+    
+    if (this.cameraPositionLocation) {
+      gl.uniform2f(this.cameraPositionLocation, cameraState.position.x, cameraState.position.y);
+    }
+    if (this.viewportSizeLocation) {
+      gl.uniform2f(this.viewportSizeLocation, cameraState.viewportSize.width, cameraState.viewportSize.height);
+    }
+    
+    // Bind spine data texture
+    if (this.spineDataTexture && this.spineDataTexLocation !== null) {
+      gl.activeTexture(gl.TEXTURE7);
+      gl.bindTexture(gl.TEXTURE_2D, this.spineDataTexture);
+      gl.uniform1i(this.spineDataTexLocation, 7);
+    }
+    
+    gl.bindVertexArray(this.vao);
+    
+    // Single instanced draw call for all spines!
+    gl.drawArraysInstanced(gl.TRIANGLES, 0, this.maxVerticesPerSpine, MAX_INSTANCES);
+    
+    gl.bindVertexArray(null);
+  }
+
+  private dispose(): void {
+    const gl = this.gl;
+    if (!gl) {
+      return;
+    }
+    
+    if (this.vao) {
+      gl.deleteVertexArray(this.vao);
+      this.vao = null;
+    }
+    if (this.instanceBuffer) {
+      gl.deleteBuffer(this.instanceBuffer);
+      this.instanceBuffer = null;
+    }
+    if (this.spineDataTexture) {
+      gl.deleteTexture(this.spineDataTexture);
+      this.spineDataTexture = null;
+    }
+    if (this.program) {
+      gl.deleteProgram(this.program);
+    }
+    if (this.vertexShader) {
+      gl.deleteShader(this.vertexShader);
+    }
+    if (this.fragmentShader) {
+      gl.deleteShader(this.fragmentShader);
+    }
+    this.program = null;
+    this.vertexShader = null;
+    this.fragmentShader = null;
+    this.handles = [];
+    this.freeSlots = [];
+    this.activeCount = 0;
+  }
+}
+
+export const spineGpuRenderer = new SpineGpuRenderer();

--- a/src/ui/renderers/primitives/gpu/spine/index.ts
+++ b/src/ui/renderers/primitives/gpu/spine/index.ts
@@ -1,0 +1,1 @@
+export { spineGpuRenderer, type SpineGpuHandle, type SpineAnimationParams } from "./SpineGpuRenderer";

--- a/src/ui/renderers/primitives/index.ts
+++ b/src/ui/renderers/primitives/index.ts
@@ -17,6 +17,7 @@ export {
   createDynamicPolygonStrokePrimitive,
 } from "./basic/PolygonPrimitive";
 export { createPolygonGpuPrimitive } from "./PolygonGpuPrimitive";
+export { createSpineGpuPrimitive } from "./SpineGpuPrimitive";
 export {
   createJoinedPolygonGpuPrimitive,
   createJoinedCircleGpuPrimitive,

--- a/src/ui/renderers/primitives/utils/fill.ts
+++ b/src/ui/renderers/primitives/utils/fill.ts
@@ -83,26 +83,39 @@ const resolveRadius = (
 // Static fallback stops to avoid allocations
 const FALLBACK_SOLID_STOP: SceneGradientStop[] = [{ offset: 0, color: { r: 1, g: 1, b: 1, a: 1 } }];
 
+// OPTIMIZATION: Cache limited stops per gradient fill to avoid repeated allocations
+const gradientStopsCache = new WeakMap<readonly SceneGradientStop[], SceneGradientStop[]>();
+
 const limitStops = (stops: readonly SceneGradientStop[]): SceneGradientStop[] => {
-  // OPTIMIZATION: Don't slice if within limit - just return a copy
+  // Check cache first
+  let cached = gradientStopsCache.get(stops);
+  if (cached) {
+    return cached;
+  }
+  
+  // OPTIMIZATION: Don't slice if within limit - just return a copy (cached)
   if (stops.length <= MAX_GRADIENT_STOPS) {
-    return stops.slice();
-  }
-  const limited: SceneGradientStop[] = [];
-  const lastIndex = stops.length - 1;
-  limited.push(stops[0]!);
-  const middleCount = MAX_GRADIENT_STOPS - 2;
-  if (middleCount > 0) {
-    const step = lastIndex / (middleCount + 1);
-    for (let i = 1; i <= middleCount; i += 1) {
-      const rawIndex = Math.round(i * step);
-      const index = Math.min(lastIndex - 1, Math.max(1, rawIndex));
-      const candidate = (stops[index] ?? stops[lastIndex])!;
-      limited.push(candidate);
+    cached = stops.slice();
+  } else {
+    const limited: SceneGradientStop[] = [];
+    const lastIndex = stops.length - 1;
+    limited.push(stops[0]!);
+    const middleCount = MAX_GRADIENT_STOPS - 2;
+    if (middleCount > 0) {
+      const step = lastIndex / (middleCount + 1);
+      for (let i = 1; i <= middleCount; i += 1) {
+        const rawIndex = Math.round(i * step);
+        const index = Math.min(lastIndex - 1, Math.max(1, rawIndex));
+        const candidate = (stops[index] ?? stops[lastIndex])!;
+        limited.push(candidate);
+      }
     }
+    limited.push(stops[lastIndex]!);
+    cached = limited;
   }
-  limited.push(stops[lastIndex]!);
-  return limited;
+  
+  gradientStopsCache.set(stops, cached);
+  return cached;
 };
 
 // Cached solid stop per fill to avoid allocations

--- a/src/ui/renderers/utils/WebGLSceneRenderer.ts
+++ b/src/ui/renderers/utils/WebGLSceneRenderer.ts
@@ -27,6 +27,7 @@ import { textureResourceManager } from "../textures/TextureResourceManager";
 import { setAnimationGpuContext, disposeAnimationGpuResources } from "../objects/shared/animation-gpu";
 import { disposeAnchorsGpuResources, updateAnchorsGpuTexture } from "../objects/shared/anchors-gpu";
 import { polygonGpuRenderer } from "../primitives/gpu/polygon";
+import { spineGpuRenderer } from "../primitives/gpu/spine";
 import { joinedPolygonGpuRenderer } from "../primitives/gpu/joined";
 
 const VERTEX_SHADER = SCENE_VERTEX_SHADER;
@@ -315,6 +316,8 @@ export class WebGLSceneRenderer {
     this.drawBuffer(this.dynamicBuffer, this.objectsRenderer.getDynamicVertexCount());
     polygonGpuRenderer.setContext(this.gl);
     polygonGpuRenderer.render(this.gl, cameraState);
+    spineGpuRenderer.setContext(this.gl);
+    spineGpuRenderer.render(this.gl, cameraState);
     joinedPolygonGpuRenderer.setContext(this.gl);
     if (joinedPolygonGpuRenderer.hasHandles()) {
       const uploadStart = performance.now();
@@ -390,6 +393,7 @@ export class WebGLSceneRenderer {
     disposeAnchorsGpuResources(this.gl);
     setAnimationGpuContext(null);
     polygonGpuRenderer.setContext(null);
+    spineGpuRenderer.setContext(null);
     joinedPolygonGpuRenderer.setContext(null);
     this.gl.deleteBuffer(this.staticBuffer);
     this.gl.deleteBuffer(this.dynamicBuffer);

--- a/src/ui/screens/Scene/components/debug/SceneDebugPanel.tsx
+++ b/src/ui/screens/Scene/components/debug/SceneDebugPanel.tsx
@@ -23,6 +23,9 @@ const SceneDebugPanelInner: React.FC<SceneDebugPanelProps> = ({ bridge }) => {
   const vboRef = useRef<HTMLDivElement | null>(null);
   const particlesRef = useRef<HTMLDivElement | null>(null);
   const movableRef = useRef<HTMLDivElement | null>(null);
+  const unitsRef = useRef<HTMLDivElement | null>(null);
+  const jointsRef = useRef<HTMLDivElement | null>(null);
+  const animationsRef = useRef<HTMLDivElement | null>(null);
   const joinedRef = useRef<HTMLDivElement | null>(null);
   const joinedTimingRef = useRef<HTMLDivElement | null>(null);
   const lastDisplayedTime = useRef<string | null>(null);
@@ -30,6 +33,9 @@ const SceneDebugPanelInner: React.FC<SceneDebugPanelProps> = ({ bridge }) => {
   const lastDisplayedVbo = useRef<string | null>(null);
   const lastDisplayedParticles = useRef<string | null>(null);
   const lastDisplayedMovable = useRef<string | null>(null);
+  const lastDisplayedUnits = useRef<string | null>(null);
+  const lastDisplayedJoints = useRef<string | null>(null);
+  const lastDisplayedAnimations = useRef<string | null>(null);
   const lastDisplayedJoined = useRef<string | null>(null);
   const lastDisplayedJoinedTiming = useRef<string | null>(null);
 
@@ -78,6 +84,30 @@ const SceneDebugPanelInner: React.FC<SceneDebugPanelProps> = ({ bridge }) => {
         }
       }
 
+      if (unitsRef.current) {
+        const next = `Units: ${debugStats.unitCount}`;
+        if (lastDisplayedUnits.current !== next) {
+          lastDisplayedUnits.current = next;
+          unitsRef.current.textContent = next;
+        }
+      }
+
+      if (jointsRef.current) {
+        const next = `Joints: ${debugStats.jointCount} (GPU ${debugStats.jointGpuCount} / CPU ${debugStats.jointCpuCount})`;
+        if (lastDisplayedJoints.current !== next) {
+          lastDisplayedJoints.current = next;
+          jointsRef.current.textContent = next;
+        }
+      }
+
+      if (animationsRef.current) {
+        const next = `Animations: ${debugStats.animationCount} (GPU ${debugStats.animationGpuCount} / CPU ${debugStats.animationCpuCount})`;
+        if (lastDisplayedAnimations.current !== next) {
+          lastDisplayedAnimations.current = next;
+          animationsRef.current.textContent = next;
+        }
+      }
+
       if (joinedRef.current) {
         const next = `Joined GPU: ${debugStats.joinedHandles} handles / ${debugStats.joinedDrawCalls} draws`;
         if (lastDisplayedJoined.current !== next) {
@@ -110,6 +140,9 @@ const SceneDebugPanelInner: React.FC<SceneDebugPanelProps> = ({ bridge }) => {
       <div className="scene-debug-panel__item" ref={vboRef} />
       <div className="scene-debug-panel__item" ref={particlesRef} />
       <div className="scene-debug-panel__item" ref={movableRef} />
+      <div className="scene-debug-panel__item" ref={unitsRef} />
+      <div className="scene-debug-panel__item" ref={jointsRef} />
+      <div className="scene-debug-panel__item" ref={animationsRef} />
       <div className="scene-debug-panel__item" ref={joinedRef} />
       <div className="scene-debug-panel__item" ref={joinedTimingRef} />
     </div>

--- a/src/ui/screens/Scene/components/debug/debugStats.ts
+++ b/src/ui/screens/Scene/components/debug/debugStats.ts
@@ -17,6 +17,13 @@ export interface DebugStats {
   joinedDrawCalls: number;
   joinedRenderMs: number;
   joinedUploadMs: number;
+  unitCount: number;
+  jointCount: number;
+  jointGpuCount: number;
+  jointCpuCount: number;
+  animationCount: number;
+  animationGpuCount: number;
+  animationCpuCount: number;
   // FPS tracking - updated by render loop
   frameCount: number;
   lastFpsUpdate: number;
@@ -35,6 +42,13 @@ export const debugStats: DebugStats = {
   joinedDrawCalls: 0,
   joinedRenderMs: 0,
   joinedUploadMs: 0,
+  unitCount: 0,
+  jointCount: 0,
+  jointGpuCount: 0,
+  jointCpuCount: 0,
+  animationCount: 0,
+  animationGpuCount: 0,
+  animationCpuCount: 0,
   frameCount: 0,
   lastFpsUpdate: 0,
   currentFps: 0,
@@ -72,6 +86,30 @@ export const updateJoinedStats = (stats: {
   debugStats.joinedDrawCalls = stats.drawCalls;
   debugStats.joinedRenderMs = stats.renderMs;
   debugStats.joinedUploadMs = stats.uploadMs;
+};
+
+export const updateUnitStats = (count: number): void => {
+  debugStats.unitCount = count;
+};
+
+export const updateJointStats = (stats: {
+  total: number;
+  gpu: number;
+  cpu: number;
+}): void => {
+  debugStats.jointCount = stats.total;
+  debugStats.jointGpuCount = stats.gpu;
+  debugStats.jointCpuCount = stats.cpu;
+};
+
+export const updateAnimationStats = (stats: {
+  total: number;
+  gpu: number;
+  cpu: number;
+}): void => {
+  debugStats.animationCount = stats.total;
+  debugStats.animationGpuCount = stats.gpu;
+  debugStats.animationCpuCount = stats.cpu;
 };
 
 /** 

--- a/src/ui/screens/StressTest/StressTestScreen.css
+++ b/src/ui/screens/StressTest/StressTestScreen.css
@@ -1,0 +1,17 @@
+.stress-test-screen {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  color: inherit;
+}
+
+.stress-test-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  box-sizing: border-box;
+  border: 2px solid rgba(76, 123, 195, 0.65);
+  border-radius: 0.5rem;
+  user-select: none;
+}

--- a/src/ui/screens/StressTest/StressTestScreen.tsx
+++ b/src/ui/screens/StressTest/StressTestScreen.tsx
@@ -18,7 +18,7 @@ import {
 import { getPlayerUnitConfig, type PlayerUnitRendererConfig } from "@db/player-units-db";
 import type { UnitModuleId } from "@db/unit-modules-db";
 import { resolveAnimationExecutionMode } from "@ui/renderers/objects/shared/animation-pipeline";
-import { isAnimationGpuAvailable } from "@ui/renderers/objects/shared/animation-gpu";
+import { isAnimationGpuAvailable, setAnimationGpuContext } from "@ui/renderers/objects/shared/animation-gpu";
 import { particleEmitterGpuRenderer } from "@ui/renderers/primitives/gpu/particle-emitter";
 import { updateAllWhirlInterpolations } from "@ui/renderers/objects";
 import { whirlGpuRenderer } from "@ui/renderers/primitives/gpu/whirl";
@@ -275,6 +275,9 @@ export const StressTestScreen: React.FC = () => {
     unitsRef.current = buildStressUnits(scene);
 
     const { gl, webglRenderer, cleanup: webglCleanup } = setupWebGLScene(canvas, scene);
+    
+    // Set GPU context for animation primitives
+    setAnimationGpuContext(gl);
 
     const handleResize = () => {
       const dpr = window.devicePixelRatio || 1;

--- a/src/ui/screens/StressTest/StressTestScreen.tsx
+++ b/src/ui/screens/StressTest/StressTestScreen.tsx
@@ -1,0 +1,377 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import { SceneObjectManager } from "@core/logic/provided/services/scene-object-manager/SceneObjectManager";
+import { FILL_TYPES } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.const";
+import { cloneSceneColor } from "@shared/helpers/scene-color.helper";
+import { cloneRendererConfigForScene, deriveRendererStroke } from "@shared/helpers/renderer-clone.helper";
+import { setupWebGLScene } from "@ui/screens/Scene/hooks/useWebGLSceneSetup";
+import { createWebGLRenderLoop } from "@ui/screens/Scene/hooks/useWebGLRenderLoop";
+import { cloneEmitterConfig } from "@ui/screens/SaveSlotSelect/save-slot-scene-utils";
+import { SceneDebugPanel } from "@ui/screens/Scene/components/debug/SceneDebugPanel";
+import {
+  tickFrame,
+  updateAnimationStats,
+  updateJointStats,
+  updateJoinedStats,
+  updateUnitStats,
+} from "@ui/screens/Scene/components/debug/debugStats";
+import { getPlayerUnitConfig, type PlayerUnitRendererConfig } from "@db/player-units-db";
+import type { UnitModuleId } from "@db/unit-modules-db";
+import { resolveAnimationExecutionMode } from "@ui/renderers/objects/shared/animation-pipeline";
+import { isAnimationGpuAvailable } from "@ui/renderers/objects/shared/animation-gpu";
+import { particleEmitterGpuRenderer } from "@ui/renderers/primitives/gpu/particle-emitter";
+import { updateAllWhirlInterpolations } from "@ui/renderers/objects";
+import { whirlGpuRenderer } from "@ui/renderers/primitives/gpu/whirl";
+import { petalAuraGpuRenderer } from "@ui/renderers/primitives/gpu/petal-aura";
+import { arcGpuRenderer } from "@ui/renderers/primitives/gpu/arc";
+import { renderFireRings } from "@ui/renderers/primitives/gpu/fire-ring";
+import { joinedPolygonGpuRenderer } from "@ui/renderers/primitives/gpu/joined";
+import "./StressTestScreen.css";
+
+const MAP_SIZE = { width: 2400, height: 1600 };
+const GRID_COLS = 10;
+const GRID_ROWS = 10;
+
+type StressUnitState = {
+  objectId: string;
+  orbitCenter: SceneVector2;
+  orbitRadius: number;
+  orbitSpeed: number;
+  phase: number;
+  wobbleAmplitude: number;
+  previousPosition: SceneVector2;
+  modules: UnitModuleId[];
+  skills: string[];
+};
+
+const STRESS_TEST_GROUPS: Array<{ count: number; modules: UnitModuleId[] }> = [
+  { count: 25, modules: ["burningTail"] },
+  { count: 25, modules: ["freezingTail"] },
+  { count: 25, modules: ["mendingGland"] },
+  { count: 25, modules: ["perforator"] },
+];
+
+const getRandomSeed = (seed: number): number => {
+  const x = Math.sin(seed * 917.17) * 10000;
+  return x - Math.floor(x);
+};
+
+const buildModuleAssignments = (): UnitModuleId[][] => {
+  const modules: UnitModuleId[][] = [];
+  STRESS_TEST_GROUPS.forEach((group) => {
+    for (let i = 0; i < group.count; i += 1) {
+      modules.push(group.modules);
+    }
+  });
+  return modules;
+};
+
+const buildUnitStats = (
+  modules: UnitModuleId[],
+  skills: string[],
+  renderer: PlayerUnitRendererConfig,
+  gpuAvailable: boolean
+) => {
+  let jointTotal = 0;
+  let jointGpu = 0;
+  let jointCpu = 0;
+  let animTotal = 0;
+  let animGpu = 0;
+  let animCpu = 0;
+
+  renderer.layers.forEach((layer) => {
+    if (layer.requiresModule && !modules.includes(layer.requiresModule)) {
+      return;
+    }
+    if (layer.requiresSkill && !skills.includes(layer.requiresSkill)) {
+      return;
+    }
+    if (layer.requiresEffect) {
+      return;
+    }
+
+    if (layer.join) {
+      jointTotal += 1;
+      const canGpuJoin =
+        gpuAvailable &&
+        !layer.anim &&
+        (layer.shape === "polygon" || layer.shape === "circle");
+      if (canGpuJoin) {
+        jointGpu += 1;
+      } else {
+        jointCpu += 1;
+      }
+    }
+
+    if (layer.anim) {
+      animTotal += 1;
+      const executionMode = resolveAnimationExecutionMode({
+        requested: layer.anim.executionMode,
+        gpuAvailable,
+        warnKey: "stress-test",
+      });
+      if (executionMode === "gpu") {
+        animGpu += 1;
+      } else {
+        animCpu += 1;
+      }
+    }
+  });
+
+  return {
+    jointTotal,
+    jointGpu,
+    jointCpu,
+    animTotal,
+    animGpu,
+    animCpu,
+  };
+};
+
+const updateStressStats = (units: StressUnitState[], renderer: PlayerUnitRendererConfig) => {
+  const gpuAvailable = isAnimationGpuAvailable();
+  let jointTotal = 0;
+  let jointGpu = 0;
+  let jointCpu = 0;
+  let animTotal = 0;
+  let animGpu = 0;
+  let animCpu = 0;
+
+  units.forEach((unit) => {
+    const stats = buildUnitStats(unit.modules, unit.skills, renderer, gpuAvailable);
+    jointTotal += stats.jointTotal;
+    jointGpu += stats.jointGpu;
+    jointCpu += stats.jointCpu;
+    animTotal += stats.animTotal;
+    animGpu += stats.animGpu;
+    animCpu += stats.animCpu;
+  });
+
+  updateUnitStats(units.length);
+  updateJointStats({ total: jointTotal, gpu: jointGpu, cpu: jointCpu });
+  updateAnimationStats({ total: animTotal, gpu: animGpu, cpu: animCpu });
+};
+
+const createStressUnits = (
+  scene: SceneObjectManager,
+  modulesList: UnitModuleId[]
+): StressUnitState => {
+  const config = getPlayerUnitConfig("bluePentagon");
+  const stroke = deriveRendererStroke(config.renderer);
+  const renderer = cloneRendererConfigForScene(config.renderer);
+  const baseFillColor = cloneSceneColor(config.renderer.fill)!;
+  const baseStrokeColor = stroke?.color ? cloneSceneColor(stroke.color) : undefined;
+  const emitter = cloneEmitterConfig(config.emitter);
+  const skills = modulesList.length > 0 ? ["void_modules"] : [];
+
+  const objectId = scene.addObject("playerUnit", {
+    position: { x: 0, y: 0 },
+    fill: { fillType: FILL_TYPES.SOLID, color: baseFillColor },
+    stroke: stroke
+      ? {
+          color: cloneSceneColor(stroke.color)!,
+          width: stroke.width,
+        }
+      : undefined,
+    rotation: 0,
+    customData: {
+      renderer,
+      emitter,
+      physicalSize: config.physicalSize,
+      baseFillColor,
+      baseStrokeColor,
+      modules: modulesList,
+      skills,
+    },
+  });
+
+  return {
+    objectId,
+    orbitCenter: { x: 0, y: 0 },
+    orbitRadius: 0,
+    orbitSpeed: 0,
+    phase: 0,
+    wobbleAmplitude: 0,
+    previousPosition: { x: 0, y: 0 },
+    modules: modulesList,
+    skills,
+  };
+};
+
+const buildStressUnits = (scene: SceneObjectManager): StressUnitState[] => {
+  const assignments = buildModuleAssignments();
+  const spacingX = MAP_SIZE.width / (GRID_COLS + 1);
+  const spacingY = MAP_SIZE.height / (GRID_ROWS + 1);
+  const startX = spacingX;
+  const startY = spacingY;
+
+  return assignments.map((modulesList, index) => {
+    const unit = createStressUnits(scene, modulesList);
+    const row = Math.floor(index / GRID_COLS);
+    const col = index % GRID_COLS;
+    const center: SceneVector2 = {
+      x: startX + col * spacingX,
+      y: startY + row * spacingY,
+    };
+    const radius = 28 + getRandomSeed(index + 1) * 48;
+    const speedSeed = getRandomSeed(index + 31);
+    const speed = (0.00025 + speedSeed * 0.0004) * (index % 2 === 0 ? 1 : -1);
+    const phase = getRandomSeed(index + 77) * Math.PI * 2;
+    const wobble = 6 + getRandomSeed(index + 101) * 8;
+    const initialPosition: SceneVector2 = {
+      x: center.x + Math.cos(phase) * radius,
+      y: center.y + Math.sin(phase) * radius,
+    };
+    scene.updateObject(unit.objectId, { position: initialPosition });
+    return {
+      ...unit,
+      orbitCenter: center,
+      orbitRadius: radius,
+      orbitSpeed: speed,
+      phase,
+      wobbleAmplitude: wobble,
+      previousPosition: { ...initialPosition },
+    };
+  });
+};
+
+const updateStressUnits = (
+  scene: SceneObjectManager,
+  units: StressUnitState[],
+  timestamp: number
+) => {
+  units.forEach((unit, index) => {
+    const angle = unit.phase + timestamp * unit.orbitSpeed;
+    const wobble = Math.sin(timestamp * 0.001 + unit.phase) * unit.wobbleAmplitude;
+    const nextPosition: SceneVector2 = {
+      x: unit.orbitCenter.x + Math.cos(angle) * unit.orbitRadius + wobble,
+      y: unit.orbitCenter.y + Math.sin(angle) * unit.orbitRadius + wobble * 0.5,
+    };
+    const dx = nextPosition.x - unit.previousPosition.x;
+    const dy = nextPosition.y - unit.previousPosition.y;
+    const rotation = Math.atan2(dy, dx) + (index % 3) * 0.05;
+    unit.previousPosition = nextPosition;
+    scene.updateObject(unit.objectId, { position: nextPosition, rotation });
+  });
+};
+
+export const StressTestScreen: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const unitsRef = useRef<StressUnitState[]>([]);
+  const rendererConfig = useMemo(() => getPlayerUnitConfig("bluePentagon").renderer, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return undefined;
+    }
+
+    const wrapper = canvas.parentElement as HTMLElement | null;
+    const scene = new SceneObjectManager();
+    scene.setMapSize(MAP_SIZE);
+
+    unitsRef.current = buildStressUnits(scene);
+
+    const { gl, webglRenderer, cleanup: webglCleanup } = setupWebGLScene(canvas, scene);
+
+    const handleResize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const targetWidth = wrapper?.clientWidth ?? window.innerWidth;
+      const targetHeight = wrapper?.clientHeight ?? window.innerHeight;
+      const width = Math.max(1, Math.round(targetWidth * dpr));
+      const height = Math.max(1, Math.round(targetHeight * dpr));
+      canvas.style.width = `${targetWidth}px`;
+      canvas.style.height = `${targetHeight}px`;
+      canvas.width = width;
+      canvas.height = height;
+      gl.viewport(0, 0, width, height);
+      scene.setViewportScreenSize(width, height);
+      const scale = Math.min(1, width / MAP_SIZE.width, height / MAP_SIZE.height);
+      scene.setScale(scale);
+      const viewWidth = width / scale;
+      const viewHeight = height / scale;
+      const posX = Math.max(0, (MAP_SIZE.width - viewWidth) / 2);
+      const posY = Math.max(0, (MAP_SIZE.height - viewHeight) / 2);
+      scene.setCameraPosition(posX, posY);
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    const initialChanges = scene.flushChanges();
+    webglRenderer.getObjectsRenderer().applyChanges(initialChanges);
+    webglRenderer.syncBuffers(0);
+
+    updateStressStats(unitsRef.current, rendererConfig);
+
+    let lastJoinedStatsUpdate = 0;
+    const renderLoop = createWebGLRenderLoop({
+      webglRenderer,
+      scene,
+      gl,
+      beforeUpdate: (timestamp) => {
+        updateStressUnits(scene, unitsRef.current, timestamp);
+      },
+      beforeEffects: (timestamp, glContext, cameraState) => {
+        particleEmitterGpuRenderer.beforeRender(glContext, timestamp);
+        particleEmitterGpuRenderer.render(
+          glContext,
+          cameraState.position,
+          cameraState.viewportSize,
+          timestamp
+        );
+        updateAllWhirlInterpolations();
+        whirlGpuRenderer.beforeRender(glContext, timestamp);
+        petalAuraGpuRenderer.beforeRender(glContext, timestamp);
+        whirlGpuRenderer.render(
+          glContext,
+          cameraState.position,
+          cameraState.viewportSize,
+          timestamp
+        );
+        petalAuraGpuRenderer.render(
+          glContext,
+          cameraState.position,
+          cameraState.viewportSize,
+          timestamp
+        );
+        arcGpuRenderer.beforeRender(glContext, timestamp);
+        arcGpuRenderer.render(
+          glContext,
+          cameraState.position,
+          cameraState.viewportSize,
+          timestamp
+        );
+        renderFireRings(glContext, cameraState.position, cameraState.viewportSize, timestamp);
+      },
+      afterRender: (timestamp) => {
+        tickFrame();
+        if (timestamp - lastJoinedStatsUpdate >= 500) {
+          lastJoinedStatsUpdate = timestamp;
+          const joinedStats = joinedPolygonGpuRenderer.getStats();
+          updateJoinedStats({
+            handles: joinedStats.handles,
+            drawCalls: joinedStats.drawCalls,
+            renderMs: joinedStats.renderMs,
+            uploadMs: joinedStats.anchorUploadMs,
+          });
+        }
+      },
+    });
+
+    renderLoop.start();
+
+    return () => {
+      renderLoop.stop();
+      window.removeEventListener("resize", handleResize);
+      webglCleanup();
+    };
+  }, [rendererConfig]);
+
+  return (
+    <div className="stress-test-screen">
+      <canvas ref={canvasRef} className="stress-test-canvas" />
+      <SceneDebugPanel />
+    </div>
+  );
+};

--- a/src/ui/screens/StressTest/StressTestScreen.tsx
+++ b/src/ui/screens/StressTest/StressTestScreen.tsx
@@ -26,6 +26,8 @@ import { petalAuraGpuRenderer } from "@ui/renderers/primitives/gpu/petal-aura";
 import { arcGpuRenderer } from "@ui/renderers/primitives/gpu/arc";
 import { renderFireRings } from "@ui/renderers/primitives/gpu/fire-ring";
 import { joinedPolygonGpuRenderer } from "@ui/renderers/primitives/gpu/joined";
+import { spineGpuRenderer } from "@ui/renderers/primitives/gpu/spine";
+import { polygonGpuRenderer } from "@ui/renderers/primitives/gpu/polygon";
 import "./StressTestScreen.css";
 
 const MAP_SIZE = { width: 2400, height: 1600 };
@@ -342,6 +344,9 @@ export const StressTestScreen: React.FC = () => {
           cameraState.viewportSize,
           timestamp
         );
+        spineGpuRenderer.setContext(glContext);
+        spineGpuRenderer.render(glContext, cameraState);
+        polygonGpuRenderer.render(glContext, cameraState);
         renderFireRings(glContext, cameraState.position, cameraState.viewportSize, timestamp);
       },
       afterRender: (timestamp) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,6 +96,7 @@ module.exports = (env, argv) => {
       }),
       new webpack.DefinePlugin({
         "process.env.IS_DEMO": JSON.stringify(process.env.IS_DEMO ?? ""),
+        "process.env.IS_STRESSTEST": JSON.stringify(process.env.IS_STRESSTEST ?? ""),
       }),
       new CopyStaticAssetsPlugin(),
     ],


### PR DESCRIPTION
### Motivation
- Tail join anchors (used by glow/tail positioning) were lost during player-unit layer sanitization, causing joins to render at the layer's base offset instead of the target anchor.
- The stress test lacked visibility into joined GPU activity, making it hard to tell whether joins were active and where anchors were coming from.

### Description
- Preserve join metadata by carrying `connectionSlots` and `join` through the player-unit layer sanitizer so join/anchor info is not dropped during sanitization (`src/ui/renderers/objects/implementations/player-unit/helpers.ts`).
- Ensure join target groups are collected for anchor writes by treating any `layer.join` as a join target (adjusted in composite primitives helper) so CPU anchor registration is performed when needed (`src/ui/renderers/objects/implementations/player-unit/composite-primitives.helpers.ts`).
- Add joined-GPU stats reporting to the stress test render loop and surface joined renderer stats in the debug panel, including new debug counters and UI refs, and wire up the joined GPU renderer (`src/ui/screens/StressTest/StressTestScreen.tsx`, `src/ui/screens/Scene/components/debug/debugStats.ts`, `src/ui/screens/Scene/components/debug/SceneDebugPanel.tsx`).
- Add a small stress-test entry screen, CSS and build/runtime plumbing for enabling the stress test build flag (`src/shared/helpers/stresstest.helper.ts`, `src/react-app-env.d.ts`, `webpack.config.js`, `package.json`).

### Testing
- Ran the automated test suite with `npm test` which compiles TypeScript and runs the test runner, and all tests passed (67 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69839edd94e88320931f5281b6919542)