### PR TITLE
Add crafting overdrive support and unlocks

### DIFF
--- a/src/db/bonuses-db.ts
+++ b/src/db/bonuses-db.ts
@@ -24,6 +24,7 @@ export const BONUS_IDS = [
   "all_units_knockback_reduction",
   "spell_power",
   "crafting_speed_mult",
+  "crafting_overdrive_max",
   "building_cost_multiplier"
 ] as const;
 
@@ -121,6 +122,11 @@ const BONUS_DB: Record<BonusId, BonusConfig> = {
     id: "crafting_speed_mult",
     name: "Crafting Speed Multiplier",
     defaultValue: 1,
+  },
+  crafting_overdrive_max: {
+    id: "crafting_overdrive_max",
+    name: "Crafting Overdrive Limit",
+    defaultValue: 0,
   },
   building_cost_multiplier: {
     id: "building_cost_multiplier",

--- a/src/db/buildings-db.ts
+++ b/src/db/buildings-db.ts
@@ -10,7 +10,8 @@ export type BuildingId =
   | "iron_forest"
   | "mana_plant"
   | "blacksmith"
-  | "treasure_vault";
+  | "treasure_vault"
+  | "throughput_regulator";
 
 export type BuildingCostFunction = (level: number) => ResourceAmount;
 
@@ -171,6 +172,25 @@ const BUILDING_DB: Record<BuildingId, BuildingConfig> = {
       {
         type: "skill",
         id: "advanced_construction",
+        level: 1,
+      },
+    ],
+  },
+  throughput_regulator: {
+    id: "throughput_regulator",
+    name: "Throughput Regulator",
+    description:
+      "Install precise regulators to safely drive fabrication lines beyond standard tolerances.",
+    effects: {
+      crafting_overdrive_max: {
+        income: (level) => level,
+      },
+    },
+    cost: createScalingCost({ silver: 250, copper: 400, stone: 800 }, 5),
+    unlockedBy: [
+      {
+        type: "skill",
+        id: "draftsmanship",
         level: 1,
       },
     ],

--- a/src/db/buildings-db.ts
+++ b/src/db/buildings-db.ts
@@ -186,7 +186,8 @@ const BUILDING_DB: Record<BuildingId, BuildingConfig> = {
         income: (level) => level,
       },
     },
