### PR TITLE
Map resource preview cache and refine enemy weighting in previews

### DIFF
--- a/src/core/logic/ui/BridgeSchema.ts
+++ b/src/core/logic/ui/BridgeSchema.ts
@@ -12,6 +12,7 @@ import type {
   MapListEntry,
   MapAutoRestartState,
   MapEffectsBridgeState,
+  MapResourcePreviewCache,
 } from "@logic/modules/active-map/map/map.types";
 import type { BuildingsWorkshopBridgeState } from "@logic/modules/camp/buildings/buildings.types";
 import type { CraftingBridgeState } from "@logic/modules/camp/crafting/crafting.types";
@@ -55,6 +56,7 @@ export interface BridgeSchema {
   "maps/selectedLevel": number;
   "maps/clearedLevelsTotal": number;
   "maps/lastPlayed": { mapId: MapId; level: number } | null;
+  "maps/resourcePreview": MapResourcePreviewCache;
   "maps/autoRestart": MapAutoRestartState;
   "maps/selectViewTransform": ViewTransform | null;
   "maps/controlHintsCollapsed": boolean;

--- a/src/db/arcs-db.ts
+++ b/src/db/arcs-db.ts
@@ -29,10 +29,10 @@ export interface ArcConfig {
 
 const HEAL_ARC_COLOR: SceneColor = { r: 0.6, g: 1.0, b: 0.5, a: 0.55 };
 const HEAL_ARC_BLUR: SceneColor = { r: 0.6, g: 0.9, b: 0.3, a: 0.55 };
-const FRENZY_ARC_COLOR: SceneColor = { r: 1.0, g: 0.9, b: 0.2, a: 1.0 };
-const FRENZY_ARC_BLUR: SceneColor = { r: 1.0, g: 0.4, b: 0.4, a: 0.6 };
+const FRENZY_ARC_COLOR: SceneColor = { r: 1.0, g: 0.9, b: 0.2, a: 0.9 };
+const FRENZY_ARC_BLUR: SceneColor = { r: 1.0, g: 0.6, b: 0.4, a: 0.6 };
 const FREEZE_ARC_COLOR: SceneColor = { r: 0.6, g: 0.85, b: 1.0, a: 0.9 };
-const FREEZE_ARC_BLUR: SceneColor = { r: 0.4, g: 0.7, b: 1.0, a: 0.5 };
+const FREEZE_ARC_BLUR: SceneColor = { r: 0.6, g: 0.85, b: 1.0, a: 0.8 };
 const BLEEDING_ARC_COLOR: SceneColor = { r: 1.0, g: 0.55, b: 0.55, a: 0.95 };
 const BLEEDING_ARC_BLUR: SceneColor = { r: 1.0, g: 0.25, b: 0.25, a: 0.46 };
 const LASER_ARC_COLOR: SceneColor = { r: 1.0, g: 0.65, b: 0.7, a: 0.99 };
@@ -59,7 +59,7 @@ const ARC_DB: Record<ArcType, ArcConfig> = {
   frenzy: {
     coreColor: FRENZY_ARC_COLOR,
     blurColor: FRENZY_ARC_BLUR,
-    coreWidth: 2,
+    coreWidth: 4,
     blurWidth: 25,
     soundEffectUrl: getAssetUrl("audio/sounds/unit_effects/buff_v2.mp3"),
     lifetimeMs: 1000,
@@ -73,7 +73,7 @@ const ARC_DB: Record<ArcType, ArcConfig> = {
     coreColor: FREEZE_ARC_COLOR,
     blurColor: FREEZE_ARC_BLUR,
     coreWidth: 2,
-    blurWidth: 30,
+    blurWidth: 18,
     lifetimeMs: 900,
     fadeStartMs: 450,
     bendsPer100Px: 2.5,

--- a/src/logic/modules/active-map/map/map.const.ts
+++ b/src/logic/modules/active-map/map/map.const.ts
@@ -10,6 +10,7 @@ export const MAP_SELECTED_BRIDGE_KEY = "maps/selected";
 export const MAP_SELECTED_LEVEL_BRIDGE_KEY = "maps/selectedLevel";
 export const MAP_CLEARED_LEVELS_BRIDGE_KEY = "maps/clearedLevelsTotal";
 export const MAP_LAST_PLAYED_BRIDGE_KEY = "maps/lastPlayed";
+export const MAP_RESOURCE_PREVIEW_BRIDGE_KEY = "maps/resourcePreview";
 export const MAP_AUTO_RESTART_BRIDGE_KEY = "maps/autoRestart";
 export const MAP_SELECT_VIEW_TRANSFORM_BRIDGE_KEY = "maps/selectViewTransform";
 export const MAP_CONTROL_HINTS_COLLAPSED_BRIDGE_KEY = "maps/controlHintsCollapsed";

--- a/src/logic/modules/active-map/map/map.module.ts
+++ b/src/logic/modules/active-map/map/map.module.ts
@@ -12,6 +12,13 @@ import {
   getMapList,
   isMapId,
 } from "../../../../db/maps/maps-db";
+import { getBrickConfig } from "../../../../db/bricks-db";
+import { getEnemyConfig, type EnemyType } from "../../../../db/enemies-db";
+import {
+  createEmptyResourceStockpile,
+  RESOURCE_IDS,
+  type ResourceStockpile,
+} from "../../../../db/resources-db";
 import type { BonusEffectMap } from "@shared/types/bonuses";
 import { buildBricksFromBlueprints } from "../../../services/brick-layout/BrickLayoutService";
 import { MapSelectionState } from "./map.selection";
@@ -24,6 +31,8 @@ import {
   MapLevelStats,
   MapListEntry,
   MapModuleOptions,
+  MapResourcePreview,
+  MapResourcePreviewCache,
   MapRunResult,
   MapSaveData,
   MapStats,
@@ -53,6 +62,7 @@ import {
   PLAYER_UNIT_SPAWN_SAFE_RADIUS,
   AUTO_RESTART_SKILL_ID,
   BONUS_CONTEXT_CLEARED_LEVELS,
+  MAP_RESOURCE_PREVIEW_BRIDGE_KEY,
   INSPECT_TARGET_TOOLTIP_THROTTLE_MS,
 } from "./map.const";
 import {
@@ -64,6 +74,8 @@ import {
 } from "./map.helpers";
 import { isDemoBuild } from "@shared/helpers/demo.helper";
 import { trackAnalyticsEvent } from "@shared/helpers/google-analytics.helper";
+import { calculateBrickStatsForLevel } from "../bricks/bricks.helpers";
+import { calculateEnemyStatsForLevel, sanitizeEnemyLevel } from "../enemies/enemies.helpers";
 
 export class MapModule implements GameModule {
   public readonly id = "maps";
@@ -92,6 +104,7 @@ export class MapModule implements GameModule {
   private mapEffectsElapsedMs = 0;
   private mapEffectsLastPublishMs = 0;
   private lastMapEffectsSnapshot: MapEffectsBridgeState | null = null;
+  private mapResourcePreviewCache: MapResourcePreviewCache | null = null;
 
   constructor(options: MapModuleOptions) {
     this.options = options;
@@ -129,6 +142,7 @@ export class MapModule implements GameModule {
     this.refreshAutoRestartState();
     this.pushAutoRestartState();
     this.pushMapList();
+    this.pushMapResourcePreviewCache();
     this.pushMapSelectViewTransform();
     this.pushControlHintsState();
     this.resetInspectedTargetState();
@@ -162,6 +176,7 @@ export class MapModule implements GameModule {
     this.pushAutoRestartState();
     this.pushMapList();
     this.pushLastPlayedMap();
+    this.pushMapResourcePreviewCache();
     this.pushMapSelectViewTransform();
     this.pushControlHintsState();
 
@@ -879,6 +894,145 @@ export class MapModule implements GameModule {
     this.pushClearedLevelsTotal();
     DataBridgeHelpers.pushState(this.options.bridge, MAP_LIST_BRIDGE_KEY, list);
     this.newUnlocks.invalidate("maps");
+  }
+
+  private pushMapResourcePreviewCache(): void {
+    const cache = this.ensureMapResourcePreviewCache();
+    DataBridgeHelpers.pushState(this.options.bridge, MAP_RESOURCE_PREVIEW_BRIDGE_KEY, cache);
+  }
+
+  private ensureMapResourcePreviewCache(): MapResourcePreviewCache {
+    if (this.mapResourcePreviewCache) {
+      return this.mapResourcePreviewCache;
+    }
+    const cache: MapResourcePreviewCache = {};
+    getMapList().forEach((map) => {
+      const config = getMapConfig(map.id);
+      cache[map.id] = this.buildMapResourcePreview(config);
+    });
+    this.mapResourcePreviewCache = cache;
+    return cache;
+  }
+
+  private buildMapResourcePreview(config: MapConfig): MapResourcePreview {
+    const mapLevel = 1;
+    const brickTotalsLevel1 = this.computeBrickTotalsForLevel(config, mapLevel);
+    const enemyRewardsLevel1 = this.computeEnemyRewardsForLevel(config, mapLevel);
+    const multiplier =
+      config.resourceMultiplier !== undefined && config.resourceMultiplier > 0
+        ? Math.max(config.resourceMultiplier, 0)
+        : 1;
+    const scaledBrickTotals =
+      multiplier !== 1
+        ? this.scaleResourceStockpilePreview(brickTotalsLevel1, multiplier)
+        : brickTotalsLevel1;
+    const scaledEnemyRewards: Partial<Record<EnemyType, ResourceStockpile>> = {};
+    Object.entries(enemyRewardsLevel1).forEach(([type, rewards]) => {
+      scaledEnemyRewards[type as EnemyType] =
+        multiplier !== 1
+          ? this.scaleResourceStockpilePreview(rewards ?? createEmptyResourceStockpile(), multiplier)
+          : rewards ?? createEmptyResourceStockpile();
+    });
+
+    const resourceIds = RESOURCE_IDS.filter((id) => {
+      if ((scaledBrickTotals[id] ?? 0) > 0) {
+        return true;
+      }
+      return Object.values(scaledEnemyRewards).some((reward) => (reward?.[id] ?? 0) > 0);
+    });
+
+    return {
+      resourceIds,
+      brickTotalsLevel1: scaledBrickTotals,
+      enemyRewardsLevel1: scaledEnemyRewards,
+    };
+  }
+
+  private computeBrickTotalsForLevel(config: MapConfig, mapLevel: number): ResourceStockpile {
+    const totals = createEmptyResourceStockpile();
+    const bricks = buildBricksFromBlueprints(config.bricks({ mapLevel }));
+    bricks.forEach((brick) => {
+      const brickConfig = getBrickConfig(brick.type);
+      const stats = calculateBrickStatsForLevel(brickConfig, brick.level);
+      this.addResourceStockpile(totals, stats.rewards);
+    });
+    return totals;
+  }
+
+  private computeEnemyRewardsForLevel(
+    config: MapConfig,
+    mapLevel: number
+  ): Partial<Record<EnemyType, ResourceStockpile>> {
+    const levelsByType = new Map<EnemyType, number>();
+    if (config.enemies) {
+      config.enemies({ mapLevel }).forEach((spawn) => {
+        const level = sanitizeEnemyLevel(spawn.level ?? mapLevel);
+        this.setEnemyLevelPreview(levelsByType, spawn.type, level);
+      });
+    }
+    config.enemySpawnPoints?.forEach((spawnPoint) => {
+      if (spawnPoint.enabled === false) {
+        return;
+      }
+      const levelOffset = spawnPoint.levelOffset ?? 0;
+      const enemyLevel = sanitizeEnemyLevel(mapLevel + levelOffset);
+      const validTypes = spawnPoint.enemyTypes.filter((enemyType) => {
+        if (enemyType.minLevel !== undefined && mapLevel < enemyType.minLevel) {
+          return false;
+        }
+        if (enemyType.maxLevel !== undefined && mapLevel > enemyType.maxLevel) {
+          return false;
+        }
+        return true;
+      });
+      if (validTypes.length === 0) {
+        return;
+      }
+      const weightedTypes = validTypes.filter((enemyType) => Math.max(enemyType.weight, 0) > 0);
+      const previewTypes = weightedTypes.length > 0 ? weightedTypes : [validTypes[0]!];
+      previewTypes.forEach((enemyType) => {
+        this.setEnemyLevelPreview(levelsByType, enemyType.type, enemyLevel);
+      });
+    });
+
+    const rewards: Partial<Record<EnemyType, ResourceStockpile>> = {};
+    levelsByType.forEach((level, type) => {
+      const stats = calculateEnemyStatsForLevel(getEnemyConfig(type), level);
+      rewards[type] = stats.rewards;
+    });
+    return rewards;
+  }
+
+  private setEnemyLevelPreview(
+    levelsByType: Map<EnemyType, number>,
+    type: EnemyType,
+    level: number
+  ): void {
+    const stored = levelsByType.get(type);
+    if (!stored || level > stored) {
+      levelsByType.set(type, level);
+    }
+  }
+
+  private addResourceStockpile(target: ResourceStockpile, source: ResourceStockpile): void {
+    RESOURCE_IDS.forEach((id) => {
+      const base = target[id] ?? 0;
+      const add = source[id] ?? 0;
+      target[id] = base + add;
+    });
+  }
+
+  private scaleResourceStockpilePreview(
+    source: ResourceStockpile,
+    multiplier: number
+  ): ResourceStockpile {
+    const scaled = createEmptyResourceStockpile();
+    RESOURCE_IDS.forEach((id) => {
+      const base = source[id] ?? 0;
+      const value = Math.round(base * multiplier * 100) / 100;
+      scaled[id] = value > 0 ? value : 0;
+    });
+    return scaled;
   }
 
   private registerUnlockNotifications(): void {

--- a/src/logic/modules/active-map/map/map.types.ts
+++ b/src/logic/modules/active-map/map/map.types.ts
@@ -18,6 +18,8 @@ import type { EnemyRuntimeState } from "../enemies/enemies.types";
 import type { StatusEffectsModule } from "../status-effects/status-effects.module";
 import type { PlayerUnitState } from "../player-units/units/UnitTypes";
 import { MapId, MapListEntry as MapListEntryConfig } from "../../../../db/maps/maps-db";
+import type { EnemyType } from "../../../../db/enemies-db";
+import type { ResourceId, ResourceStockpile } from "../../../../db/resources-db";
 import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import type { TargetSnapshot } from "../targeting/targeting.types";
 import { MapRunState } from "./MapRunState";
@@ -102,6 +104,14 @@ export interface MapEffectsBridgeState {
     postProcess?: MapEffectPostProcessConfig;
   } | null;
 }
+
+export interface MapResourcePreview {
+  readonly resourceIds: ResourceId[];
+  readonly brickTotalsLevel1: ResourceStockpile;
+  readonly enemyRewardsLevel1: Partial<Record<EnemyType, ResourceStockpile>>;
+}
+
+export type MapResourcePreviewCache = Partial<Record<MapId, MapResourcePreview>>;
 
 export type MapModuleInstance = GameModule & { id: string };
 

--- a/src/shared/helpers/resource-abundance.helper.ts
+++ b/src/shared/helpers/resource-abundance.helper.ts
@@ -20,6 +20,8 @@ export const getResourceAbundanceLevel = (
     return 1;
   }
 
+  if (safeCount === 1) return 5;
+
   const k = 3;
   const p = 1.8;
   const denominator = Math.log(safeTotal + k);

--- a/src/shared/helpers/resource-abundance.helper.ts
+++ b/src/shared/helpers/resource-abundance.helper.ts
@@ -1,0 +1,41 @@
+export type ResourceAbundanceLevel = 1 | 2 | 3 | 4 | 5;
+
+const RESOURCE_ABUNDANCE_LABELS: Record<ResourceAbundanceLevel, string> = {
+  1: "Sparse",
+  2: "Limited",
+  3: "Moderate",
+  4: "Rich",
+  5: "Abundant",
+};
+
+export const getResourceAbundanceLevel = (
+  amount: number,
+  total: number,
+  n: number
+): ResourceAbundanceLevel => {
+  const safeTotal = Number.isFinite(total) ? Math.max(0, total) : 0;
+  const safeAmount = Number.isFinite(amount) ? Math.max(0, amount) : 0;
+  const safeCount = Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 0;
+  if (safeTotal <= 0 || safeCount <= 0) {
+    return 1;
+  }
+
+  const k = 3;
+  const p = 1.8;
+  const denominator = Math.log(safeTotal + k);
+  if (denominator <= 0) {
+    return 1;
+  }
+  const s = Math.log(safeAmount + k) / denominator;
+  const seq = Math.log(safeTotal / safeCount + k) / denominator;
+  if (seq <= 0) {
+    return 1;
+  }
+  const x = s / seq;
+  const raw = Math.round(4 * Math.pow(x, p));
+  const level = Math.max(1, Math.min(5, raw));
+  return level as ResourceAbundanceLevel;
+};
+
+export const getResourceAbundanceLabel = (level: ResourceAbundanceLevel): string =>
+  RESOURCE_ABUNDANCE_LABELS[level];

--- a/src/ui/screens/VoidCamp/VoidCampScreen.tsx
+++ b/src/ui/screens/VoidCamp/VoidCampScreen.tsx
@@ -10,9 +10,10 @@ import { GAME_VERSIONS } from "@db/version-db";
 import {
   MAP_CLEARED_LEVELS_BRIDGE_KEY,
   MAP_LIST_BRIDGE_KEY,
+  MAP_RESOURCE_PREVIEW_BRIDGE_KEY,
   MAP_SELECTED_BRIDGE_KEY,
 } from "@logic/modules/active-map/map/map.const";
-import { MapListEntry } from "@logic/modules/active-map/map/map.types";
+import { MapListEntry, MapResourcePreviewCache } from "@logic/modules/active-map/map/map.types";
 import { TIME_BRIDGE_KEY } from "@logic/modules/shared/time/time.module";
 import { RESOURCE_TOTALS_BRIDGE_KEY } from "@logic/modules/shared/resources/resources.module";
 import type { ResourceAmountPayload } from "@logic/modules/shared/resources/resources.types";
@@ -108,6 +109,11 @@ export const VoidCampScreen: React.FC<VoidCampScreenProps> = ({
   const timePlayed = useBridgeValue(bridge, TIME_BRIDGE_KEY, 0);
   const maps = useBridgeValue(bridge, MAP_LIST_BRIDGE_KEY, [] as MapListEntry[]);
   const selectedMap = useBridgeValue(bridge, MAP_SELECTED_BRIDGE_KEY, null as MapId | null);
+  const mapResourcePreviewCache = useBridgeValue(
+    bridge,
+    MAP_RESOURCE_PREVIEW_BRIDGE_KEY,
+    {} as MapResourcePreviewCache
+  );
   const clearedLevelsTotal = useBridgeValue(
     bridge,
     MAP_CLEARED_LEVELS_BRIDGE_KEY,
@@ -361,6 +367,7 @@ export const VoidCampScreen: React.FC<VoidCampScreenProps> = ({
             maps={maps}
             clearedLevelsTotal={clearedLevelsTotal}
             selectedMap={selectedMap}
+            mapResourcePreviewCache={mapResourcePreviewCache}
             onSelectMap={(mapId) => uiApi.map.selectMap(mapId)}
             onSelectMapLevel={(mapId, level) => uiApi.map.selectMapLevel(mapId, level)}
             onStartMap={handleStartMap}

--- a/src/ui/screens/VoidCamp/components/CampContent/CampContent.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/CampContent.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { MapId } from "@/db/maps/maps-db";
-import { MapListEntry } from "@logic/modules/active-map/map/map.types";
+import { MapListEntry, MapResourcePreviewCache } from "@logic/modules/active-map/map/map.types";
 import { CampTabsMenu } from "./TabMenu/CampTabsMenu";
 import { CampTabPanels } from "./TabPanels/CampTabPanels";
 import { UnitModuleWorkshopBridgeState } from "@logic/modules/camp/unit-module-workshop/unit-module-workshop.types";
@@ -19,6 +19,7 @@ interface CampContentProps {
   maps: MapListEntry[];
   clearedLevelsTotal: number;
   selectedMap: MapId | null;
+  mapResourcePreviewCache: MapResourcePreviewCache;
   onSelectMap: (mapId: MapId) => void;
   onSelectMapLevel: (mapId: MapId, level: number) => void;
   onStartMap: (mapId: MapId) => void;
@@ -38,6 +39,7 @@ export const CampContent: React.FC<CampContentProps> = ({
   maps,
   clearedLevelsTotal,
   selectedMap,
+  mapResourcePreviewCache,
   onSelectMap,
   onSelectMapLevel,
   onStartMap,
@@ -116,6 +118,7 @@ export const CampContent: React.FC<CampContentProps> = ({
         maps={maps}
         clearedLevelsTotal={clearedLevelsTotal}
         selectedMap={selectedMap}
+        mapResourcePreviewCache={mapResourcePreviewCache}
         onSelectMap={onSelectMap}
         onSelectMapLevel={onSelectMapLevel}
         onStartMap={onStartMap}

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/CampTabPanels.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/CampTabPanels.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { MapId, getMapConfig } from "@/db/maps/maps-db";
-import { MapListEntry } from "@logic/modules/active-map/map/map.types";
+import { MapListEntry, MapResourcePreviewCache } from "@logic/modules/active-map/map/map.types";
 import { SkillTreeView } from "@/ui/screens/VoidCamp/components/CampContent/TabPanels/SkillTree/SkillTreeView";
 import { ModulesWorkshopView } from "@/ui/screens/VoidCamp/components/CampContent/TabPanels/ModulesWorkshop/ModulesWorkshopView";
 import { UnitDesignerView } from "@screens/VoidCamp/components/UnitDesigner/UnitDesignerView";
@@ -23,6 +23,7 @@ type CampTabPanelsProps = {
   maps: MapListEntry[];
   clearedLevelsTotal: number;
   selectedMap: MapId | null;
+  mapResourcePreviewCache: MapResourcePreviewCache;
   onSelectMap: (mapId: MapId) => void;
   onSelectMapLevel: (mapId: MapId, level: number) => void;
   onStartMap: (mapId: MapId) => void;
@@ -40,6 +41,7 @@ export const CampTabPanels: React.FC<CampTabPanelsProps> = ({
   maps,
   clearedLevelsTotal,
   selectedMap,
+  mapResourcePreviewCache,
   onSelectMap,
   onSelectMapLevel,
   onStartMap,
@@ -79,6 +81,7 @@ export const CampTabPanels: React.FC<CampTabPanelsProps> = ({
         maps={maps}
         clearedLevelsTotal={clearedLevelsTotal}
         selectedMap={selectedMap}
+        mapResourcePreviewCache={mapResourcePreviewCache}
         achievements={achievementsState}
         onSelectMap={onSelectMap}
         onSelectLevel={onSelectMapLevel}

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.css
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.css
@@ -349,8 +349,8 @@
 .map-tree__details-resources-item {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
   justify-content: space-between;
+  gap: var(--spacing-md);
   padding: var(--spacing-xs) var(--spacing-sm);
   border-radius: var(--radius-sm);
   background: rgba(15, 23, 42, 0.35);
@@ -358,20 +358,46 @@
   font-size: 0.9rem;
 }
 
-.map-tree__details-resources-item span:first-of-type {
-  flex: 1;
+.map-tree__details-resources-label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  min-width: 0;
 }
 
 .map-tree__details-resources-level {
-  color: var(--color-text-strong);
+  flex-shrink: 0;
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+/* Rarity colors: rarest → most abundant */
+.map-tree__details-resources-level--1 {
+  color: #f97316;
+}
+
+.map-tree__details-resources-level--2 {
+  color: #eab308;
+}
+
+.map-tree__details-resources-level--3 {
+  color: #f8fafc;
+}
+
+.map-tree__details-resources-level--4 {
+  color: #86efac;
+}
+
+.map-tree__details-resources-level--5 {
+  color: #22c55e;
 }
 
 .map-tree__details-resources-icon {
   width: 22px;
   height: 22px;
+  flex-shrink: 0;
 }
 
 .map-tree__popover {

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.css
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.css
@@ -341,7 +341,7 @@
 
 .map-tree__details-resources-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: 1fr;
   gap: var(--spacing-sm);
   margin: 0;
 }
@@ -350,11 +350,23 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
+  justify-content: space-between;
   padding: var(--spacing-xs) var(--spacing-sm);
   border-radius: var(--radius-sm);
   background: rgba(15, 23, 42, 0.35);
   color: var(--color-text-subtle);
   font-size: 0.9rem;
+}
+
+.map-tree__details-resources-item span:first-of-type {
+  flex: 1;
+}
+
+.map-tree__details-resources-level {
+  color: var(--color-text-strong);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .map-tree__details-resources-icon {

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.css
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.css
@@ -328,6 +328,40 @@
   font-size: 0.9rem;
 }
 
+.map-tree__details-resources {
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.map-tree__details-resources-title {
+  font-weight: 600;
+  color: var(--color-text-strong);
+  font-size: 0.9rem;
+}
+
+.map-tree__details-resources-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--spacing-sm);
+  margin: 0;
+}
+
+.map-tree__details-resources-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--color-text-subtle);
+  font-size: 0.9rem;
+}
+
+.map-tree__details-resources-icon {
+  width: 22px;
+  height: 22px;
+}
+
 .map-tree__popover {
   position: absolute;
   transform: translate(-50%, -50%);

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.tsx
@@ -5,7 +5,7 @@ import type {
   WheelEvent as ReactWheelEvent,
 } from "react";
 import { MapId, getMapConfig } from "@/db/maps/maps-db";
-import { getResourceConfig } from "@/db/resources-db";
+import { RESOURCE_IDS, type ResourceId, getResourceConfig } from "@/db/resources-db";
 import { getAssetUrl } from "@shared/helpers/assets.helper";
 import { MapListEntry } from "@logic/modules/active-map/map/map.types";
 import { classNames } from "@ui-shared/classNames";
@@ -26,6 +26,7 @@ import type { NewUnlockNotificationBridgeState } from "@logic/services/new-unloc
 import { NewUnlockWrapper } from "@ui-shared/NewUnlockWrapper";
 import { isDemoBuild } from "@shared/helpers/demo.helper";
 import { ResourceIcon } from "@ui-shared/icons/ResourceIcon";
+import { getResourceAbundanceLabel, getResourceAbundanceLevel } from "@shared/helpers/resource-abundance.helper";
 import "./MapSelectPanel.css";
 import type { MapModuleUiApi, MapResourcePreviewCache } from "@logic/modules/active-map/map/map.types";
 
@@ -374,6 +375,35 @@ export const MapSelectPanel: React.FC<MapSelectPanelProps> = ({
     }
     return mapResourcePreviewCache[activeMap.id] ?? null;
   }, [activeMap, mapResourcePreviewCache]);
+  const activeResourceTotals = useMemo(() => {
+    if (!activeResourcePreview) {
+      return null;
+    }
+    const amounts: Partial<Record<ResourceId, number>> = {};
+    const addStockpile = (stockpile?: Record<ResourceId, number> | null): void => {
+      if (!stockpile) {
+        return;
+      }
+      RESOURCE_IDS.forEach((id) => {
+        const value = stockpile[id] ?? 0;
+        if (value <= 0) {
+          return;
+        }
+        amounts[id] = (amounts[id] ?? 0) + value;
+      });
+    };
+    addStockpile(activeResourcePreview.brickTotalsLevel1);
+    Object.values(activeResourcePreview.enemyRewardsLevel1).forEach((reward) => addStockpile(reward));
+    const total = activeResourcePreview.resourceIds.reduce(
+      (sum, id) => sum + (amounts[id] ?? 0),
+      0
+    );
+    return {
+      amounts,
+      total,
+      count: activeResourcePreview.resourceIds.length,
+    };
+  }, [activeResourcePreview]);
 
   const setPopoverForMap = useCallback(
     (map: MapListEntry) => {
@@ -979,6 +1009,20 @@ export const MapSelectPanel: React.FC<MapSelectPanelProps> = ({
                       <li key={resourceId} className="map-tree__details-resources-item">
                         <ResourceIcon resourceId={resourceId} className="map-tree__details-resources-icon" />
                         <span>{getResourceConfig(resourceId).name}</span>
+                        <span className="map-tree__details-resources-level">
+                          {(() => {
+                            if (!activeResourceTotals) {
+                              return getResourceAbundanceLabel(1);
+                            }
+                            const amount = activeResourceTotals.amounts[resourceId] ?? 0;
+                            const level = getResourceAbundanceLevel(
+                              amount,
+                              activeResourceTotals.total,
+                              activeResourceTotals.count
+                            );
+                            return getResourceAbundanceLabel(level);
+                          })()}
+                        </span>
                       </li>
                     ))}
                   </ul>

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.tsx
@@ -26,6 +26,7 @@ import type { NewUnlockNotificationBridgeState } from "@logic/services/new-unloc
 import { NewUnlockWrapper } from "@ui-shared/NewUnlockWrapper";
 import { isDemoBuild } from "@shared/helpers/demo.helper";
 import { ResourceIcon } from "@ui-shared/icons/ResourceIcon";
+import type { ResourceAbundanceLevel } from "@shared/helpers/resource-abundance.helper";
 import { getResourceAbundanceLabel, getResourceAbundanceLevel } from "@shared/helpers/resource-abundance.helper";
 import "./MapSelectPanel.css";
 import type { MapModuleUiApi, MapResourcePreviewCache } from "@logic/modules/active-map/map/map.types";
@@ -1005,26 +1006,31 @@ export const MapSelectPanel: React.FC<MapSelectPanelProps> = ({
                 <div className="map-tree__details-resources">
                   <div className="map-tree__details-resources-title">Potential resources</div>
                   <ul className="map-tree__details-resources-list list-reset">
-                    {activeResourcePreview.resourceIds.map((resourceId) => (
-                      <li key={resourceId} className="map-tree__details-resources-item">
-                        <ResourceIcon resourceId={resourceId} className="map-tree__details-resources-icon" />
-                        <span>{getResourceConfig(resourceId).name}</span>
-                        <span className="map-tree__details-resources-level">
-                          {(() => {
-                            if (!activeResourceTotals) {
-                              return getResourceAbundanceLabel(1);
-                            }
-                            const amount = activeResourceTotals.amounts[resourceId] ?? 0;
-                            const level = getResourceAbundanceLevel(
-                              amount,
-                              activeResourceTotals.total,
-                              activeResourceTotals.count
-                            );
-                            return getResourceAbundanceLabel(level);
-                          })()}
-                        </span>
-                      </li>
-                    ))}
+                    {activeResourcePreview.resourceIds.map((resourceId) => {
+                      const abundanceLevel: ResourceAbundanceLevel = !activeResourceTotals
+                        ? 1
+                        : getResourceAbundanceLevel(
+                            activeResourceTotals.amounts[resourceId] ?? 0,
+                            activeResourceTotals.total,
+                            activeResourceTotals.count
+                          );
+                      return (
+                        <li key={resourceId} className="map-tree__details-resources-item">
+                          <span className="map-tree__details-resources-label">
+                            <ResourceIcon resourceId={resourceId} className="map-tree__details-resources-icon" />
+                            <span>{getResourceConfig(resourceId).name}</span>
+                          </span>
+                          <span
+                            className={classNames(
+                              "map-tree__details-resources-level",
+                              `map-tree__details-resources-level--${abundanceLevel}`
+                            )}
+                          >
+                            {getResourceAbundanceLabel(abundanceLevel)}
+                          </span>
+                        </li>
+                      );
+                    })}
                   </ul>
                 </div>
               ) : null}

--- a/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.tsx
+++ b/src/ui/screens/VoidCamp/components/CampContent/TabPanels/MapSelectPanel/MapSelectPanel.tsx
@@ -5,6 +5,7 @@ import type {
   WheelEvent as ReactWheelEvent,
 } from "react";
 import { MapId, getMapConfig } from "@/db/maps/maps-db";
+import { getResourceConfig } from "@/db/resources-db";
 import { getAssetUrl } from "@shared/helpers/assets.helper";
 import { MapListEntry } from "@logic/modules/active-map/map/map.types";
 import { classNames } from "@ui-shared/classNames";
@@ -24,8 +25,9 @@ import {
 import type { NewUnlockNotificationBridgeState } from "@logic/services/new-unlock-notification/new-unlock-notification.types";
 import { NewUnlockWrapper } from "@ui-shared/NewUnlockWrapper";
 import { isDemoBuild } from "@shared/helpers/demo.helper";
+import { ResourceIcon } from "@ui-shared/icons/ResourceIcon";
 import "./MapSelectPanel.css";
-import type { MapModuleUiApi } from "@logic/modules/active-map/map/map.types";
+import type { MapModuleUiApi, MapResourcePreviewCache } from "@logic/modules/active-map/map/map.types";
 
 const CELL_SIZE_X = 200;
 const CELL_SIZE_Y = 180;
@@ -49,6 +51,7 @@ interface MapSelectPanelProps {
   maps: MapListEntry[];
   clearedLevelsTotal: number;
   selectedMap: MapId | null;
+  mapResourcePreviewCache: MapResourcePreviewCache;
   achievements: AchievementsBridgePayload;
   onSelectMap: (mapId: MapId) => void;
   onSelectLevel: (mapId: MapId, level: number) => void;
@@ -138,6 +141,7 @@ export const MapSelectPanel: React.FC<MapSelectPanelProps> = ({
   maps,
   clearedLevelsTotal,
   selectedMap,
+  mapResourcePreviewCache,
   achievements,
   onSelectMap,
   onSelectLevel,
@@ -364,6 +368,12 @@ export const MapSelectPanel: React.FC<MapSelectPanelProps> = ({
     }
     return achievements.achievements.find((entry) => entry.id === achievementId) ?? null;
   }, [achievements.achievements, activeMap]);
+  const activeResourcePreview = useMemo(() => {
+    if (!activeMap) {
+      return null;
+    }
+    return mapResourcePreviewCache[activeMap.id] ?? null;
+  }, [activeMap, mapResourcePreviewCache]);
 
   const setPopoverForMap = useCallback(
     (map: MapListEntry) => {
@@ -959,6 +969,19 @@ export const MapSelectPanel: React.FC<MapSelectPanelProps> = ({
                     effects={activeAchievement.bonusEffects}
                     emptyLabel="No bonuses yet."
                   />
+                </div>
+              ) : null}
+              {activeResourcePreview && activeResourcePreview.resourceIds.length > 0 ? (
+                <div className="map-tree__details-resources">
+                  <div className="map-tree__details-resources-title">Potential resources</div>
+                  <ul className="map-tree__details-resources-list list-reset">
+                    {activeResourcePreview.resourceIds.map((resourceId) => (
+                      <li key={resourceId} className="map-tree__details-resources-item">
+                        <ResourceIcon resourceId={resourceId} className="map-tree__details-resources-icon" />
+                        <span>{getResourceConfig(resourceId).name}</span>
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               ) : null}
               <div className="map-tree__details-list">

--- a/tests/ResourceAbundance.test.ts
+++ b/tests/ResourceAbundance.test.ts
@@ -1,0 +1,29 @@
+import { strict as assert } from "assert";
+
+import { describe, test } from "./testRunner";
+import {
+  getResourceAbundanceLabel,
+  getResourceAbundanceLevel,
+} from "../src/shared/helpers/resource-abundance.helper";
+
+describe("resource abundance helper", () => {
+  test("calculates levels with logarithmic scaling", () => {
+    assert.equal(getResourceAbundanceLevel(1, 100, 5), 1);
+    assert.equal(getResourceAbundanceLevel(5, 100, 5), 2);
+    assert.equal(getResourceAbundanceLevel(20, 100, 5), 4);
+    assert.equal(getResourceAbundanceLevel(50, 100, 5), 5);
+  });
+
+  test("maps levels to labels for UI display", () => {
+    assert.equal(getResourceAbundanceLabel(1), "Sparse");
+    assert.equal(getResourceAbundanceLabel(2), "Limited");
+    assert.equal(getResourceAbundanceLabel(3), "Moderate");
+    assert.equal(getResourceAbundanceLabel(4), "Rich");
+    assert.equal(getResourceAbundanceLabel(5), "Abundant");
+  });
+
+  test("handles empty totals safely", () => {
+    assert.equal(getResourceAbundanceLevel(0, 0, 0), 1);
+    assert.equal(getResourceAbundanceLevel(10, 0, 2), 1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a fast, precomputed preview of potential resources per map so the UI can show icons/names without re-running game logic on every render. 
- Ensure previews only include realistic enemy drops by avoiding types that cannot spawn (fixes previews that showed impossible drops when spawn weights are zero).

### Description
- Add typed preview types `MapResourcePreview` and `MapResourcePreviewCache` and expose them via a new bridge key `MAP_RESOURCE_PREVIEW_BRIDGE_KEY` (`maps/resourcePreview`).
- Implement per-map preview building and caching in `MapModule`: compute brick totals for level 1, compute enemy reward samples for level 1, apply `resourceMultiplier` scaling, and cache the results in `mapResourcePreviewCache` emitted on module initialization via `DataBridgeHelpers.pushState`.
- Refine enemy preview selection logic to filter `enemySpawnPoints` to only valid types and prefer weighted spawnable types (falling back to the first valid type when all weights are zero) to avoid previewing impossible enemy drops (`map.module.ts`).
- Wire the bridge value into the UI: read `maps/resourcePreview` in `VoidCampScreen`, pass `mapResourcePreviewCache` through `CampContent` → `CampTabPanels` → `MapSelectPanel`, render icons and names using `ResourceIcon` and `getResourceConfig` and add styles (`MapSelectPanel.tsx`, `MapSelectPanel.css`).
- Update `BridgeSchema` for type-safety to include the new `maps/resourcePreview` entry.

### Testing
- Ran the full test suite with `npm test` and all tests passed (`67 tests passed`).
- Performed local dev build/dev-run checks by triggering the module initialization path that publishes the new bridge key (no additional automated UI tests were added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873caf2224832080ca3e31514f95a8)