### PR TITLE
Add bleeding status effect, emitter renderer, and bleeding turret enemy

### DIFF
--- a/src/db/arcs-db.ts
+++ b/src/db/arcs-db.ts
@@ -33,8 +33,8 @@ const FRENZY_ARC_COLOR: SceneColor = { r: 1.0, g: 0.9, b: 0.2, a: 1.0 };
 const FRENZY_ARC_BLUR: SceneColor = { r: 1.0, g: 0.4, b: 0.4, a: 0.6 };
 const FREEZE_ARC_COLOR: SceneColor = { r: 0.6, g: 0.85, b: 1.0, a: 0.9 };
 const FREEZE_ARC_BLUR: SceneColor = { r: 0.4, g: 0.7, b: 1.0, a: 0.5 };
-const BLEEDING_ARC_COLOR: SceneColor = { r: 1.0, g: 0.25, b: 0.25, a: 0.95 };
-const BLEEDING_ARC_BLUR: SceneColor = { r: 1.0, g: 0.1, b: 0.15, a: 0.6 };
+const BLEEDING_ARC_COLOR: SceneColor = { r: 1.0, g: 0.55, b: 0.45, a: 0.95 };
+const BLEEDING_ARC_BLUR: SceneColor = { r: 1.0, g: 0.6, b: 0.45, a: 0.6 };
 const LASER_ARC_COLOR: SceneColor = { r: 1.0, g: 0.65, b: 0.7, a: 0.99 };
 const LASER_ARC_BLUR: SceneColor = { r: 1.0, g: 0.65, b: 0.7, a: 0.25 };
 const PLASMA_BEAM_ARC_COLOR: SceneColor = { r: 0.45, g: 0.7, b: 1.0, a: 0.98 };