-    cost: createScalingCost({ silver: 250, copper: 400, stone: 800 }, 5),
+    maxLevel: 3,
+    cost: createScalingCost({ silver: 2500, copper: 40000, stone: 800000 }, 3),
     unlockedBy: [
       {
         type: "skill",

--- a/src/db/skills-db.ts
+++ b/src/db/skills-db.ts
@@ -30,6 +30,7 @@ export const SKILL_IDS = [
   "autorestart_rituals",
   "construction_guild",
   "construction_ledgers",
+  "draftsmanship",
   "quarry_overseers",
   "granite_bonding",
   "bastion_foundations",
@@ -130,6 +131,21 @@ const createDualResourceCost = (
   (level: number): ResourceAmount => ({
     [firstId]: Math.ceil(firstBase * Math.pow(firstGrowth, Math.max(level, 1))),
     [secondId]: Math.ceil(secondBase * Math.pow(secondGrowth, Math.max(level, 1))),
+  });
+
+const createTriResourceCost = (
+  firstId: ResourceId,
+  firstBase: number,
+  secondId: ResourceId,
+  secondBase: number,
+  thirdId: ResourceId,
+  thirdBase: number,
+  growth: number
+) =>
+  (level: number): ResourceAmount => ({
+    [firstId]: Math.ceil(firstBase * Math.pow(growth, Math.max(level, 1))),
+    [secondId]: Math.ceil(secondBase * Math.pow(growth, Math.max(level, 1))),
+    [thirdId]: Math.ceil(thirdBase * Math.pow(growth, Math.max(level, 1))),
   });
 
 const createMixedCost = (
@@ -281,6 +297,21 @@ const SKILL_DB: Record<SkillId, SkillConfig> = {
     },
     nodesRequired: { construction_guild: 1 },
     cost: createResourceCost("paper", 8, 2.0),
+  },
+  draftsmanship: {
+    id: "draftsmanship",
+    name: "Draftsmanship",
+    description:
+      "Refine schematics for controlled overdrive, letting you push crafting limits at a cost.",
+    nodePosition: { x: -2, y: 6 },
+    maxLevel: 5,
+    effects: {
+      crafting_overdrive_max: {
+        income: (level) => level,
+      },
+    },
+    nodesRequired: { construction_ledgers: 1 },
+    cost: createTriResourceCost("stone", 200, "copper", 60, "paper", 10, 5),
   },
   quarry_overseers: {
     id: "quarry_overseers",

--- a/src/db/skills-db.ts
+++ b/src/db/skills-db.ts
@@ -304,14 +304,10 @@ const SKILL_DB: Record<SkillId, SkillConfig> = {
     description:
       "Refine schematics for controlled overdrive, letting you push crafting limits at a cost.",
     nodePosition: { x: -2, y: 6 },
-    maxLevel: 5,
-    effects: {
-      crafting_overdrive_max: {
-        income: (level) => level,
-      },
-    },
+    maxLevel: 1,
+    effects: {},
     nodesRequired: { construction_ledgers: 1 },
-    cost: createTriResourceCost("stone", 200, "copper", 60, "paper", 10, 5),
+    cost: createResourceCost("paper", 100, 1),
   },
   quarry_overseers: {
     id: "quarry_overseers",

--- a/src/logic/modules/camp/crafting/crafting.helpers.ts
+++ b/src/logic/modules/camp/crafting/crafting.helpers.ts
@@ -8,6 +8,7 @@ export const createEmptyRuntimeState = (): CraftingRecipeRuntimeState => ({
   queue: 0,
   progressMs: 0,
   inProgress: false,
+  overdriveLevel: 0,
 });
 
 export const sanitizeQueueValue = (value: unknown): number => {

--- a/src/logic/modules/camp/crafting/crafting.module.ts
+++ b/src/logic/modules/camp/crafting/crafting.module.ts
@@ -15,10 +15,11 @@ import {
 import {
   ResourceId,
   ResourceStockpile,
+  ResourceAmount,
   getResourceConfig,
   normalizeResourceAmount,
 } from "../../../../db/resources-db";
-import { clamp01 } from "@shared/helpers/numbers.helper";
+import { clamp01, clampNumber } from "@shared/helpers/numbers.helper";
 import type {
   CraftingRecipeBridgeState,
   CraftingBridgeState,
@@ -54,6 +55,7 @@ export class CraftingModule implements GameModule {
   private unlocked = false;
   private progressBroadcastTimer = 0;
   private craftingSpeedMultiplier = 1;
+  private maxOverdriveLevel = 0;
   private craftingSpeedDirty = true;
   private hasRegisteredUnlocks = false;
 
@@ -65,6 +67,9 @@ export class CraftingModule implements GameModule {
     this.newUnlocks = options.newUnlocks;
     this.craftingSpeedMultiplier = this.sanitizeCraftingSpeedMultiplier(
       this.bonuses.getBonusValue("crafting_speed_mult")
+    );
+    this.maxOverdriveLevel = this.sanitizeOverdriveMaxLevel(
+      this.bonuses.getBonusValue("crafting_overdrive_max")
     );
     this.bonuses.subscribe((values) => this.handleBonusValuesUpdated(values));
     CRAFTING_RECIPE_IDS.forEach((id) => {
@@ -84,6 +89,7 @@ export class CraftingModule implements GameModule {
       state.queue = 0;
       state.inProgress = false;
       state.progressMs = 0;
+      state.overdriveLevel = 0;
     });
     this.refreshVisibility();
     this.newUnlocks.invalidate("crafting");
@@ -101,13 +107,14 @@ export class CraftingModule implements GameModule {
   public save(): unknown {
     const serialized: Partial<Record<CraftingRecipeId, CraftingRecipeSaveState>> = {};
     this.runtimeStates.forEach((state, id) => {
-      if (state.queue <= 0 && !state.inProgress) {
+      if (state.queue <= 0 && !state.inProgress && state.overdriveLevel <= 0) {
         return;
       }
       serialized[id] = {
         queue: state.queue,
         progressMs: state.progressMs > 0 ? state.progressMs : undefined,
         inProgress: state.inProgress || undefined,
+        overdriveLevel: state.overdriveLevel > 0 ? state.overdriveLevel : undefined,
       };
     });
     if (Object.keys(serialized).length === 0) {
@@ -129,7 +136,7 @@ export class CraftingModule implements GameModule {
       const config = getCraftingRecipeConfig(id);
       const state = this.getRuntimeState(id);
       const available = this.unlocks.areConditionsMet(config.unlockedBy ?? []);
-      const duration = this.getRecipeDuration(config);
+      const duration = this.getRecipeDuration(config, state.overdriveLevel);
 
       if (state.inProgress) {
         if (state.queue <= 0) {
@@ -150,7 +157,7 @@ export class CraftingModule implements GameModule {
           state.progressMs = 0;
           return;
         }
-        if (this.tryStartRecipe(config)) {
+        if (this.tryStartRecipe(config, state)) {
           state.inProgress = true;
           state.progressMs = 0;
           stateChanged = true;
@@ -221,12 +228,31 @@ export class CraftingModule implements GameModule {
     this.setRecipeQueue(id, maxQueue);
   }
 
+  public setRecipeOverdriveLevel(id: CraftingRecipeId, value: number): void {
+    if (!CRAFTING_RECIPE_IDS.includes(id)) {
+      return;
+    }
+    const state = this.getRuntimeState(id);
+    const nextLevel = this.sanitizeOverdriveLevel(value);
+    if (!this.applyOverdriveLevel(id, state, nextLevel)) {
+      return;
+    }
+    this.progressBroadcastTimer = 0;
+    this.refreshVisibility();
+    this.pushState();
+  }
+
   public getRecipeQueue(id: CraftingRecipeId): number {
     return this.getRuntimeState(id).queue;
   }
 
-  private tryStartRecipe(config: CraftingRecipeConfig): boolean {
-    return this.resources.spendResources(config.ingredients);
+  private tryStartRecipe(
+    config: CraftingRecipeConfig,
+    state: CraftingRecipeRuntimeState
+  ): boolean {
+    return this.resources.spendResources(
+      this.getRecipeCost(config, state.overdriveLevel)
+    );
   }
 
   private completeRecipe(
@@ -260,7 +286,9 @@ export class CraftingModule implements GameModule {
     totals: ResourceStockpile
   ): number {
     const config = getCraftingRecipeConfig(id);
-    const normalized = normalizeResourceAmount(config.ingredients);
+    const normalized = normalizeResourceAmount(
+      this.getRecipeCost(config, state.overdriveLevel)
+    );
     let maxAdditional = Infinity;
     (Object.keys(normalized) as ResourceId[]).forEach((resourceId) => {
       const cost = normalized[resourceId];
@@ -284,7 +312,7 @@ export class CraftingModule implements GameModule {
     const visible = CRAFTING_RECIPE_IDS.filter((id) => {
       const config = getCraftingRecipeConfig(id);
       const state = this.getRuntimeState(id);
-      if (state.queue > 0 || state.inProgress) {
+      if (state.queue > 0 || state.inProgress || state.overdriveLevel > 0) {
         return true;
       }
       return this.unlocks.areConditionsMet(config.unlockedBy ?? []);
@@ -333,15 +361,16 @@ export class CraftingModule implements GameModule {
   ): CraftingRecipeBridgeState {
     const config = getCraftingRecipeConfig(id);
     const state = this.getRuntimeState(id);
-    const cost = toCostRecord(config.ingredients);
-    const duration = this.getRecipeDuration(config);
+    const cost = toCostRecord(this.getRecipeCost(config, state.overdriveLevel));
+    const duration = this.getRecipeDuration(config, state.overdriveLevel);
     const progress = state.inProgress ? clamp01(state.progressMs / duration) : 0;
     const maxQueue = this.computeMaxQueue(id, state, totals);
     const available = this.unlocks.areConditionsMet(config.unlockedBy ?? []);
     const waitingForResources =
       state.queue > 0 &&
       !state.inProgress &&
-      (!available || !this.resources.canAfford(config.ingredients));
+      (!available ||
+        !this.resources.canAfford(this.getRecipeCost(config, state.overdriveLevel)));
 
     const productConfig = getResourceConfig(config.productId);
 
@@ -357,6 +386,8 @@ export class CraftingModule implements GameModule {
       progress,
       durationMs: duration,
       maxQueue,
+      overdriveLevel: state.overdriveLevel,
+      maxOverdriveLevel: this.maxOverdriveLevel,
       waitingForResources,
     };
   }
@@ -375,6 +406,7 @@ export class CraftingModule implements GameModule {
       state.queue = 0;
       state.progressMs = 0;
       state.inProgress = false;
+      state.overdriveLevel = 0;
     });
 
     if (!data || typeof data !== "object") {
@@ -395,13 +427,15 @@ export class CraftingModule implements GameModule {
       }
       const state = this.getRuntimeState(id);
       const queue = sanitizeQueueValue(entry.queue);
-      const duration = this.getRecipeDuration(config);
+      const overdriveLevel = this.sanitizeOverdriveLevel(entry.overdriveLevel);
+      const duration = this.getRecipeDuration(config, overdriveLevel);
       const progress = sanitizeProgressValue(entry.progressMs, duration);
       const inProgress = Boolean(entry.inProgress) && queue > 0;
 
       state.queue = inProgress ? Math.max(queue, 1) : queue;
       state.inProgress = inProgress;
       state.progressMs = inProgress ? progress : 0;
+      state.overdriveLevel = overdriveLevel;
     });
   }
 
@@ -409,11 +443,27 @@ export class CraftingModule implements GameModule {
     const multiplier = this.sanitizeCraftingSpeedMultiplier(
       values.crafting_speed_mult ?? this.craftingSpeedMultiplier
     );
+    const maxOverdriveLevel = this.sanitizeOverdriveMaxLevel(
+      values.crafting_overdrive_max ?? this.maxOverdriveLevel
+    );
+    let shouldPush = false;
     if (Math.abs(multiplier - this.craftingSpeedMultiplier) < 1e-9) {
-      return;
+      if (maxOverdriveLevel === this.maxOverdriveLevel) {
+        return;
+      }
+    } else {
+      this.craftingSpeedMultiplier = multiplier;
+      this.onCraftingSpeedMultiplierChanged();
+      shouldPush = true;
     }
-    this.craftingSpeedMultiplier = multiplier;
-    this.onCraftingSpeedMultiplierChanged();
+    if (maxOverdriveLevel !== this.maxOverdriveLevel) {
+      this.maxOverdriveLevel = maxOverdriveLevel;
+      shouldPush = true;
+      this.clampOverdriveLevels();
+    }
+    if (shouldPush) {
+      this.pushState();
+    }
   }
 
   private onCraftingSpeedMultiplierChanged(): void {
@@ -425,15 +475,15 @@ export class CraftingModule implements GameModule {
         return;
       }
       const config = getCraftingRecipeConfig(id);
-      const duration = this.getRecipeDuration(config);
+      const duration = this.getRecipeDuration(config, state.overdriveLevel);
       if (state.progressMs > duration) {
         state.progressMs = duration;
       }
     });
   }
 
-  private getRecipeDuration(config: CraftingRecipeConfig): number {
-    const multiplier = this.craftingSpeedMultiplier;
+  private getRecipeDuration(config: CraftingRecipeConfig, overdriveLevel: number): number {
+    const multiplier = this.craftingSpeedMultiplier * this.getOverdriveMultiplier(overdriveLevel);
     if (!Number.isFinite(multiplier) || multiplier <= 0) {
       return Math.max(1, Math.round(config.baseDurationMs));
     }
@@ -441,10 +491,85 @@ export class CraftingModule implements GameModule {
     return Math.max(1, Math.round(adjusted));
   }
 
+  private getRecipeCost(
+    config: CraftingRecipeConfig,
+    overdriveLevel: number
+  ): ResourceAmount {
+    const multiplier = this.getOverdriveMultiplier(overdriveLevel);
+    if (!Number.isFinite(multiplier) || multiplier <= 0 || multiplier === 1) {
+      return config.ingredients;
+    }
+    const normalized = normalizeResourceAmount(config.ingredients);
+    const scaled: ResourceAmount = {};
+    (Object.keys(normalized) as ResourceId[]).forEach((id) => {
+      const value = normalized[id];
+      if (value > 0) {
+        scaled[id] = Math.ceil(value * multiplier);
+      }
+    });
+    return scaled;
+  }
+
   private sanitizeCraftingSpeedMultiplier(value: number | undefined): number {
     if (!Number.isFinite(value) || (value ?? 0) <= 0) {
       return 1;
     }
     return value ?? 1;
+  }
+
+  private sanitizeOverdriveMaxLevel(value: number | undefined): number {
+    if (!Number.isFinite(value)) {
+      return 0;
+    }
+    return Math.max(0, Math.floor(value ?? 0));
+  }
+
+  private sanitizeOverdriveLevel(value: unknown): number {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      return 0;
+    }
+    return clampNumber(Math.floor(value), 0, this.maxOverdriveLevel);
+  }
+
+  private clampOverdriveLevels(): boolean {
+    let changed = false;
+    CRAFTING_RECIPE_IDS.forEach((id) => {
+      const state = this.getRuntimeState(id);
+      const nextLevel = this.sanitizeOverdriveLevel(state.overdriveLevel);
+      if (this.applyOverdriveLevel(id, state, nextLevel)) {
+        changed = true;
+      }
+    });
+    return changed;
+  }
+
+  private applyOverdriveLevel(
+    id: CraftingRecipeId,
+    state: CraftingRecipeRuntimeState,
+    nextLevel: number
+  ): boolean {
+    if (state.overdriveLevel === nextLevel) {
+      return false;
+    }
+    if (state.inProgress) {
+      const config = getCraftingRecipeConfig(id);
+      const previousDuration = this.getRecipeDuration(config, state.overdriveLevel);
+      const nextDuration = this.getRecipeDuration(config, nextLevel);
+      const ratio = clamp01(state.progressMs / previousDuration);
+      state.progressMs = Math.round(nextDuration * ratio);
+      if (state.progressMs > nextDuration) {
+        state.progressMs = nextDuration;
+      }
+    }
+    state.overdriveLevel = nextLevel;
+    return true;
+  }
+
+  private getOverdriveMultiplier(level: number): number {
+    if (!Number.isFinite(level) || level <= 0) {
+      return 1;
+    }
+    const multiplier = Math.pow(2, Math.max(0, Math.floor(level)));
+    return Number.isFinite(multiplier) ? multiplier : 1;
   }
 }

--- a/src/logic/modules/camp/crafting/crafting.types.ts
+++ b/src/logic/modules/camp/crafting/crafting.types.ts
@@ -18,6 +18,8 @@ export interface CraftingRecipeBridgeState {
   readonly progress: number;
   readonly durationMs: number;
   readonly maxQueue: number;
+  readonly overdriveLevel: number;
+  readonly maxOverdriveLevel: number;
   readonly waitingForResources: boolean;
 }
 
@@ -38,12 +40,14 @@ export interface CraftingRecipeRuntimeState {
   queue: number;
   progressMs: number;
   inProgress: boolean;
+  overdriveLevel: number;
 }
 
 export interface CraftingRecipeSaveState {
   readonly queue?: number;
   readonly progressMs?: number;
   readonly inProgress?: boolean;
+  readonly overdriveLevel?: number;
 }
 
 export interface CraftingModuleSaveData {
@@ -54,6 +58,7 @@ export interface CraftingModuleUiApi {
   setRecipeQueue(id: CraftingRecipeId, value: number): void;
   adjustRecipeQueue(id: CraftingRecipeId, delta: number): void;
   setRecipeQueueToMax(id: CraftingRecipeId): void;
+  setRecipeOverdriveLevel(id: CraftingRecipeId, value: number): void;
 }
 
 declare module "@core/logic/ui/ui-api.registry" {

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.css
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.css
@@ -77,6 +77,12 @@
   color: var(--color-text-strong);
 }
 
+.crafting-recipe__overdrive-heading {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
 .crafting-recipe__queue-row {
   display: flex;
   gap: var(--spacing-md);
@@ -96,6 +102,24 @@
 }
 
 .crafting-recipe__queue-input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+}
+
+.crafting-recipe__queue-select {
+  width: 100%;
+  max-width: 120px;
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-soft);
+  background: var(--color-surface-raised);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.crafting-recipe__queue-select:focus {
   outline: none;
   border-color: rgba(56, 189, 248, 0.8);
   box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.css
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.css
@@ -77,6 +77,13 @@
   color: var(--color-text-strong);
 }
 
+.crafting-recipe__queue-row {
+  display: flex;
+  gap: var(--spacing-md);
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
 .crafting-recipe__queue-input {
   width: 100%;
   max-width: 120px;

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.tsx
@@ -99,6 +99,18 @@ export const CraftingView: React.FC<CraftingViewProps> = ({ state, resources }) 
     [crafting]
   );
 
+  const handleOverdriveChange = useCallback(
+    (recipeId: CraftingRecipeId, value: string) => {
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed)) {
+        crafting.setRecipeOverdriveLevel(recipeId, 0);
+        return;
+      }
+      crafting.setRecipeOverdriveLevel(recipeId, Math.max(0, Math.floor(parsed)));
+    },
+    [crafting]
+  );
+
   const handleButtonClick = useCallback(
     (recipeId: CraftingRecipeId, type: "set" | "delta" | "max", value?: number) => {
       switch (type) {
@@ -179,17 +191,35 @@ export const CraftingView: React.FC<CraftingViewProps> = ({ state, resources }) 
                   <ResourceCostDisplay cost={recipe.cost} missing={missing} />
                 </div>
                 <div className="crafting-recipe__queue">
-                  <label className="crafting-recipe__queue-label">
-                    <span className="text-muted">Queue</span>
-                    <input
-                      type="number"
-                      inputMode="numeric"
-                      min={0}
-                      className="crafting-recipe__queue-input"
-                      value={recipe.queue}
-                      onChange={(event) => handleInputChange(recipe.id, event.target.value)}
-                    />
-                  </label>
+                  <div className="crafting-recipe__queue-row">
+                    <label className="crafting-recipe__queue-label">
+                      <span className="text-muted">Queue</span>
+                      <input
+                        type="number"
+                        inputMode="numeric"
+                        min={0}
+                        className="crafting-recipe__queue-input"
+                        value={recipe.queue}
+                        onChange={(event) => handleInputChange(recipe.id, event.target.value)}
+                      />
+                    </label>
+                    {recipe.maxOverdriveLevel > 0 ? (
+                      <label className="crafting-recipe__queue-label">
+                        <span className="text-muted">Overdrive</span>
+                        <input
+                          type="number"
+                          inputMode="numeric"
+                          min={0}
+                          max={recipe.maxOverdriveLevel}
+                          className="crafting-recipe__queue-input"
+                          value={recipe.overdriveLevel}
+                          onChange={(event) =>
+                            handleOverdriveChange(recipe.id, event.target.value)
+                          }
+                        />
+                      </label>
+                    ) : null}
+                  </div>
                   <div className="crafting-recipe__quick-buttons">
                     {QUICK_BUTTONS.map((button) => (
                       <button

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.tsx
@@ -14,8 +14,12 @@ import {
 } from "@logic/services/new-unlock-notification/new-unlock-notification.const";
 import type { NewUnlockNotificationBridgeState } from "@logic/services/new-unlock-notification/new-unlock-notification.types";
 import { NewUnlockWrapper } from "@ui-shared/NewUnlockWrapper";
+import { HintTooltip } from "@ui-shared/HintTooltip";
 import "./CraftingView.css";
 import type { CraftingModuleUiApi } from "@logic/modules/camp/crafting/crafting.types";
+
+const OVERDRIVE_HINT =
+  "Speeds up crafting at the cost of efficiency: 2× output rate but 2× resource cost per batch.";
 
 interface CraftingViewProps {
   readonly state: CraftingBridgeState;
@@ -205,18 +209,27 @@ export const CraftingView: React.FC<CraftingViewProps> = ({ state, resources }) 
                     </label>
                     {recipe.maxOverdriveLevel > 0 ? (
                       <label className="crafting-recipe__queue-label">
-                        <span className="text-muted">Overdrive</span>
-                        <input
-                          type="number"
-                          inputMode="numeric"
-                          min={0}
-                          max={recipe.maxOverdriveLevel}
-                          className="crafting-recipe__queue-input"
+                        <span className="crafting-recipe__overdrive-heading">
+                          <span className="text-muted">Overdrive</span>
+                          <HintTooltip text={OVERDRIVE_HINT} ariaLabel="Overdrive help" />
+                        </span>
+                        <select
+                          className="crafting-recipe__queue-select"
                           value={recipe.overdriveLevel}
                           onChange={(event) =>
                             handleOverdriveChange(recipe.id, event.target.value)
                           }
-                        />
+                          aria-label="Overdrive level"
+                        >
+                          {Array.from(
+                            { length: recipe.maxOverdriveLevel + 1 },
+                            (_, i) => (
+                              <option key={i} value={i}>
+                                {i}
+                              </option>
+                            )
+                          )}
+                        </select>
                       </label>
                     ) : null}
                   </div>

--- a/src/ui/shared/HintTooltip.css
+++ b/src/ui/shared/HintTooltip.css
@@ -1,0 +1,57 @@
+.hint-tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
+
+.hint-tooltip__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25em;
+  height: 1.25em;
+  border-radius: 50%;
+  background: var(--color-border-soft, rgba(255, 255, 255, 0.15));
+  color: var(--color-text-muted, rgba(255, 255, 255, 0.7));
+  font-size: 0.85em;
+  font-weight: 600;
+  line-height: 1;
+  cursor: help;
+  user-select: none;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.hint-tooltip__trigger:hover,
+.hint-tooltip__trigger:focus {
+  background: var(--color-border-strong, rgba(255, 255, 255, 0.25));
+  color: var(--color-text, rgba(255, 255, 255, 0.9));
+  outline: none;
+}
+
+.hint-tooltip__popover {
+  position: fixed;
+  z-index: 10000;
+  max-width: 260px;
+  padding: 0.75em 1em;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--color-text, #e2e8f0);
+  background: var(--color-surface-elevated, #1e293b);
+  border: 1px solid var(--color-border-strong, rgba(255, 255, 255, 0.2));
+  border-radius: var(--radius-md, 6px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  white-space: normal;
+  pointer-events: none;
+  opacity: 1;
+}
+
+.hint-tooltip__popover::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 0.4em solid transparent;
+  border-top-color: var(--color-surface-elevated, #1e293b);
+}

--- a/src/ui/shared/HintTooltip.tsx
+++ b/src/ui/shared/HintTooltip.tsx
@@ -1,0 +1,95 @@
+import { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
+import "./HintTooltip.css";
+
+interface HintTooltipProps {
+  /** Hint text shown in the popover on hover/focus */
+  text: string;
+  /** Accessible label for the trigger (e.g. "Overdrive help") */
+  ariaLabel?: string;
+}
+
+export const HintTooltip: React.FC<HintTooltipProps> = ({
+  text,
+  ariaLabel = "Show hint",
+}) => {
+  const [visible, setVisible] = useState(false);
+  const [popoverStyle, setPopoverStyle] = useState<{ left: number; top: number } | null>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const containerRef = useRef<HTMLSpanElement>(null);
+
+  const updatePosition = useRef(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const gap = 6;
+    setPopoverStyle({
+      left: rect.left + rect.width / 2,
+      top: rect.top - gap,
+    });
+  });
+
+  useEffect(() => {
+    if (!visible) {
+      setPopoverStyle(null);
+      return;
+    }
+    updatePosition.current();
+    const handleScrollOrResize = () => updatePosition.current();
+    window.addEventListener("scroll", handleScrollOrResize, true);
+    window.addEventListener("resize", handleScrollOrResize);
+    return () => {
+      window.removeEventListener("scroll", handleScrollOrResize, true);
+      window.removeEventListener("resize", handleScrollOrResize);
+    };
+  }, [visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setVisible(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [visible]);
+
+  const popoverEl =
+    visible && popoverStyle ? (
+      <span
+        className="hint-tooltip__popover"
+        role="tooltip"
+        style={{
+          left: popoverStyle.left,
+          top: popoverStyle.top,
+          transform: "translate(-50%, -100%)",
+        }}
+      >
+        {text}
+      </span>
+    ) : null;
+
+  return (
+    <span
+      ref={containerRef}
+      className="hint-tooltip"
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+      onFocus={() => setVisible(true)}
+      onBlur={() => setVisible(false)}
+    >
+      <span
+        ref={triggerRef}
+        className="hint-tooltip__trigger"
+        role="button"
+        tabIndex={0}
+        aria-label={ariaLabel}
+        aria-expanded={visible}
+      >
+        ?
+      </span>
+      {typeof document !== "undefined" && document.body ? createPortal(popoverEl, document.body) : null}
+    </span>
+  );
+};

--- a/tests/CraftingModule.test.ts
+++ b/tests/CraftingModule.test.ts
@@ -1,0 +1,98 @@
+import assert from "assert";
+import { describe, test } from "./testRunner";
+import { DataBridge } from "../src/core/logic/ui/DataBridge";
+import { CraftingModule } from "../src/logic/modules/camp/crafting/crafting.module";
+import { CRAFTING_STATE_BRIDGE_KEY } from "../src/logic/modules/camp/crafting/crafting.const";
+import { ResourcesModule } from "../src/logic/modules/shared/resources/resources.module";
+import { UnlockService } from "../src/logic/services/unlock/UnlockService";
+import { BonusesModule } from "../src/logic/modules/shared/bonuses/bonuses.module";
+import { BonusesValueAdapter } from "../src/logic/modules/shared/bonuses/bonuses.adapter";
+import { MapRunState } from "../src/logic/modules/active-map/map/MapRunState";
+import { MapRunContextAdapter } from "../src/logic/modules/active-map/map/map-run-context.adapter";
+import { UnlockProgressionAdapter } from "../src/logic/services/unlock/unlock-progression.adapter";
+import { NewUnlockNotificationService } from "../src/logic/services/new-unlock-notification/NewUnlockNotification";
+import type { CraftingBridgeState } from "../src/logic/modules/camp/crafting/crafting.types";
+
+const createCraftingModule = (overdriveMax: number) => {
+  const bridge = new DataBridge();
+  const unlocks = new UnlockService({
+    getMapStats: () => ({}),
+    getSkillLevel: () => 1,
+  });
+  const bonuses = new BonusesModule();
+  bonuses.initialize();
+  bonuses.registerSource("test", {
+    crafting_overdrive_max: {
+      income: (level) => level,
+    },
+  });
+  bonuses.setSourceLevel("test", overdriveMax);
+  const runState = new MapRunState();
+  runState.start();
+  const resources = new ResourcesModule({
+    bridge,
+    progression: new UnlockProgressionAdapter(unlocks),
+    bonusValues: new BonusesValueAdapter(bonuses),
+    runtimeContext: new MapRunContextAdapter(runState),
+  });
+  resources.initialize();
+  const newUnlocks = new NewUnlockNotificationService({ bridge });
+  newUnlocks.initialize();
+  const crafting = new CraftingModule({
+    bridge,
+    resources,
+    unlocks,
+    bonuses,
+    newUnlocks,
+  });
+  crafting.initialize();
+
+  return { bridge, crafting };
+};
+
+const findRecipe = (state: CraftingBridgeState, id: string) => {
+  const recipe = state.recipes.find((entry) => entry.id === id);
+  assert(recipe, `recipe ${id} should exist`);
+  return recipe;
+};
+
+describe("CraftingModule overdrive", () => {
+  test("multiplies recipe cost by 2^level", () => {
+    const { bridge, crafting } = createCraftingModule(3);
+    crafting.setRecipeOverdriveLevel("tools", 2);
+
+    const payload = bridge.getValue(CRAFTING_STATE_BRIDGE_KEY) as CraftingBridgeState;
+    const recipe = findRecipe(payload, "tools");
+
+    assert.strictEqual(recipe.cost.iron, 200);
+    assert.strictEqual(recipe.cost.wood, 40);
+  });
+
+  test("reduces recipe duration by 2^level", () => {
+    const { bridge, crafting } = createCraftingModule(2);
+    crafting.setRecipeOverdriveLevel("paper", 1);
+
+    const payload = bridge.getValue(CRAFTING_STATE_BRIDGE_KEY) as CraftingBridgeState;
+    const recipe = findRecipe(payload, "paper");
+
+    assert.strictEqual(recipe.durationMs, 1500);
+  });
+
+  test("persists overdrive per recipe", () => {
+    const { bridge, crafting } = createCraftingModule(3);
+    crafting.setRecipeOverdriveLevel("tools", 2);
+    crafting.setRecipeOverdriveLevel("paper", 1);
+
+    const saved = crafting.save();
+
+    const { bridge: nextBridge, crafting: nextCrafting } = createCraftingModule(3);
+    nextCrafting.load(saved);
+
+    const payload = nextBridge.getValue(CRAFTING_STATE_BRIDGE_KEY) as CraftingBridgeState;
+    const tools = findRecipe(payload, "tools");
+    const paper = findRecipe(payload, "paper");
+
+    assert.strictEqual(tools.overdriveLevel, 2);
+    assert.strictEqual(paper.overdriveLevel, 1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Introduce an "overdrive" mode for crafting so individual recipes can be pushed for faster output at increased resource cost and controlled via progression.
- Provide a progression path (skill/building) and bonus to expose and raise the overdrive cap.
- Expose a small UI control so players can pick per-recipe overdrive and persist it across saves.

### Description
- Added per-recipe overdrive state and bridge fields in `src/logic/modules/camp/crafting/crafting.types.ts` and initialized it in `createEmptyRuntimeState` in `.../crafting.helpers.ts`.
- Implemented overdrive logic in `src/logic/modules/camp/crafting/crafting.module.ts`: per-recipe `overdriveLevel`, clamped by the `crafting_overdrive_max` bonus, multiplier computed as `2^level` for both speed and cost, duration/cost scaling via `getRecipeDuration`/`getRecipeCost`, progress recalculation on level change, and save/load serialization of `overdriveLevel`.
- Added UI control in `src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.tsx` (and minor CSS in the same folder) to show an `Overdrive` numeric input right of the `Queue` input when `maxOverdriveLevel > 0`, wired to `crafting.setRecipeOverdriveLevel(...)`.
- Introduced the `crafting_overdrive_max` bonus in `src/db/bonuses-db.ts`, a new skill `draftsmanship` in `src/db/skills-db.ts` that increases the overdrive cap, and a building `throughput_regulator` in `src/db/buildings-db.ts` that also provides `crafting_overdrive_max` income.
- Exposed UI API method `setRecipeOverdriveLevel` in `crafting.types` and implemented it in the module.
- Added unit tests in `tests/CraftingModule.test.ts` that validate cost scaling, duration scaling, and per-recipe persistence of overdrive.

### Testing
- Ran the test suite with `npm test` (TypeScript compile via `tsc -p tsconfig.tests.json` and tests runner); all tests passed: `67 tests passed` (including the new `CraftingModule overdrive` tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d9ff61648320bdd18f937b696f2c)