### PR TITLE
Add rectangle brick generator and Gear map

### DIFF
--- a/src/db/maps/map-definitions/gear.ts
+++ b/src/db/maps/map-definitions/gear.ts
@@ -15,8 +15,8 @@ const mapConfig = (() => {
     bricks: ({ mapLevel }) => {
       const baseLevel = Math.max(0, Math.floor(mapLevel));
       const gearLevel = baseLevel + 2;
-      const innerRadius = 160;
-      const outerRadius = 240;
+      const innerRadius = 260;
+      const outerRadius = 340;
       const toothWidth = 120;
       const toothHeight = 60;
       const toothRadius = outerRadius + toothHeight / 2 + 20;

--- a/src/db/maps/map-definitions/gear.ts
+++ b/src/db/maps/map-definitions/gear.ts
@@ -1,0 +1,70 @@
+import type { SceneSize, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import { circleWithBricks, rectangleWithBricks } from "../../../logic/services/brick-layout/BrickLayoutService";
+import type { MapConfig } from "../maps-db.types";
+
+const mapConfig = (() => {
+  const size: SceneSize = { width: 1200, height: 1200 };
+  const center: SceneVector2 = { x: size.width / 2, y: size.height / 2 };
+  const spawnPoint: SceneVector2 = { ...center };
+
+  return {
+    name: "Gear",
+    size,
+    spawnPoints: [spawnPoint],
+    nodePosition: { x: 5, y: 3 },
+    bricks: ({ mapLevel }) => {
+      const baseLevel = Math.max(0, Math.floor(mapLevel));
+      const gearLevel = baseLevel + 2;
+      const innerRadius = 160;
+      const outerRadius = 240;
+      const toothWidth = 120;
+      const toothHeight = 60;
+      const toothRadius = outerRadius + toothHeight / 2 + 20;
+
+      const circle = circleWithBricks(
+        "compactIron",
+        { center, innerRadius, outerRadius },
+        { level: gearLevel },
+      );
+
+      const teeth = Array.from({ length: 8 }, (_, index) => {
+        const angle = (Math.PI / 4) * index;
+        const toothCenter: SceneVector2 = {
+          x: center.x + Math.cos(angle) * toothRadius,
+          y: center.y + Math.sin(angle) * toothRadius,
+        };
+
+        return rectangleWithBricks(
+          "compactIron",
+          {
+            center: toothCenter,
+            width: toothWidth,
+            height: toothHeight,
+            rotation: angle,
+            brickRotation: angle,
+          },
+          { level: gearLevel },
+        );
+      });
+
+      return [circle, ...teeth];
+    },
+    playerUnits: [
+      {
+        type: "bluePentagon",
+        position: { ...spawnPoint },
+      },
+    ],
+    unlockedBy: [
+      {
+        type: "map",
+        id: "adit",
+        level: 1,
+      },
+    ],
+    mapsRequired: { adit: 1 },
+    maxLevel: 1,
+  } satisfies MapConfig;
+})();
+
+export default mapConfig;

--- a/src/db/maps/maps-db.ts
+++ b/src/db/maps/maps-db.ts
@@ -10,6 +10,7 @@ import deathfulGuns from "./map-definitions/deathfulGuns";
 import encagedBeast from "./map-definitions/encagedBeast";
 import foundations from "./map-definitions/foundations";
 import frozenForest from "./map-definitions/frozenForest";
+import gear from "./map-definitions/gear";
 import initial from "./map-definitions/initial";
 import megaBrick from "./map-definitions/megaBrick";
 import mine from "./map-definitions/mine";
@@ -60,6 +61,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
   silverRing,
   frozenForest,
   volcano,
+  gear,
   megaBrick,
   ancientPyramids,
   deathfulGuns,

--- a/src/db/maps/maps-db.types.ts
+++ b/src/db/maps/maps-db.types.ts
@@ -35,6 +35,7 @@ export type MapId =
   | "deadlyTunnels"
   | "encagedBeast"
   | "coalConvoy"
+  | "gear"
   | "uranium_fields";
 
 export interface MapBrickGeneratorOptions {

--- a/src/logic/services/brick-layout/BrickLayoutService.ts
+++ b/src/logic/services/brick-layout/BrickLayoutService.ts
@@ -6,6 +6,7 @@ import type {
   ArcWithBricksOptions,
   PolygonWithBricksOptions,
   SquareWithBricksOptions,
+  RectangleWithBricksOptions,
   ConnectorWithBricksOptions,
   TemplateWithBricksOptions,
   BezierCurveWithBricksOptions,
@@ -17,6 +18,7 @@ import {
   generateArcBricks,
   generatePolygonBricks,
   generateSquareBricks,
+  generateRectangleBricks,
   generateConnectorBricks,
   generateTemplateBricks,
   generateBezierCurveBricks,
@@ -62,6 +64,17 @@ export const squareWithBricks = (
   generationOptions?: BrickGenerationOptions
 ): BrickShapeBlueprint => ({
   shape: "square",
+  brickType,
+  options,
+  generationOptions,
+});
+
+export const rectangleWithBricks = (
+  brickType: BrickType,
+  options: RectangleWithBricksOptions,
+  generationOptions?: BrickGenerationOptions
+): BrickShapeBlueprint => ({
+  shape: "rectangle",
   brickType,
   options,
   generationOptions,
@@ -140,6 +153,12 @@ export const buildBricksFromBlueprints = (
           blueprint.options,
           blueprint.generationOptions
         );
+      case "rectangle":
+        return generateRectangleBricks(
+          blueprint.brickType,
+          blueprint.options,
+          blueprint.generationOptions
+        );
       case "connector":
         return generateConnectorBricks(
           blueprint.brickType,
@@ -176,6 +195,7 @@ export type {
   ArcWithBricksOptions,
   PolygonWithBricksOptions,
   SquareWithBricksOptions,
+  RectangleWithBricksOptions,
   ConnectorWithBricksOptions,
   TemplateWithBricksOptions,
   BezierCurveWithBricksOptions,

--- a/src/logic/services/brick-layout/brick-layout.generators.ts
+++ b/src/logic/services/brick-layout/brick-layout.generators.ts
@@ -8,6 +8,7 @@ import type {
   ArcWithBricksOptions,
   PolygonWithBricksOptions,
   SquareWithBricksOptions,
+  RectangleWithBricksOptions,
   ConnectorWithBricksOptions,
   TemplateWithBricksOptions,
   BezierCurveSegment,
@@ -301,6 +302,53 @@ export const generateSquareBricks = (
       offsetX: options.offsetX,
       offsetY: options.offsetY,
       brickRotation: options.brickRotation,
+    },
+    generationOptions
+  );
+};
+
+/**
+ * Generates bricks in a rectangle pattern.
+ */
+export const generateRectangleBricks = (
+  brickType: BrickType,
+  options: RectangleWithBricksOptions,
+  generationOptions?: BrickGenerationOptions
+): BrickData[] => {
+  if (!Number.isFinite(options.width) || !Number.isFinite(options.height)) {
+    return [];
+  }
+
+  if (options.width <= 0 || options.height <= 0) {
+    return [];
+  }
+
+  const halfWidth = options.width / 2;
+  const halfHeight = options.height / 2;
+  const rotation = options.rotation ?? 0;
+  const cos = Math.cos(rotation);
+  const sin = Math.sin(rotation);
+
+  const vertices: SceneVector2[] = [
+    { x: -halfWidth, y: -halfHeight },
+    { x: halfWidth, y: -halfHeight },
+    { x: halfWidth, y: halfHeight },
+    { x: -halfWidth, y: halfHeight },
+  ].map((corner) => ({
+    x: options.center.x + corner.x * cos - corner.y * sin,
+    y: options.center.y + corner.x * sin + corner.y * cos,
+  }));
+
+  return generatePolygonBricks(
+    brickType,
+    {
+      vertices,
+      spacing: options.spacing,
+      spacingX: options.spacingX,
+      spacingY: options.spacingY,
+      offsetX: options.offsetX,
+      offsetY: options.offsetY,
+      brickRotation: options.brickRotation ?? rotation,
     },
     generationOptions
   );

--- a/src/logic/services/brick-layout/brick-layout.types.ts
+++ b/src/logic/services/brick-layout/brick-layout.types.ts
@@ -44,6 +44,14 @@ export interface SquareWithBricksOptions
   readonly rotation?: number;
 }
 
+export interface RectangleWithBricksOptions
+  extends Omit<PolygonWithBricksOptions, "vertices" | "holes"> {
+  readonly center: SceneVector2;
+  readonly width: number;
+  readonly height: number;
+  readonly rotation?: number;
+}
+
 export interface ConnectorWithBricksOptions
   extends Omit<PolygonWithBricksOptions, "vertices" | "holes"> {
   readonly start: SceneVector2;
@@ -112,6 +120,12 @@ export type BrickShapeBlueprint =
       readonly shape: "square";
       readonly brickType: BrickType;
       readonly options: SquareWithBricksOptions;
+      readonly generationOptions?: BrickGenerationOptions;
+    }
+  | {
+      readonly shape: "rectangle";
+      readonly brickType: BrickType;
+      readonly options: RectangleWithBricksOptions;
       readonly generationOptions?: BrickGenerationOptions;
     }
   | {


### PR DESCRIPTION
### Motivation
- Provide rectangle-shaped brick layouts (with rotation and optional brick alignment) so level designers can place rotated rectangular clusters of bricks. 
- Reuse rectangle layouts to create new visual map content (a gear composed of a ring and rectangular teeth).
- Register the new map in the maps DB so it becomes available and unlockable after the `adit` map.

### Description
- Add `RectangleWithBricksOptions` type and extend `BrickShapeBlueprint` to include a `shape: "rectangle"` variant in `src/logic/services/brick-layout/brick-layout.types.ts`.
- Implement `generateRectangleBricks` in `src/logic/services/brick-layout/brick-layout.generators.ts` that builds a rotated rectangle polygon and delegates to `generatePolygonBricks`, defaulting `brickRotation` to the rectangle rotation when not provided.
- Expose a `rectangleWithBricks` blueprint factory and wire the rectangle case into `buildBricksFromBlueprints` in `src/logic/services/brick-layout/BrickLayoutService.ts`.
- Add a new map definition `src/db/maps/map-definitions/gear.ts` that composes a circular ring and 8 rotated rectangular teeth using `circleWithBricks` and `rectangleWithBricks` with `compactIron` bricks.
- Register the new `gear` map id in `src/db/maps/maps-db.types.ts` and include the map in `src/db/maps/maps-db.ts`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984fb422ab08320a702a887ea6e17c5)