### PR TITLE
Handle high-speed crafting ticks and update UI rate display

### DIFF
--- a/src/logic/modules/camp/crafting/crafting.module.ts
+++ b/src/logic/modules/camp/crafting/crafting.module.ts
@@ -145,9 +145,28 @@ export class CraftingModule implements GameModule {
           return;
         }
         state.progressMs += clampedDelta;
-        if (state.progressMs >= duration) {
+        while (state.progressMs >= duration) {
+          const leftover = state.progressMs - duration;
           this.completeRecipe(id, state, config);
           stateChanged = true;
+          if (state.queue <= 0) {
+            state.progressMs = 0;
+            return;
+          }
+          if (!available) {
+            state.inProgress = false;
+            state.progressMs = 0;
+            stateChanged = true;
+            return;
+          }
+          if (!this.tryStartRecipe(config, state)) {
+            state.inProgress = false;
+            state.progressMs = 0;
+            stateChanged = true;
+            return;
+          }
+          state.inProgress = true;
+          state.progressMs = leftover;
         }
         return;
       }

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/BuildingsWorkshop/BuildingsWorkshopView.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/BuildingsWorkshop/BuildingsWorkshopView.tsx
@@ -144,7 +144,10 @@ export const BuildingsWorkshopView: React.FC<BuildingsWorkshopViewProps> = ({
               const missing = computeMissingCost(building.nextCost, totals);
               const hasMissingResources = Object.keys(missing).length > 0;
               const unlockPath = `buildings.${building.id}`;
-              const maxLevelLabel = building.maxLevel !== null ? building.maxLevel : "∞";
+              const levelLabel =
+                building.maxLevel !== null
+                  ? `${building.level}/${building.maxLevel}`
+                  : String(building.level);
               return (
                 <li key={building.id}>
                   <NewUnlockWrapper
@@ -170,10 +173,10 @@ export const BuildingsWorkshopView: React.FC<BuildingsWorkshopViewProps> = ({
                       setHoveredId((current) => (current === building.id ? null : current))
                     }
                   >
-                    <span className="modules-workshop__card-title heading-3">{building.name}</span>
-                    <span className="modules-workshop__card-level">
-                      {building.level}/{maxLevelLabel}
-                    </span>
+                    <div className="modules-workshop__card-title-row">
+                      <span className="modules-workshop__card-title heading-3">{building.name}</span>
+                      <span className="modules-workshop__card-level">{levelLabel}</span>
+                    </div>
                     <div className="modules-workshop__card-cost">
                       {building.nextCost ? (
                         <ResourceCostDisplay cost={building.nextCost} missing={missing} />
@@ -194,8 +197,9 @@ export const BuildingsWorkshopView: React.FC<BuildingsWorkshopViewProps> = ({
               <div className="modules-workshop__details-header">
                 <h3 className="heading-3">{activeBuilding.name}</h3>
                 <span className="modules-workshop__details-level">
-                  {activeBuilding.level}/
-                  {activeBuilding.maxLevel !== null ? activeBuilding.maxLevel : "∞"}
+                  {activeBuilding.maxLevel !== null
+                    ? `${activeBuilding.level}/${activeBuilding.maxLevel}`
+                    : String(activeBuilding.level)}
                 </span>
               </div>
               <p className="modules-workshop__details-description">{activeBuilding.description}</p>
@@ -212,8 +216,9 @@ export const BuildingsWorkshopView: React.FC<BuildingsWorkshopViewProps> = ({
                   <div className="building-row">
                     <span className="text-subtle">Level</span>
                     <span className="modules-workshop__cost-value">
-                      {activeBuilding.level}/
-                      {activeBuilding.maxLevel !== null ? activeBuilding.maxLevel : "∞"}
+                      {activeBuilding.maxLevel !== null
+                        ? `${activeBuilding.level}/${activeBuilding.maxLevel}`
+                        : String(activeBuilding.level)}
                     </span>
                   </div>
                   <div className="building-row">

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.tsx
@@ -77,6 +77,15 @@ const formatCraftTime = (durationMs: number): string => {
   return `${Math.max(1, Math.round(durationMs))}ms`;
 };
 
+const formatCraftMetric = (productAmount: number, durationMs: number): string => {
+  if (durationMs > 200) {
+    return `Craft time ${formatCraftTime(durationMs)}`;
+  }
+  const safeDuration = Math.max(1, durationMs);
+  const rate = productAmount / (safeDuration / 1000);
+  return `Craft rate ${formatNumber(rate, { maximumFractionDigits: 0 })} / sec`;
+};
+
 export const CraftingView: React.FC<CraftingViewProps> = ({ state, resources }) => {
   const { uiApi, bridge } = useAppLogic();
   const crafting = uiApi.crafting as CraftingModuleUiApi;
@@ -185,9 +194,8 @@ export const CraftingView: React.FC<CraftingViewProps> = ({ state, resources }) 
                     <h3 className="heading-3 crafting-recipe__title">{recipe.productName}</h3>
                     <p className="body-sm text-muted">
                       Produces {formatNumber(recipe.productAmount, { maximumFractionDigits: 0 })}{" "}
-                      {recipe.productName.toLowerCase()} per batch · Craft time {formatCraftTime(
-                        recipe.durationMs
-                      )}
+                      {recipe.productName.toLowerCase()} per batch ·{" "}
+                      {formatCraftMetric(recipe.productAmount, recipe.durationMs)}
                     </p>
                   </div>
                 </div>

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/ModulesWorkshop/ModulesWorkshopView.css
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/ModulesWorkshop/ModulesWorkshopView.css
@@ -99,13 +99,23 @@
   box-shadow: 0 0 18px rgba(56, 189, 248, 0.25);
 }
 
+.modules-workshop__card-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+}
+
 .modules-workshop__card-title {
   font-size: 1.1rem;
   font-weight: 600;
   color: var(--color-text-strong);
+  min-width: 0;
 }
 
 .modules-workshop__card-level {
+  flex-shrink: 0;
   font-size: 0.85rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/ModulesWorkshop/ModulesWorkshopView.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/ModulesWorkshop/ModulesWorkshopView.tsx
@@ -111,7 +111,11 @@ export const ModulesWorkshopView: React.FC<ModulesWorkshopViewProps> = ({
     return state.modules.find((module) => module.id === activeId) ?? null;
   }, [hoveredId, selectedId, state.modules]);
 
-  const formatMaxLevel = useCallback((value: number | null) => (value !== null ? value : "∞"), []);
+  const formatLevelLabel = useCallback(
+    (level: number, maxLevel: number | null) =>
+      maxLevel !== null ? `${level}/${maxLevel}` : String(level),
+    []
+  );
 
   const activeMissing = useMemo(
     () => (activeModule ? computeMissingCost(activeModule.nextCost, totals) : {}),
@@ -160,7 +164,7 @@ export const ModulesWorkshopView: React.FC<ModulesWorkshopViewProps> = ({
             const moduleMissing = computeMissingCost(module.nextCost, totals);
             const hasMissingResources = Object.keys(moduleMissing).length > 0;
             const unlockPath = `biolab.organs.${module.id}`;
-            const maxLevelLabel = formatMaxLevel(module.maxLevel);
+            const levelLabel = formatLevelLabel(module.level, module.maxLevel);
             return (
               <li key={module.id}>
                 <NewUnlockWrapper
@@ -184,10 +188,10 @@ export const ModulesWorkshopView: React.FC<ModulesWorkshopViewProps> = ({
                     onFocus={() => setHoveredId(module.id)}
                     onBlur={() => setHoveredId((current) => (current === module.id ? null : current))}
                   >
-                    <span className="modules-workshop__card-title heading-3">{module.name}</span>
-                    <span className="modules-workshop__card-level">
-                      {module.level}/{maxLevelLabel}
-                    </span>
+                    <div className="modules-workshop__card-title-row">
+                      <span className="modules-workshop__card-title heading-3">{module.name}</span>
+                      <span className="modules-workshop__card-level">{levelLabel}</span>
+                    </div>
                     <div className="modules-workshop__card-cost">
                       {module.nextCost ? (
                         <ResourceCostDisplay
@@ -213,7 +217,7 @@ export const ModulesWorkshopView: React.FC<ModulesWorkshopViewProps> = ({
               className="modules-workshop__details--scrollable"
               name={activeModule.name}
               level={activeModule.level}
-              levelLabel={`${activeModule.level}/${formatMaxLevel(activeModule.maxLevel)}`}
+              levelLabel={formatLevelLabel(activeModule.level, activeModule.maxLevel)}
               description={activeModule.description}
               effectLabel={activeModule.bonusLabel}
               currentEffect={

--- a/src/ui/shared/ModuleDetailsCard.css
+++ b/src/ui/shared/ModuleDetailsCard.css
@@ -1,5 +1,5 @@
 .modules-workshop__details {
-  /*background: var(--color-surface-card);*/
+  background: var(--color-surface-card);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border-soft);
   padding: var(--spacing-xl);
@@ -12,6 +12,7 @@
 .modules-workshop__details.no-wrapper {
   border: none;
   padding: 0;
+  background: none;
 }
 
 .modules-workshop__details--scrollable {
@@ -22,8 +23,15 @@
 
 .modules-workshop__details-header {
   display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xs);
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.modules-workshop__details-header .heading-3 {
+  margin: 0;
+  min-width: 0;
 }
 
 .modules-workshop__details-level {


### PR DESCRIPTION
### Motivation
- Ensure the crafting `tick` can finish multiple recipes in a single update when `deltaMs` makes `progressMs` exceed the recipe `duration`, so fast craft speeds aren’t lost.
- Preserve leftover progress across completions so time is not lost between successive recipes in the same tick.
- Improve the UI to better convey extremely fast recipes by showing a per-second rate for short durations while keeping the existing time formatting for normal durations.

### Description
- Reworked the in-progress handling in `src/logic/modules/camp/crafting/crafting.module.ts` so `state.progressMs` is incremented by `delta`, then looped while `state.progressMs >= duration` to call `completeRecipe`, compute `leftover`, decrement/inspect `queue`, and attempt to start the next recipe via `tryStartRecipe`/resource checks.
- Leftover time is preserved by setting `state.progressMs = leftover` between iterations, and if resources are insufficient the code sets `state.inProgress = false` and `state.progressMs = 0` so the UI shows `Waiting for resources`.
- Added `formatCraftMetric` in `src/ui/screens/VoidCamp/components/CampContent/TabPanels/Crafting/CraftingView.tsx` that uses `recipe.productAmount` and `recipe.durationMs` to display `Craft rate X / sec` when `durationMs <= 200`, and otherwise uses the existing `formatCraftTime` (`ms/s`) behavior.

### Testing
- Ran the test suite with `npm test`, which compiled and executed the tests and reported `67 tests passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984efe247c08320b990bfb5a4394028)