@@ -84,14 +84,17 @@ const ARC_DB: Record<ArcType, ArcConfig> = {
   bleeding: {
     coreColor: BLEEDING_ARC_COLOR,
     blurColor: BLEEDING_ARC_BLUR,
-    coreWidth: 2,
-    blurWidth: 30,
-    lifetimeMs: 900,
-    fadeStartMs: 450,
-    bendsPer100Px: 2.5,
-    noiseAmplitude: 5,
-    oscillationPeriodMs: 280,
-    oscillationAmplitude: 0.6,
+    coreWidth: 0.15,
+    blurWidth: 9,
+    lifetimeMs: 700,
+    fadeStartMs: 350,
+    bendsPer100Px: 3,
+    noiseAmplitude: 16,
+    aperiodicStrength: 0.55,
+    kinkAmplitude: 2,
+    kinkFrequency: 1.2,
+    oscillationPeriodMs: 170,
+    oscillationAmplitude: 0.4,
   },
   laser: {
     coreColor: LASER_ARC_COLOR,

--- a/src/db/arcs-db.ts
+++ b/src/db/arcs-db.ts
@@ -5,6 +5,7 @@ export type ArcType =
   | "heal"
   | "frenzy"
   | "freeze"
+  | "bleeding"
   | "laser"
   | "plasmaBeam"
   | "chainLightning";
@@ -32,6 +33,8 @@ const FRENZY_ARC_COLOR: SceneColor = { r: 1.0, g: 0.9, b: 0.2, a: 1.0 };
 const FRENZY_ARC_BLUR: SceneColor = { r: 1.0, g: 0.4, b: 0.4, a: 0.6 };
 const FREEZE_ARC_COLOR: SceneColor = { r: 0.6, g: 0.85, b: 1.0, a: 0.9 };
 const FREEZE_ARC_BLUR: SceneColor = { r: 0.4, g: 0.7, b: 1.0, a: 0.5 };
+const BLEEDING_ARC_COLOR: SceneColor = { r: 1.0, g: 0.25, b: 0.25, a: 0.95 };
+const BLEEDING_ARC_BLUR: SceneColor = { r: 1.0, g: 0.1, b: 0.15, a: 0.6 };
 const LASER_ARC_COLOR: SceneColor = { r: 1.0, g: 0.65, b: 0.7, a: 0.99 };
 const LASER_ARC_BLUR: SceneColor = { r: 1.0, g: 0.65, b: 0.7, a: 0.25 };
 const PLASMA_BEAM_ARC_COLOR: SceneColor = { r: 0.45, g: 0.7, b: 1.0, a: 0.98 };
@@ -69,6 +72,18 @@ const ARC_DB: Record<ArcType, ArcConfig> = {
   freeze: {
     coreColor: FREEZE_ARC_COLOR,
     blurColor: FREEZE_ARC_BLUR,
+    coreWidth: 2,
+    blurWidth: 30,
+    lifetimeMs: 900,
+    fadeStartMs: 450,
+    bendsPer100Px: 2.5,
+    noiseAmplitude: 5,
+    oscillationPeriodMs: 280,
+    oscillationAmplitude: 0.6,
+  },
+  bleeding: {
+    coreColor: BLEEDING_ARC_COLOR,
+    blurColor: BLEEDING_ARC_BLUR,
     coreWidth: 2,
     blurWidth: 30,
     lifetimeMs: 900,

--- a/src/db/enemies-db.ts
+++ b/src/db/enemies-db.ts
@@ -26,6 +26,7 @@ export type EnemyType =
   | "burstTurretEnemy"
   | "volleyTurretEnemy"
   | "explosionTurretEnemy"
+  | "bleedingTurretEnemy"
   | "spectreEnemy"
   | "encagedBeastEnemy"
   | "coalConvoyGuardian"
@@ -1553,6 +1554,80 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
     targeting: {
       avoidSharedTargets: true,
       skipTargetsWithEffects: ["freeze"],
+      searchPadding: 200,
+    },
+  },
+  bleedingTurretEnemy: {
+    knockBackDistance: 160,
+    knockBackSpeed: 160,
+    name: "Bleeding Turret",
+    renderer: {
+      kind: "composite",
+      fill: { r: 0.9, g: 0.25, b: 0.25, a: 1 },
+      layers: [
+        {
+          shape: "polygon",
+          vertices: [
+            { x: 14, y: -2 },
+            { x: 0, y: -4 },
+            { x: 0, y: 4 },
+            { x: 14, y: 2 },
+          ],
+          fill: { type: "base", brightness: 0.3 },
+        },
+        {
+          shape: "polygon",
+          vertices: [
+            { x: 0, y: -4 },
+            { x: -3, y: -8 },
+            { x: -3, y: 8 },
+            { x: 0, y: 4 },
+          ],
+          fill: { type: "base", brightness: 0.22 },
+        },
+        {
+          shape: "polygon",
+          vertices: [
+            { x: -3, y: -8 },
+            { x: -9, y: -11 },
+            { x: -9, y: -5 },
+            { x: -3, y: 3 },
+          ],
+          fill: { type: "base", brightness: 0.18 },
+        },
+        {
+          shape: "polygon",
+          vertices: [
+            { x: -3, y: 8 },
+            { x: -9, y: 11 },
+            { x: -9, y: 5 },
+            { x: -3, y: -3 },
+          ],
+          fill: { type: "base", brightness: 0.18 },
+        },
+      ],
+    },
+    maxHp: 150,
+    armor: 10,
+    baseDamage: 0,
+    attackInterval: 1.8,
+    attackRange: 1600,
+    moveSpeed: 0,
+    physicalSize: 26,
+    reward: normalizeResourceAmount({
+      stone: 32,
+      iron: 6,
+    }),
+    arcAttack: {
+      arcType: "bleeding",
+      statusEffectId: "bleeding",
+      statusEffectOptions: {
+        damagePerSecond: 12,
+        durationMs: 4000,
+      },
+    },
+    targeting: {
+      avoidSharedTargets: true,
       searchPadding: 200,
     },
   },

--- a/src/db/enemies-db.ts
+++ b/src/db/enemies-db.ts
@@ -614,7 +614,7 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
             anim: {
               type: "sway",
               periodMs: 1500,
-              amplitude: 3,
+              amplitude: 6,
               falloff: "tip",
               axis: "normal",
               phase: 1.1,
@@ -637,7 +637,7 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
             anim: {
               type: "sway",
               periodMs: 1500,
-              amplitude: 3,
+              amplitude: 6,
               falloff: "tip",
               axis: "normal",
               phase: 1.1,
@@ -660,7 +660,7 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
             anim: {
               type: "sway",
               periodMs: 1500,
-              amplitude: 3,
+              amplitude: 5,
               falloff: "tip",
               axis: "normal",
               phase: 1.1,
@@ -682,7 +682,7 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
             anim: {
               type: "sway",
               periodMs: 1500,
-              amplitude: 3,
+              amplitude: 5,
               falloff: "tip",
               axis: "normal",
               phase: 1.1,
@@ -707,7 +707,7 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
             anim: {
               type: "sway",
               periodMs: 1500,
-              amplitude: 3,
+              amplitude: 6,
               falloff: "tip",
               axis: "normal",
               phase: 4.24,
@@ -753,7 +753,7 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
             anim: {
               type: "sway",
               periodMs: 1500,
-              amplitude: 3,
+              amplitude: 6,
               falloff: "tip",
               axis: "normal",
               phase: 4.24,
@@ -775,7 +775,7 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
             anim: {
               type: "sway",
               periodMs: 1500,
-              amplitude: 3,
+              amplitude: 5,
               falloff: "tip",
               axis: "normal",
               phase: 4.24,
@@ -1607,8 +1607,8 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
         },
       ],
     },
-    maxHp: 150,
-    armor: 10,
+    maxHp: 25000,
+    armor: 1000,
     baseDamage: 0,
     attackInterval: 1.8,
     attackRange: 1600,
@@ -1622,7 +1622,7 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
       arcType: "bleeding",
       statusEffectId: "bleeding",
       statusEffectOptions: {
-        damagePerSecond: 12,
+        damagePerSecond: 124,
         durationMs: 4000,
       },
     },

--- a/src/db/maps/map-definitions/gear.ts
+++ b/src/db/maps/map-definitions/gear.ts
@@ -49,6 +49,23 @@ const mapConfig = (() => {
 
       return [circle, ...teeth];
     },
+    enemies: ({ mapLevel }) => {
+      const level = Math.max(1, Math.floor(mapLevel));
+      const turretCount = 4;
+      const turretRadius = 360;
+      return Array.from({ length: turretCount }, (_, index) => {
+        const angle = (index / turretCount) * Math.PI * 2;
+        const position: SceneVector2 = {
+          x: center.x + Math.cos(angle) * turretRadius,
+          y: center.y + Math.sin(angle) * turretRadius,
+        };
+        return {
+          type: "bleedingTurretEnemy",
+          level,
+          position,
+        };
+      });
+    },
     playerUnits: [
       {
         type: "bluePentagon",

--- a/src/db/maps/map-definitions/gear.ts
+++ b/src/db/maps/map-definitions/gear.ts
@@ -52,7 +52,7 @@ const mapConfig = (() => {
     enemies: ({ mapLevel }) => {
       const level = Math.max(1, Math.floor(mapLevel));
       const turretCount = 4;
-      const turretRadius = 360;
+      const turretRadius = 480;
       return Array.from({ length: turretCount }, (_, index) => {
         const angle = (index / turretCount) * Math.PI * 2;
         const position: SceneVector2 = {

--- a/src/db/status-effects-db.ts
+++ b/src/db/status-effects-db.ts
@@ -1,6 +1,7 @@
 import type { VisualEffectId, VisualEffectOverlayConfig } from "./effects-db";
 import type { BrickEffectTint } from "@/logic/modules/active-map/bricks/bricks.types";
 import { EFFECT_TINTS } from "@/logic/modules/active-map/bricks/brick-effects.const";
+import type { ParticleEmitterConfig } from "@/logic/interfaces/visuals/particle-emitters-config";
 
 export type StatusEffectId =
   | "frenzy"
@@ -12,7 +13,8 @@ export type StatusEffectId =
   | "poison"
   | "burn"
   | "freeze"
-  | "cracks";
+  | "cracks"
+  | "bleeding";
 
 export type StatusEffectTargetType = "unit" | "enemy" | "brick";
 
@@ -31,10 +33,16 @@ export interface StatusEffectVisuals {
   readonly auraEffectId?: VisualEffectId;
   readonly brickTint?: BrickEffectTint;
   readonly brickTintPriority?: number;
+  readonly unitEmitters?: StatusEffectUnitEmitterConfig;
   readonly stackIntensity?: {
     readonly mode: "linear" | "sqrt";
     readonly maxIntensity: number;
   };
+}
+
+export interface StatusEffectUnitEmitterConfig {
+  readonly emitters: readonly ParticleEmitterConfig[];
+  readonly offsetScale?: "absolute" | "unit";
 }
 
 export interface StatusEffectConfigBase {
@@ -54,6 +62,20 @@ const INTERNAL_FURNACE_COLOR = {
   g: 0.35,
   b: 0.32,
   a: 1,
+};
+
+const BLEEDING_EMITTER_BASE: ParticleEmitterConfig = {
+  particlesPerSecond: 18,
+  particleLifetimeMs: 650,
+  fadeStartMs: 400,
+  sizeRange: { min: 2.2, max: 4.2 },
+  color: { r: 0.88, g: 0.12, b: 0.16, a: 0.9 },
+  baseSpeed: 60,
+  speedVariation: 20,
+  spread: Math.PI * 0.65,
+  spawnRadius: { min: 0, max: 2.5 },
+  shape: "circle",
+  maxParticles: 120,
 };
 
 const STATUS_EFFECTS_DB: Record<StatusEffectId, StatusEffectConfig> = {
@@ -176,12 +198,43 @@ const STATUS_EFFECTS_DB: Record<StatusEffectId, StatusEffectConfig> = {
       },
     },
   },
+  bleeding: {
+    id: "bleeding",
+    kind: "damageOverTime",
+    target: "unit",
+    durationMs: 4000,
+    tickIntervalMs: 1000,
+    maxStacks: 4,
+    visuals: {
+      unitEmitters: {
+        offsetScale: "unit",
+        emitters: [
+          {
+            ...BLEEDING_EMITTER_BASE,
+            offset: { x: -0.6, y: 0 },
+            direction: Math.PI,
+          },
+          {
+            ...BLEEDING_EMITTER_BASE,
+            offset: { x: 0.6, y: 0 },
+            direction: 0,
+          },
+        ],
+      },
+    },
+  },
 };
 
 export const STATUS_EFFECT_OVERLAY_IDS: StatusEffectId[] = Object.values(
   STATUS_EFFECTS_DB
 )
   .filter((config) => Boolean(config.visuals?.overlay))
+  .map((config) => config.id);
+
+export const STATUS_EFFECT_UNIT_EMITTER_IDS: StatusEffectId[] = Object.values(
+  STATUS_EFFECTS_DB
+)
+  .filter((config) => Boolean(config.visuals?.unitEmitters))
   .map((config) => config.id);
 
 export const getStatusEffectConfig = (id: StatusEffectId): StatusEffectConfig => {

--- a/src/db/status-effects-db.ts
+++ b/src/db/status-effects-db.ts
@@ -65,17 +65,17 @@ const INTERNAL_FURNACE_COLOR = {
 };
 
 const BLEEDING_EMITTER_BASE: ParticleEmitterConfig = {
-  particlesPerSecond: 18,
-  particleLifetimeMs: 650,
+  particlesPerSecond: 1800,
+  particleLifetimeMs: 950,
   fadeStartMs: 400,
   sizeRange: { min: 2.2, max: 4.2 },
-  color: { r: 0.88, g: 0.12, b: 0.16, a: 0.9 },
-  baseSpeed: 60,
-  speedVariation: 20,
+  color: { r: 0.78, g: 0.32, b: 0.36, a: 0.9 },
+  baseSpeed: 0.1,
+  speedVariation: 0.01,
   spread: Math.PI * 0.65,
   spawnRadius: { min: 0, max: 2.5 },
-  shape: "circle",
-  maxParticles: 120,
+  shape: "triangle",
+  maxParticles: 1200,
 };
 
 const STATUS_EFFECTS_DB: Record<StatusEffectId, StatusEffectConfig> = {
@@ -206,18 +206,24 @@ const STATUS_EFFECTS_DB: Record<StatusEffectId, StatusEffectConfig> = {
     tickIntervalMs: 1000,
     maxStacks: 4,
     visuals: {
+      overlay: {
+        color: { r: 0.9, g: 0.2, b: 0.2, a: 1 },
+        intensity: 0.45,
+        priority: 12,
+        target: "fill",
+      },
       unitEmitters: {
         offsetScale: "unit",
         emitters: [
           {
             ...BLEEDING_EMITTER_BASE,
-            offset: { x: -0.6, y: 0 },
-            direction: Math.PI,
+            offset: { x: 0, y: -0.5 },
+            direction: -Math.PI / 2, // perpendicular left from movement
           },
           {
             ...BLEEDING_EMITTER_BASE,
-            offset: { x: 0.6, y: 0 },
-            direction: 0,
+            offset: { x: 0, y: 0.5 },
+            direction: Math.PI / 2, // perpendicular right from movement
           },
         ],
       },

--- a/src/logic/modules/active-map/enemies/enemies.module.ts
+++ b/src/logic/modules/active-map/enemies/enemies.module.ts
@@ -19,6 +19,7 @@ import { DamageService } from "../targeting/DamageService";
 import { MovementService } from "@core/logic/provided/services/movement/MovementService";
 import type { MovementBodyState } from "@core/logic/provided/services/movement/movement.types";
 import { EnemyStateFactory, EnemyStateInput } from "./enemies.state-factory";
+import { getStatusEffectConfig } from "../../../../db/status-effects-db";
 import {
   subtractVectors,
   scaleVector,
@@ -764,7 +765,9 @@ export class EnemiesModule implements GameModule {
       );
       if (arcAttack.statusEffectId) {
         const effectTarget = { type: "unit", id: target.id } as const;
-        if (!this.statusEffects.hasEffect(arcAttack.statusEffectId, effectTarget)) {
+        const effectConfig = getStatusEffectConfig(arcAttack.statusEffectId);
+        const canStack = Math.max(effectConfig.maxStacks ?? 0, 0) > 1;
+        if (canStack || !this.statusEffects.hasEffect(arcAttack.statusEffectId, effectTarget)) {
           this.statusEffects.applyEffect(
             arcAttack.statusEffectId,
             effectTarget,

--- a/src/logic/modules/active-map/enemies/enemies.targeting-provider.ts
+++ b/src/logic/modules/active-map/enemies/enemies.targeting-provider.ts
@@ -48,6 +48,7 @@ export class EnemyTargetingProvider implements TargetingProvider<"enemy", EnemyR
       maxHp: enemy.maxHp,
       armor: enemy.armor,
       baseDamage: enemy.baseDamage,
+      effectiveDamage: enemy.baseDamage,
       physicalSize: enemy.physicalSize,
       data: enemy,
     };

--- a/src/logic/modules/active-map/map/map.factory.ts
+++ b/src/logic/modules/active-map/map/map.factory.ts
@@ -37,6 +37,7 @@ export const createMapDefinition = (
       sceneCleanup,
       getSkillLevel: (id: SkillId) => container.get<SkillTreeModule>("skillTree").getLevel(id),
       newUnlocks: container.get("newUnlocks"),
+      statusEffects: container.get("statusEffects"),
     });
   },
   registerAsModule: true,

--- a/src/logic/modules/active-map/map/map.module.ts
+++ b/src/logic/modules/active-map/map/map.module.ts
@@ -34,7 +34,8 @@ import { MapSceneCleanup, MapSceneCleanupContract } from "./map.scene-cleanup";
 import type { BrickRuntimeState } from "../bricks/bricks.types";
 import type { EnemyRuntimeState } from "../enemies/enemies.types";
 import type { PlayerUnitState } from "../player-units/units/UnitTypes";
-import type { TargetSnapshot } from "../targeting/targeting.types";
+import type { ActiveEffectInfo, TargetSnapshot } from "../targeting/targeting.types";
+import { getStatusEffectConfig } from "../../../../db/status-effects-db";
 import {
   MAP_LIST_BRIDGE_KEY,
   MAP_SELECTED_BRIDGE_KEY,
@@ -330,6 +331,10 @@ export class MapModule implements GameModule {
 
   private toBrickTarget(brick: BrickRuntimeState): TargetSnapshot<"brick", BrickRuntimeState> {
     const rewardMultiplier = this.getRewardMultiplier();
+    const activeEffects = this.getBrickActiveEffects(brick.id);
+    const outgoingMultiplier = this.options.statusEffects?.getBrickOutgoingDamageMultiplier(brick.id) ?? 1;
+    const flatReduction = this.options.statusEffects?.getBrickOutgoingDamageFlatReduction(brick.id) ?? 0;
+    const effectiveDamage = Math.max(0, Math.round(brick.baseDamage * outgoingMultiplier - flatReduction));
     return {
       id: brick.id,
       type: "brick",
@@ -338,14 +343,18 @@ export class MapModule implements GameModule {
       maxHp: brick.maxHp,
       armor: brick.armor,
       baseDamage: brick.baseDamage,
+      effectiveDamage,
       physicalSize: brick.physicalSize,
       rewardMultiplier,
+      activeEffects,
       data: brick,
     };
   }
 
   private toEnemyTarget(enemy: EnemyRuntimeState): TargetSnapshot<"enemy", EnemyRuntimeState> {
     const rewardMultiplier = this.getRewardMultiplier();
+    const activeEffects = this.getEnemyActiveEffects(enemy.id);
+    // Currently enemies don't have outgoing damage modifiers
     return {
       id: enemy.id,
       type: "enemy",
@@ -354,13 +363,19 @@ export class MapModule implements GameModule {
       maxHp: enemy.maxHp,
       armor: enemy.armor,
       baseDamage: enemy.baseDamage,
+      effectiveDamage: enemy.baseDamage,
       physicalSize: enemy.physicalSize,
       rewardMultiplier,
+      activeEffects,
       data: enemy,
     };
   }
 
   private toPlayerUnitTarget(unit: PlayerUnitState): TargetSnapshot<"playerUnit", PlayerUnitState> {
+    const activeEffects = this.getUnitActiveEffects(unit.id);
+    // Calculate effective damage with Internal Furnace and Frenzy bonuses
+    const attackMultiplier = this.options.statusEffects?.getUnitAttackMultiplier(unit.id) ?? 1;
+    const effectiveDamage = Math.round(unit.baseAttackDamage * attackMultiplier);
     return {
       id: unit.id,
       type: "playerUnit",
@@ -369,9 +384,57 @@ export class MapModule implements GameModule {
       maxHp: unit.maxHp,
       armor: unit.armor,
       baseDamage: unit.baseAttackDamage,
+      effectiveDamage,
       physicalSize: unit.physicalSize,
+      activeEffects,
       data: unit,
     };
+  }
+
+  private getUnitActiveEffects(unitId: string): ActiveEffectInfo[] {
+    return this.getTargetActiveEffects({ type: "unit", id: unitId });
+  }
+
+  private getEnemyActiveEffects(enemyId: string): ActiveEffectInfo[] {
+    return this.getTargetActiveEffects({ type: "enemy", id: enemyId });
+  }
+
+  private getBrickActiveEffects(brickId: string): ActiveEffectInfo[] {
+    return this.getTargetActiveEffects({ type: "brick", id: brickId });
+  }
+
+  private getTargetActiveEffects(target: { type: string; id: string }): ActiveEffectInfo[] {
+    const statusEffects = this.options.statusEffects;
+    if (!statusEffects) {
+      return [];
+    }
+    const effects = statusEffects.getActiveEffectsForTarget(target as any);
+    return effects.map((effect) => {
+      return {
+        id: effect.id,
+        name: this.getEffectDisplayName(effect.id),
+        stacks: effect.stacks,
+        maxStacks: effect.maxStacks,
+        remainingMs: effect.remainingMs,
+      };
+    });
+  }
+
+  private getEffectDisplayName(effectId: string): string {
+    const names: Record<string, string> = {
+      frenzy: "Frenzy",
+      internalFurnace: "Internal Furnace",
+      meltingTail: "Melting Tail",
+      freezingTail: "Freezing Tail",
+      weakeningCurse: "Weakening Curse",
+      weakeningCurseFlat: "Weakening Curse",
+      poison: "Poison",
+      burn: "Burn",
+      freeze: "Freeze",
+      cracks: "Cracks",
+      bleeding: "Bleeding",
+    };
+    return names[effectId] ?? effectId;
   }
 
   private getRewardMultiplier(): number {

--- a/src/logic/modules/active-map/map/map.types.ts
+++ b/src/logic/modules/active-map/map/map.types.ts
@@ -15,6 +15,7 @@ import { EventLogModule } from "../../shared/event-log/event-log.module";
 import { ArcModule } from "../../scene/arc/arc.module";
 import { EnemiesModule } from "../enemies/enemies.module";
 import type { EnemyRuntimeState } from "../enemies/enemies.types";
+import type { StatusEffectsModule } from "../status-effects/status-effects.module";
 import type { PlayerUnitState } from "../player-units/units/UnitTypes";
 import { MapId, MapListEntry as MapListEntryConfig } from "../../../../db/maps/maps-db";
 import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
@@ -50,6 +51,7 @@ export interface MapModuleOptions {
   sceneCleanup: MapSceneCleanupContract;
   getSkillLevel: (id: SkillId) => number;
   newUnlocks: NewUnlockNotificationService;
+  statusEffects?: StatusEffectsModule;
 }
 
 export interface MapSaveData {

--- a/src/logic/modules/active-map/player-units/PlayerUnitsTargetingProvider.ts
+++ b/src/logic/modules/active-map/player-units/PlayerUnitsTargetingProvider.ts
@@ -40,6 +40,7 @@ export class PlayerUnitsTargetingProvider implements TargetingProvider<"unit", P
       maxHp: unit.maxHp,
       armor: unit.armor,
       baseDamage: unit.baseAttackDamage,
+      effectiveDamage: unit.baseAttackDamage,
       physicalSize: unit.physicalSize,
       data: unit,
     };

--- a/src/logic/modules/active-map/player-units/player-units.module.ts
+++ b/src/logic/modules/active-map/player-units/player-units.module.ts
@@ -311,6 +311,7 @@ export class PlayerUnitsModule implements GameModule {
           );
           const objectId = this.scene.addObject("statusEffectEmitter", {
             position: { ...unit.position },
+            rotation: unit.rotation ?? 0,
             fill: {
               fillType: FILL_TYPES.SOLID,
               color: { r: 0, g: 0, b: 0, a: 0 },

--- a/src/logic/modules/active-map/player-units/player-units.module.ts
+++ b/src/logic/modules/active-map/player-units/player-units.module.ts
@@ -72,6 +72,7 @@ import { PlayerUnitsTargetingProvider } from "./PlayerUnitsTargetingProvider";
 import type { DamageService } from "../targeting/DamageService";
 import type { EnemiesModule } from "../enemies/enemies.module";
 import type { StatusEffectsModule } from "../status-effects/status-effects.module";
+import type { ParticleEmitterConfig } from "../../../interfaces/visuals/particle-emitters-config";
 import {
   ATTACK_DISTANCE_EPSILON,
   COLLISION_RESOLUTION_ITERATIONS,
@@ -135,6 +136,7 @@ export class PlayerUnitsModule implements GameModule {
   private unitBlueprints = new Map<PlayerUnitType, PlayerUnitBlueprintStats>();
   private readonly statsReporter: UnitStatisticsReporter;
   private lastTickTimestampMs = performance.now();
+  private readonly statusEffectEmitters = new Map<string, Map<string, string[]>>();
 
   constructor(options: PlayerUnitsModuleOptions) {
     this.scene = options.scene;
@@ -289,6 +291,56 @@ export class PlayerUnitsModule implements GameModule {
       },
       removeAura: (unitId, effectId) => {
         this.effects?.removeEffect(unitId, effectId as never);
+      },
+      applyEmitters: (unitId, effectId, emitters, options) => {
+        const unit = this.units.get(unitId);
+        if (!unit || emitters.length === 0) {
+          return;
+        }
+        const effectEmitters = this.statusEffectEmitters.get(unitId) ?? new Map();
+        if (effectEmitters.has(effectId)) {
+          return;
+        }
+        const ids: string[] = [];
+        const scaleMode = options?.offsetScale ?? "absolute";
+        emitters.forEach((emitter) => {
+          const scaledEmitter = this.scaleEmitterConfig(
+            emitter,
+            unit.physicalSize,
+            scaleMode,
+          );
+          const objectId = this.scene.addObject("statusEffectEmitter", {
+            position: { ...unit.position },
+            fill: {
+              fillType: FILL_TYPES.SOLID,
+              color: { r: 0, g: 0, b: 0, a: 0 },
+            },
+            customData: {
+              emitter: scaledEmitter,
+              tiedToObjectId: unit.objectId,
+            },
+          });
+          ids.push(objectId);
+        });
+        if (ids.length > 0) {
+          effectEmitters.set(effectId, ids);
+          this.statusEffectEmitters.set(unitId, effectEmitters);
+        }
+      },
+      removeEmitters: (unitId, effectId) => {
+        const effectEmitters = this.statusEffectEmitters.get(unitId);
+        if (!effectEmitters) {
+          return;
+        }
+        const ids = effectEmitters.get(effectId);
+        if (!ids) {
+          return;
+        }
+        ids.forEach((id) => this.scene.removeObject(id));
+        effectEmitters.delete(effectId);
+        if (effectEmitters.size === 0) {
+          this.statusEffectEmitters.delete(unitId);
+        }
       },
       damageUnit: (unitId, amount) => {
         this.applyDamage(unitId, amount);
@@ -857,6 +909,24 @@ export class PlayerUnitsModule implements GameModule {
       preCollisionVelocity: { ...unit.preCollisionVelocity },
       lastNonZeroVelocity: { ...unit.lastNonZeroVelocity },
       wanderTarget: unit.wanderTarget ? { ...unit.wanderTarget } : null,
+    };
+  }
+
+  private scaleEmitterConfig(
+    emitter: ParticleEmitterConfig,
+    physicalSize: number,
+    scaleMode: "absolute" | "unit",
+  ): ParticleEmitterConfig {
+    if (scaleMode !== "unit") {
+      return emitter;
+    }
+    const offset = emitter.offset ?? { x: 0, y: 0 };
+    return {
+      ...emitter,
+      offset: {
+        x: offset.x * physicalSize,
+        y: offset.y * physicalSize,
+      },
     };
   }
 

--- a/src/logic/modules/active-map/status-effects/status-effects.module.ts
+++ b/src/logic/modules/active-map/status-effects/status-effects.module.ts
@@ -5,6 +5,7 @@ import {
   StatusEffectVisuals,
   getStatusEffectConfig,
   STATUS_EFFECT_OVERLAY_IDS,
+  STATUS_EFFECT_UNIT_EMITTER_IDS,
 } from "../../../../db/status-effects-db";
 import type {
   StatusEffectApplicationOptions,
@@ -590,6 +591,21 @@ export class StatusEffectsModule implements GameModule {
       if (damagePerTick <= 0) {
         return null;
       }
+      const maxStacks = Math.max(config.maxStacks ?? 0, 0);
+      if (maxStacks > 0 && instances.length >= maxStacks) {
+        let expiring = instances[0]!;
+        instances.forEach((candidate) => {
+          const candidateRemaining = candidate.remainingMs ?? 0;
+          const expiringRemaining = expiring.remainingMs ?? 0;
+          if (candidateRemaining < expiringRemaining) {
+            expiring = candidate;
+          }
+        });
+        expiring.remainingMs = durationMs ?? config.durationMs;
+        expiring.data.damagePerTick = damagePerTick;
+        expiring.nextTickMs = interval;
+        return expiring;
+      }
       const instance: StatusEffectInstance = {
         id: config.id,
         target,
@@ -733,6 +749,9 @@ export class StatusEffectsModule implements GameModule {
           unitAdapter.applyOverlay(id, effectId, "fill", null);
           unitAdapter.applyOverlay(id, effectId, "stroke", null);
         });
+        STATUS_EFFECT_UNIT_EMITTER_IDS.forEach((effectId) => {
+          unitAdapter.removeEmitters(id, effectId);
+        });
         return;
       }
 
@@ -759,6 +778,12 @@ export class StatusEffectsModule implements GameModule {
         const instance = instances[0];
         const visual = instance?.visuals?.overlay ?? null;
         applyOverlay(effectId, visual ?? null);
+        const emitterVisuals = instance?.visuals?.unitEmitters;
+        if (emitterVisuals) {
+          unitAdapter.applyEmitters(id, effectId, emitterVisuals.emitters, {
+            offsetScale: emitterVisuals.offsetScale,
+          });
+        }
       });
 
       overlayIds.forEach((effectId) => {
@@ -766,6 +791,13 @@ export class StatusEffectsModule implements GameModule {
           return;
         }
         applyOverlay(effectId, null);
+      });
+
+      STATUS_EFFECT_UNIT_EMITTER_IDS.forEach((effectId) => {
+        if (effectsMap.has(effectId)) {
+          return;
+        }
+        unitAdapter.removeEmitters(id, effectId);
       });
     } else if (type === "brick") {
       if (!this.brickAdapter) {

--- a/src/logic/modules/active-map/status-effects/status-effects.module.ts
+++ b/src/logic/modules/active-map/status-effects/status-effects.module.ts
@@ -211,6 +211,60 @@ export class StatusEffectsModule implements GameModule {
     return Boolean(instances && instances.length > 0);
   }
 
+  public getActiveEffectsForTarget(target: StatusEffectTarget): {
+    id: StatusEffectId;
+    stacks: number;
+    maxStacks?: number;
+    remainingMs?: number;
+  }[] {
+    const targetKey = getTargetKey(target);
+    const effectsMap = this.effectsByTarget.get(targetKey);
+    if (!effectsMap) {
+      return [];
+    }
+    const result: { id: StatusEffectId; stacks: number; maxStacks?: number; remainingMs?: number }[] = [];
+    effectsMap.forEach((instances, effectId) => {
+      if (instances.length === 0) {
+        return;
+      }
+      const config = getStatusEffectConfig(effectId);
+      
+      // For stackingAttackBonus (like internalFurnace), show current/cap as percentages
+      if (config.kind === "stackingAttackBonus") {
+        const instance = instances[0];
+        if (instance) {
+          // Values are multipliers (1 = 100%), convert to percentage integers
+          const currentPercent = Math.round((instance.stacks ?? 0) * 100);
+          const capPercent = Math.round((instance.data.cap ?? 0) * 100);
+          result.push({
+            id: effectId,
+            stacks: currentPercent,
+            maxStacks: capPercent > 0 ? capPercent : undefined,
+            remainingMs: instance.remainingMs,
+          });
+        }
+        return;
+      }
+      
+      // For other effects, count instances as stacks
+      const totalStacks = instances.length;
+      const minRemaining = instances.reduce((min, inst) => {
+        const rem = inst.remainingMs;
+        if (rem === undefined) {
+          return min;
+        }
+        return min === undefined ? rem : Math.min(min, rem);
+      }, undefined as number | undefined);
+      result.push({
+        id: effectId,
+        stacks: totalStacks,
+        maxStacks: config.maxStacks,
+        remainingMs: minRemaining,
+      });
+    });
+    return result;
+  }
+
   public consumeAttackBonus(unitId: string): number {
     const targetKey = getTargetKey({ type: "unit", id: unitId });
     const effectsMap = this.effectsByTarget.get(targetKey);

--- a/src/logic/modules/active-map/status-effects/status-effects.types.ts
+++ b/src/logic/modules/active-map/status-effects/status-effects.types.ts
@@ -1,4 +1,5 @@
 import type { BrickEffectTint } from "../bricks/bricks.types";
+import type { ParticleEmitterConfig } from "../../../interfaces/visuals/particle-emitters-config";
 
 export type StatusEffectTargetType = "unit" | "enemy" | "brick";
 
@@ -41,6 +42,13 @@ export interface StatusEffectUnitAdapter {
   ) => void;
   readonly applyAura: (unitId: string, effectId: string) => void;
   readonly removeAura: (unitId: string, effectId: string) => void;
+  readonly applyEmitters: (
+    unitId: string,
+    effectId: string,
+    emitters: readonly ParticleEmitterConfig[],
+    options?: { offsetScale?: "absolute" | "unit" },
+  ) => void;
+  readonly removeEmitters: (unitId: string, effectId: string) => void;
   readonly damageUnit: (unitId: string, amount: number) => void;
 }
 

--- a/src/logic/modules/active-map/targeting/BricksTargetingProvider.ts
+++ b/src/logic/modules/active-map/targeting/BricksTargetingProvider.ts
@@ -64,6 +64,7 @@ export class BricksTargetingProvider implements TargetingProvider<"brick", Brick
       maxHp: brick.maxHp,
       armor: brick.armor,
       baseDamage: brick.baseDamage,
+      effectiveDamage: brick.baseDamage,
       physicalSize: brick.physicalSize,
       data: brick,
     };

--- a/src/logic/modules/active-map/targeting/targeting.types.ts
+++ b/src/logic/modules/active-map/targeting/targeting.types.ts
@@ -2,6 +2,14 @@ import type { SceneVector2 } from "@core/logic/provided/services/scene-object-ma
 
 export type TargetType = "brick" | string;
 
+export interface ActiveEffectInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly stacks: number;
+  readonly maxStacks?: number;
+  readonly remainingMs?: number;
+}
+
 export interface TargetSnapshot<TType extends TargetType = TargetType, TData = unknown> {
   readonly id: string;
   readonly type: TType;
@@ -10,8 +18,10 @@ export interface TargetSnapshot<TType extends TargetType = TargetType, TData = u
   readonly maxHp: number;
   readonly armor: number;
   readonly baseDamage: number;
+  readonly effectiveDamage: number;
   readonly physicalSize: number;
   readonly rewardMultiplier?: number;
+  readonly activeEffects?: readonly ActiveEffectInfo[];
   readonly data?: TData;
 }
 

--- a/src/ui/renderers/objects/ObjectsRendererManager.ts
+++ b/src/ui/renderers/objects/ObjectsRendererManager.ts
@@ -156,6 +156,30 @@ export class ObjectsRendererManager {
     return this.tiedObjects.getChildren(parentId);
   }
 
+  /**
+   * Get the rotation of an object by ID.
+   */
+  public getObjectRotation(objectId: string): number | undefined {
+    const managed = this.objects.get(objectId);
+    return managed?.instance.data.rotation;
+  }
+
+  /**
+   * Update rotation for tied children objects (e.g., status effect emitters).
+   */
+  public updateTiedChildrenRotation(parentId: string, rotation: number): void {
+    const children = this.tiedObjects.getChildren(parentId);
+    if (!children) {
+      return;
+    }
+    children.forEach((childId) => {
+      const managed = this.objects.get(childId);
+      if (managed) {
+        managed.instance.data.rotation = rotation;
+      }
+    });
+  }
+
   public applyChanges(
     changes: ReturnType<SceneUiApi["flushChanges"]>,
     frameDeltaMs?: number

--- a/src/ui/renderers/objects/implementations/status-effect-emitter/StatusEffectEmitterObjectRenderer.ts
+++ b/src/ui/renderers/objects/implementations/status-effect-emitter/StatusEffectEmitterObjectRenderer.ts
@@ -1,0 +1,41 @@
+import {
+  DynamicPrimitive,
+  ObjectRegistration,
+  ObjectRenderer,
+} from "../../ObjectRenderer";
+import type { SceneObjectInstance } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import { createParticleEmitterPrimitive } from "../../../primitives";
+import {
+  createEmitterParticle,
+  getEmitterOrigin,
+  getGpuSpawnConfig,
+  getStatusEffectEmitterConfig,
+  serializeEmitterConfig,
+} from "./emitter.helpers";
+import type { StatusEffectEmitterRenderConfig } from "./types";
+
+export class StatusEffectEmitterObjectRenderer extends ObjectRenderer {
+  public register(instance: SceneObjectInstance): ObjectRegistration {
+    const emitterPrimitive = createParticleEmitterPrimitive<StatusEffectEmitterRenderConfig>(
+      instance,
+      {
+        getConfig: getStatusEffectEmitterConfig,
+        getOrigin: getEmitterOrigin,
+        spawnParticle: createEmitterParticle,
+        serializeConfig: serializeEmitterConfig,
+        getGpuSpawnConfig,
+      }
+    );
+
+    const dynamicPrimitives: DynamicPrimitive[] = [];
+    if (emitterPrimitive) {
+      emitterPrimitive.autoAnimate = true;
+      dynamicPrimitives.push(emitterPrimitive);
+    }
+
+    return {
+      staticPrimitives: [],
+      dynamicPrimitives,
+    };
+  }
+}

--- a/src/ui/renderers/objects/implementations/status-effect-emitter/emitter.helpers.ts
+++ b/src/ui/renderers/objects/implementations/status-effect-emitter/emitter.helpers.ts
@@ -1,0 +1,151 @@
+import type { SceneObjectInstance, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type {
+  GpuSpawnConfig,
+  ParticleEmitterParticleState,
+} from "../../../primitives/ParticleEmitterPrimitive";
+import { sanitizeParticleEmitterConfig } from "../../../primitives/ParticleEmitterPrimitive";
+import type { ParticleEmitterConfig } from "@/logic/interfaces/visuals/particle-emitters-config";
+import { getInstanceRenderPosition } from "../../ObjectRenderer";
+import { randomBetween } from "@shared/helpers/numbers.helper";
+import type { StatusEffectEmitterCustomData, StatusEffectEmitterRenderConfig } from "./types";
+
+const emitterConfigCache = new WeakMap<
+  SceneObjectInstance,
+  { source: ParticleEmitterConfig | undefined; config: StatusEffectEmitterRenderConfig | null }
+>();
+
+export const getStatusEffectEmitterConfig = (
+  instance: SceneObjectInstance
+): StatusEffectEmitterRenderConfig | null => {
+  const custom = instance.data.customData as StatusEffectEmitterCustomData | undefined;
+  const emitter = custom?.emitter;
+  const cached = emitterConfigCache.get(instance);
+  if (cached && cached.source === emitter) {
+    return cached.config;
+  }
+
+  const config = emitter ? sanitizeStatusEffectEmitterConfig(emitter) : null;
+  emitterConfigCache.set(instance, { source: emitter, config });
+  return config;
+};
+
+export const sanitizeStatusEffectEmitterConfig = (
+  config: ParticleEmitterConfig
+): StatusEffectEmitterRenderConfig | null => {
+  const base = sanitizeParticleEmitterConfig(config, {
+    defaultOffset: { x: 0, y: 0 },
+    defaultColor: { r: 0.9, g: 0.1, b: 0.1, a: 1 },
+  });
+  if (!base) {
+    return null;
+  }
+
+  const baseSpeed = Math.max(0, Number(config.baseSpeed) || 0);
+  const speedVariation = Math.max(0, Number(config.speedVariation) || 0);
+  const spread = Math.max(0, Number(config.spread) || 0);
+  const spawnRadiusMin = Math.max(0, config.spawnRadius?.min ?? 0);
+  const spawnRadiusMax = Math.max(spawnRadiusMin, config.spawnRadius?.max ?? spawnRadiusMin);
+  const direction = Number.isFinite(config.direction) ? Number(config.direction) : 0;
+
+  return {
+    ...base,
+    baseSpeed,
+    speedVariation,
+    spread,
+    spawnRadiusMin,
+    spawnRadiusMax,
+    direction,
+  };
+};
+
+export const serializeEmitterConfig = (config: StatusEffectEmitterRenderConfig): string => {
+  const serializedFill = config.fill ? JSON.stringify(config.fill) : "";
+  return [
+    config.particlesPerSecond,
+    config.particleLifetimeMs,
+    config.fadeStartMs,
+    config.fadeInMs,
+    config.emissionDampingInterval ?? 0,
+    config.baseSpeed,
+    config.speedVariation,
+    config.sizeRange.min,
+    config.sizeRange.max,
+    config.spawnRadiusMin,
+    config.spawnRadiusMax,
+    config.spread,
+    config.offset.x,
+    config.offset.y,
+    config.color.r,
+    config.color.g,
+    config.color.b,
+    config.color.a,
+    config.capacity,
+    serializedFill,
+    config.shape,
+    config.direction,
+  ].join(":");
+};
+
+export const getEmitterOrigin = (
+  instance: SceneObjectInstance,
+  config: StatusEffectEmitterRenderConfig
+): SceneVector2 => {
+  const position = getInstanceRenderPosition(instance);
+  return {
+    x: position.x + config.offset.x,
+    y: position.y + config.offset.y,
+  };
+};
+
+export const createEmitterParticle = (
+  origin: SceneVector2,
+  _instance: SceneObjectInstance,
+  config: StatusEffectEmitterRenderConfig
+): ParticleEmitterParticleState => {
+  const halfSpread = config.spread / 2;
+  const direction =
+    config.direction + (config.spread > 0 ? randomBetween(-halfSpread, halfSpread) : 0);
+  const speed = Math.max(
+    0,
+    config.baseSpeed +
+      (config.speedVariation > 0
+        ? randomBetween(-config.speedVariation, config.speedVariation)
+        : 0)
+  );
+  const size =
+    config.sizeRange.min === config.sizeRange.max
+      ? config.sizeRange.min
+      : randomBetween(config.sizeRange.min, config.sizeRange.max);
+  const spawnRadius =
+    config.spawnRadiusMin === config.spawnRadiusMax
+      ? config.spawnRadiusMin
+      : randomBetween(config.spawnRadiusMin, config.spawnRadiusMax);
+  const spawnAngle = Math.random() * Math.PI * 2;
+
+  return {
+    position: {
+      x: origin.x + Math.cos(spawnAngle) * spawnRadius,
+      y: origin.y + Math.sin(spawnAngle) * spawnRadius,
+    },
+    velocity: { x: Math.cos(direction) * speed, y: Math.sin(direction) * speed },
+    ageMs: 0,
+    lifetimeMs: config.particleLifetimeMs,
+    size,
+  };
+};
+
+export const getGpuSpawnConfig = (
+  _instance: SceneObjectInstance,
+  config: StatusEffectEmitterRenderConfig
+): GpuSpawnConfig => ({
+  baseSpeed: config.baseSpeed,
+  speedVariation: config.speedVariation,
+  sizeMin: config.sizeRange.min,
+  sizeMax: config.sizeRange.max,
+  spawnRadiusMin: config.spawnRadiusMin,
+  spawnRadiusMax: config.spawnRadiusMax,
+  arc: 0,
+  direction: config.direction,
+  spread: config.spread,
+  radialVelocity: false,
+});

--- a/src/ui/renderers/objects/implementations/status-effect-emitter/emitter.helpers.ts
+++ b/src/ui/renderers/objects/implementations/status-effect-emitter/emitter.helpers.ts
@@ -91,20 +91,27 @@ export const getEmitterOrigin = (
   config: StatusEffectEmitterRenderConfig
 ): SceneVector2 => {
   const position = getInstanceRenderPosition(instance);
+  const rotation = instance.data.rotation ?? 0;
+  // Rotate offset by unit rotation
+  const cos = Math.cos(rotation);
+  const sin = Math.sin(rotation);
+  const rotatedOffsetX = config.offset.x * cos - config.offset.y * sin;
+  const rotatedOffsetY = config.offset.x * sin + config.offset.y * cos;
   return {
-    x: position.x + config.offset.x,
-    y: position.y + config.offset.y,
+    x: position.x + rotatedOffsetX,
+    y: position.y + rotatedOffsetY,
   };
 };
 
 export const createEmitterParticle = (
   origin: SceneVector2,
-  _instance: SceneObjectInstance,
+  instance: SceneObjectInstance,
   config: StatusEffectEmitterRenderConfig
 ): ParticleEmitterParticleState => {
+  const unitRotation = instance.data.rotation ?? 0;
   const halfSpread = config.spread / 2;
   const direction =
-    config.direction + (config.spread > 0 ? randomBetween(-halfSpread, halfSpread) : 0);
+    unitRotation + config.direction + (config.spread > 0 ? randomBetween(-halfSpread, halfSpread) : 0);
   const speed = Math.max(
     0,
     config.baseSpeed +
@@ -135,17 +142,20 @@ export const createEmitterParticle = (
 };
 
 export const getGpuSpawnConfig = (
-  _instance: SceneObjectInstance,
+  instance: SceneObjectInstance,
   config: StatusEffectEmitterRenderConfig
-): GpuSpawnConfig => ({
-  baseSpeed: config.baseSpeed,
-  speedVariation: config.speedVariation,
-  sizeMin: config.sizeRange.min,
-  sizeMax: config.sizeRange.max,
-  spawnRadiusMin: config.spawnRadiusMin,
-  spawnRadiusMax: config.spawnRadiusMax,
-  arc: 0,
-  direction: config.direction,
-  spread: config.spread,
-  radialVelocity: false,
-});
+): GpuSpawnConfig => {
+  const unitRotation = instance.data.rotation ?? 0;
+  return {
+    baseSpeed: config.baseSpeed,
+    speedVariation: config.speedVariation,
+    sizeMin: config.sizeRange.min,
+    sizeMax: config.sizeRange.max,
+    spawnRadiusMin: config.spawnRadiusMin,
+    spawnRadiusMax: config.spawnRadiusMax,
+    arc: 0,
+    direction: unitRotation + config.direction,
+    spread: config.spread,
+    radialVelocity: false,
+  };
+};

--- a/src/ui/renderers/objects/implementations/status-effect-emitter/index.ts
+++ b/src/ui/renderers/objects/implementations/status-effect-emitter/index.ts
@@ -1,0 +1,1 @@
+export { StatusEffectEmitterObjectRenderer } from "./StatusEffectEmitterObjectRenderer";

--- a/src/ui/renderers/objects/implementations/status-effect-emitter/types.ts
+++ b/src/ui/renderers/objects/implementations/status-effect-emitter/types.ts
@@ -1,0 +1,15 @@
+import type { ParticleEmitterBaseConfig } from "../../../primitives/ParticleEmitterPrimitive";
+import type { ParticleEmitterConfig } from "@/logic/interfaces/visuals/particle-emitters-config";
+
+export interface StatusEffectEmitterCustomData {
+  readonly emitter: ParticleEmitterConfig;
+}
+
+export interface StatusEffectEmitterRenderConfig extends ParticleEmitterBaseConfig {
+  readonly baseSpeed: number;
+  readonly speedVariation: number;
+  readonly spread: number;
+  readonly spawnRadiusMin: number;
+  readonly spawnRadiusMax: number;
+  readonly direction: number;
+}

--- a/src/ui/renderers/objects/index.ts
+++ b/src/ui/renderers/objects/index.ts
@@ -16,6 +16,7 @@ import { ScreenOverlayRenderer } from "./implementations/screen-overlay";
 import { TiedObjectsRegistry } from "./TiedObjectsRegistry";
 import { SpellAreaHighlightRenderer } from "./implementations/spell-area-highlight/SpellAreaHighlightRenderer";
 import { SnowfallObjectRenderer } from "./implementations/snowfall/SnowfallObjectRenderer";
+import { StatusEffectEmitterObjectRenderer } from "./implementations/status-effect-emitter";
 
 export { ObjectsRendererManager } from "./ObjectsRendererManager";
 export { TiedObjectsRegistry } from "./TiedObjectsRegistry";
@@ -64,6 +65,7 @@ export const createObjectsRendererManager = (): ObjectsRendererManager => {
     ["spellAreaHighlight", new SpellAreaHighlightRenderer()],
     ["snowfall", new SnowfallObjectRenderer()],
     ["screenOverlay", new ScreenOverlayRenderer()],
+    ["statusEffectEmitter", new StatusEffectEmitterObjectRenderer()],
   ]);
   const tiedObjectsRegistry = new TiedObjectsRegistry();
   return new ObjectsRendererManager(renderers, tiedObjectsRegistry);

--- a/src/ui/screens/Scene/components/tooltip/createTargetTooltip.tsx
+++ b/src/ui/screens/Scene/components/tooltip/createTargetTooltip.tsx
@@ -68,7 +68,7 @@ const formatRewards = (
 
 const buildCommonStats = (target: TargetSnapshot): SceneTooltipStat[] => [
   { label: "HP", value: formatHpValue(target.hp, target.maxHp) },
-  { label: "Attack", value: formatStatValue(target.baseDamage) },
+  { label: "Attack", value: formatStatValue(target.effectiveDamage) },
   { label: "Armor", value: formatStatValue(target.armor) },
 ];
 
@@ -120,10 +120,10 @@ const buildEnemyStats = (
   return stats;
 };
 
-const buildPlayerUnitStats = (unit: PlayerUnitState): SceneTooltipStat[] => {
+const buildPlayerUnitStats = (unit: PlayerUnitState, effectiveDamage: number): SceneTooltipStat[] => {
   const stats: SceneTooltipStat[] = [
     { label: "HP", value: formatHpValue(unit.hp, unit.maxHp) },
-    { label: "Attack", value: formatStatValue(unit.baseAttackDamage) },
+    { label: "Attack", value: formatStatValue(effectiveDamage) },
     { label: "Armor", value: formatStatValue(unit.armor) },
   ];
   if (Number.isFinite(unit.baseAttackInterval)) {
@@ -141,6 +141,43 @@ const buildPlayerUnitStats = (unit: PlayerUnitState): SceneTooltipStat[] => {
   return stats;
 };
 
+const formatEffectDuration = (remainingMs?: number): string | null => {
+  if (remainingMs === undefined || !Number.isFinite(remainingMs)) {
+    return null;
+  }
+  return formatSeconds(remainingMs / 1000);
+};
+
+const formatActiveEffects = (
+  activeEffects: readonly { id: string; name: string; stacks: number; maxStacks?: number; remainingMs?: number }[] | undefined,
+): string[] | null => {
+  if (!activeEffects || activeEffects.length === 0) {
+    return null;
+  }
+  return activeEffects.map((effect) => {
+    const duration = formatEffectDuration(effect.remainingMs);
+    
+    // Format stacks based on effect type
+    let stacksLabel = "";
+    const isPercentBonus = effect.id === "internalFurnace";
+    
+    if (effect.maxStacks !== undefined && effect.maxStacks > 0) {
+      if (isPercentBonus) {
+        // Show as percentage bonus: "+45%/100%"
+        stacksLabel = ` +${effect.stacks}%/${effect.maxStacks}%`;
+      } else {
+        // Show as stack count: "2/4"
+        stacksLabel = ` ${effect.stacks}/${effect.maxStacks}`;
+      }
+    } else if (effect.stacks > 1) {
+      stacksLabel = ` x${effect.stacks}`;
+    }
+    
+    const durationLabel = duration ? ` (${duration})` : "";
+    return `${effect.name}${stacksLabel}${durationLabel}`;
+  });
+};
+
 export const createTargetTooltip = (
   target: TargetSnapshot<"brick" | "enemy" | "playerUnit", BrickRuntimeState | EnemyRuntimeState | PlayerUnitState>,
   playerUnitDisplayName?: string | null,
@@ -150,12 +187,14 @@ export const createTargetTooltip = (
     const brickConfig = getBrickConfig(brick.type);
     const title = brickConfig.name ?? `Brick: ${brick.type}`;
     const rewardLabel = formatRewards(brick.rewards, target.rewardMultiplier ?? 1);
+    const effectsList = formatActiveEffects(target.activeEffects);
     return {
       title,
       subtitle: `Level ${brick.level}`,
       stats: [
         ...buildCommonStats(target),
         ...(rewardLabel ? [{ label: "Reward", value: rewardLabel }] : []),
+        ...(effectsList ? [{ label: "Effects", value: effectsList }] : []),
       ],
     };
   }
@@ -164,10 +203,15 @@ export const createTargetTooltip = (
     const unit = target.data as PlayerUnitState;
     const unitConfig = getPlayerUnitConfig(unit.type);
     const title = playerUnitDisplayName ?? unitConfig.name;
+    const stats = buildPlayerUnitStats(unit, target.effectiveDamage);
+    const effectsList = formatActiveEffects(target.activeEffects);
+    if (effectsList) {
+      stats.push({ label: "Effects", value: effectsList });
+    }
     return {
       title,
       subtitle: "Your unit",
-      stats: buildPlayerUnitStats(unit),
+      stats,
     };
   }
 
@@ -177,6 +221,7 @@ export const createTargetTooltip = (
     enemy.reward ?? enemyConfig.reward,
     target.rewardMultiplier ?? 1,
   );
+  const effectsList = formatActiveEffects(target.activeEffects);
   return {
     title: enemyConfig.name,
     subtitle: `Level ${enemy.level}`,
@@ -184,6 +229,7 @@ export const createTargetTooltip = (
       ...buildCommonStats(target),
       ...buildEnemyStats(enemy, enemyConfig),
       ...(rewardLabel ? [{ label: "Reward", value: rewardLabel }] : []),
+      ...(effectsList ? [{ label: "Effects", value: effectsList }] : []),
     ],
   };
 };

--- a/src/ui/screens/Scene/hooks/useSceneCanvas.ts
+++ b/src/ui/screens/Scene/hooks/useSceneCanvas.ts
@@ -308,14 +308,19 @@ export const useSceneCanvas = ({
         if (interpolatedUnitPositions.size > 0) {
           objectsRenderer.applyInterpolatedPositions(interpolatedUnitPositions);
           
-          // Also update objects tied to interpolated units (e.g., auras)
+          // Also update objects tied to interpolated units (e.g., auras, status effect emitters)
           const tiedPositions = new Map<string, { x: number; y: number }>();
           interpolatedUnitPositions.forEach((pos, unitId) => {
             const tiedChildren = objectsRenderer.getTiedChildren(unitId);
-            if (tiedChildren) {
+            if (tiedChildren && tiedChildren.size > 0) {
               tiedChildren.forEach((childId) => {
                 tiedPositions.set(childId, pos);
               });
+              // Also update rotation for tied children (for status effect emitters)
+              const parentRotation = objectsRenderer.getObjectRotation(unitId);
+              if (parentRotation !== undefined) {
+                objectsRenderer.updateTiedChildrenRotation(unitId, parentRotation);
+              }
             }
           });
           if (tiedPositions.size > 0) {

--- a/tests/EnemiesModule.test.ts
+++ b/tests/EnemiesModule.test.ts
@@ -316,6 +316,7 @@ describe("EnemiesModule", () => {
               maxHp: unit.maxHp,
               armor: unit.armor,
               baseDamage: unit.baseAttackDamage,
+              effectiveDamage: unit.baseAttackDamage,
               physicalSize: unit.physicalSize,
               data: unit,
             }
@@ -507,6 +508,7 @@ describe("EnemiesModule", () => {
       maxHp: 10,
       armor: 0,
       baseDamage: 0,
+      effectiveDamage: 0,
       physicalSize: 10,
     };
 
@@ -574,6 +576,7 @@ describe("EnemiesModule", () => {
       maxHp: 100,
       armor: 0,
       baseDamage: 0,
+      effectiveDamage: 0,
     };
 
     const createSnapshot = () => ({ ...targetData, position: { ...targetPosition }, data: targetData });

--- a/tests/PlayerUnitAbilities.test.ts
+++ b/tests/PlayerUnitAbilities.test.ts
@@ -51,6 +51,7 @@ describe("PlayerUnitAbilities sound effects", () => {
         maxHp: number;
         armor: number;
         baseDamage: number;
+        effectiveDamage: number;
         physicalSize: number;
       }>;
     } = {}
@@ -179,6 +180,7 @@ describe("PlayerUnitAbilities sound effects", () => {
           maxHp: 10,
           armor: 0,
           baseDamage: 1,
+          effectiveDamage: 1,
           physicalSize: 1,
         },
       ],

--- a/tests/ProjectileController.test.ts
+++ b/tests/ProjectileController.test.ts
@@ -66,6 +66,7 @@ describe("UnitProjectileController", () => {
       maxHp: 10,
       armor: 0,
       baseDamage: 0,
+      effectiveDamage: 0,
       physicalSize: 10,
     };
 
@@ -77,6 +78,7 @@ describe("UnitProjectileController", () => {
       maxHp: 10,
       armor: 0,
       baseDamage: 0,
+      effectiveDamage: 0,
       physicalSize: 8,
     };
 

--- a/tests/StatusEffectsModule.test.ts
+++ b/tests/StatusEffectsModule.test.ts
@@ -41,6 +41,8 @@ describe("StatusEffectsModule visuals cleanup", () => {
       applyOverlay: overlays.applyOverlay,
       applyAura: () => {},
       removeAura: () => {},
+      applyEmitters: () => {},
+      removeEmitters: () => {},
       damageUnit: () => {},
     });
 
@@ -88,6 +90,8 @@ describe("StatusEffectsModule visuals cleanup", () => {
       applyOverlay: overlays.applyOverlay,
       applyAura: () => {},
       removeAura: () => {},
+      applyEmitters: () => {},
+      removeEmitters: () => {},
       damageUnit: () => {},
     });
 


### PR DESCRIPTION
### Motivation
- Add a new bleeding mechanic that deals stacking damage-over-time and provides visible blood particle emitters on affected units. 
- Allow enemies to apply stackable status effects via arc attacks and provide a matching visual arc type for bleeding. 
- Integrate per-effect particle emitters into the existing status-effects visual pipeline so emitters are attached/removed automatically when effects change.

### Description
- Introduce a `bleeding` status effect in `src/db/status-effects-db.ts` that is a `damageOverTime` effect with `maxStacks` and `unitEmitters` configuration, plus `STATUS_EFFECT_UNIT_EMITTER_IDS` for bookkeeping. 
- Extend `StatusEffectVisuals` to include `unitEmitters` and wire emitter application/removal in `src/logic/modules/active-map/status-effects/status-effects.module.ts` using `StatusEffectUnitEmitterConfig`. 
- Add a `status-effect-emitter` scene object renderer and supporting helpers at `src/ui/renderers/objects/implementations/status-effect-emitter/` that use the existing particle emitter primitive to render per-unit emitters tied to unit objects. 
- Extend `StatusEffectUnitAdapter` interface in `src/logic/modules/active-map/status-effects/status-effects.types.ts` and implement emitter application/removal in `PlayerUnitsModule` (`src/logic/modules/active-map/player-units/player-units.module.ts`) to spawn and clean up tied emitter scene objects. 
- Add a `bleeding` arc type in `src/db/arcs-db.ts` and a `bleedingTurretEnemy` entry in `src/db/enemies-db.ts` that applies the `bleeding` effect via its `arcAttack`, and place bleeding turrets on the `Gear` map (`src/db/maps/map-definitions/gear.ts`). 
- Improve DoT instance handling in `StatusEffectsModule` to refresh/replace the oldest expiring instance when `maxStacks` is reached for `damageOverTime` effects so stacking behaves as intended. 

### Testing
- No automated tests were run against these changes during this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69850090ad3c8320b839f5b2f27624b8)