### PR TITLE
Add objective integrity tracking and map completion that includes required enemies

### DIFF
--- a/src/core/logic/ui/BridgeSchema.ts
+++ b/src/core/logic/ui/BridgeSchema.ts
@@ -73,6 +73,9 @@ export interface BridgeSchema {
   "bricks/count": number;
   "bricks/totalHp": number;
 
+  // Objectives
+  "objectives/totalHp": number;
+
   // Enemies
   "enemies/count": number;
   "enemies/totalHp": number;

--- a/src/db/arcs-db.ts
+++ b/src/db/arcs-db.ts
@@ -8,7 +8,8 @@ export type ArcType =
   | "bleeding"
   | "laser"
   | "plasmaBeam"
-  | "chainLightning";
+  | "chainLightning"
+  | "silverKeeper";
 
 export interface ArcConfig {
   readonly coreColor: SceneColor;
@@ -41,6 +42,8 @@ const PLASMA_BEAM_ARC_COLOR: SceneColor = { r: 0.45, g: 0.7, b: 1.0, a: 0.98 };
 const PLASMA_BEAM_ARC_BLUR: SceneColor = { r: 0.4, g: 0.65, b: 1.0, a: 0.7 };
 const CHAIN_ARC_COLOR: SceneColor = { r: 0.85, g: 0.95, b: 1.0, a: 0.95 };
 const CHAIN_ARC_BLUR: SceneColor = { r: 0.3, g: 0.7, b: 1.0, a: 0.35 };
+const SILVER_KEEPER_ARC_COLOR: SceneColor = { r: 1, g: 0.9, b: 1.0, a: 1 };
+const SILVER_KEEPER_ARC_BLUR: SceneColor = { r: 0.7, g: 0.5, b: 0.9, a: 0.85 };
 
 const ARC_DB: Record<ArcType, ArcConfig> = {
   heal: {
@@ -127,6 +130,21 @@ const ARC_DB: Record<ArcType, ArcConfig> = {
     blurColor: CHAIN_ARC_BLUR,
     coreWidth: 1.5,
     blurWidth: 5,
+    lifetimeMs: 700,
+    fadeStartMs: 350,
+    bendsPer100Px: 3,
+    noiseAmplitude: 16,
+    aperiodicStrength: 0.55,
+    kinkAmplitude: 2,
+    kinkFrequency: 1.2,
+    oscillationPeriodMs: 170,
+    oscillationAmplitude: 0.4,
+  },
+  silverKeeper: {
+    coreColor: SILVER_KEEPER_ARC_COLOR,
+    blurColor: SILVER_KEEPER_ARC_BLUR,
+    coreWidth: 3,
+    blurWidth: 8,
     lifetimeMs: 700,
     fadeStartMs: 350,
     bendsPer100Px: 3,

--- a/src/db/enemies-db.ts
+++ b/src/db/enemies-db.ts
@@ -1954,6 +1954,7 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
     attackRange: 0,
     moveSpeed: 0,
     physicalSize: 32,
+    requireDestruction: true,
     spawner: {
       spawnRate: 0.2,
       enemyTypes: [

--- a/src/db/enemies-db.ts
+++ b/src/db/enemies-db.ts
@@ -17,6 +17,7 @@ import type { StatusEffectId } from "./status-effects-db";
 import type { StatusEffectApplicationOptions } from "@/logic/modules/active-map/status-effects/status-effects.types";
 import type { ExplosionType } from "./explosions-db";
 import type { AttackSeriesConfig } from "@shared/types/attack-series.types";
+import type { MapEnemySpawnTypeConfig } from "./maps/maps-db";
 
 export type EnemyType =
   | "basicEnemy"
@@ -33,7 +34,8 @@ export type EnemyType =
   | "freezeTurretEnemy"
   | "bigGun"
   | "laserTurretEnemy"
-  | "plasmaBeamTurretEnemy";
+  | "plasmaBeamTurretEnemy"
+  | "portalSpawnerEnemy";
 
 export interface EnemyAuraConfig {
   petalCount: number;
@@ -125,6 +127,13 @@ export interface EnemyConfig {
   readonly knockBackSpeed?: number; // Швидкість knockback при атаці юнітів
   readonly selfKnockBackDistance?: number; // Відстань knockback для ворога при отриманні урону
   readonly selfKnockBackSpeed?: number; // Швидкість knockback для ворога при отриманні урону
+  readonly requireDestruction?: boolean;
+  readonly spawner?: {
+    readonly spawnRate: number;
+    readonly enemyTypes: readonly MapEnemySpawnTypeConfig[];
+    readonly levelOffset?: number;
+    readonly maxConcurrent?: number;
+  };
 }
 
 const BASIC_ENEMY_VERTICES: readonly SceneVector2[] = [
@@ -180,6 +189,13 @@ const TURRET_ENEMY_VERTICES: readonly SceneVector2[] = [
   { x: -14, y: -10 },
   { x: -14, y: 10 },
   { x: 14, y: 2 },
+];
+
+const PORTAL_SPAWNER_VERTICES: readonly SceneVector2[] = [
+  { x: -16, y: -16 },
+  { x: 16, y: -16 },
+  { x: 16, y: 16 },
+  { x: -16, y: 16 },
 ];
 
 const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
@@ -1918,6 +1934,35 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
       explosionType: "plasmaBeam",
       explosionRadius: 36,
       spawnOffset: { x: 2, y: 0 },
+    },
+  },
+  portalSpawnerEnemy: {
+    name: "Portal Spawner",
+    renderer: {
+      kind: "polygon",
+      fill: { r: 0.4, g: 0.6, b: 0.95, a: 0.9 },
+      stroke: {
+        color: { r: 0.6, g: 0.8, b: 1, a: 1 },
+        width: 2,
+      },
+      vertices: PORTAL_SPAWNER_VERTICES,
+    },
+    maxHp: 500,
+    armor: 5,
+    baseDamage: 0,
+    attackInterval: 9999,
+    attackRange: 0,
+    moveSpeed: 0,
+    physicalSize: 32,
+    spawner: {
+      spawnRate: 0.2,
+      enemyTypes: [
+        {
+          type: "basicEnemy",
+          weight: 1,
+        },
+      ],
+      maxConcurrent: 6,
     },
   },
 };

--- a/src/db/enemies-db.ts
+++ b/src/db/enemies-db.ts
@@ -18,6 +18,7 @@ import type { StatusEffectApplicationOptions } from "@/logic/modules/active-map/
 import type { ExplosionType } from "./explosions-db";
 import type { AttackSeriesConfig } from "@shared/types/attack-series.types";
 import type { MapEnemySpawnTypeConfig } from "./maps/maps-db";
+import type { DamageApplicationOptions } from "@/logic/modules/active-map/targeting/DamageService";
 
 export type EnemyType =
   | "basicEnemy"
@@ -31,6 +32,7 @@ export type EnemyType =
   | "spectreEnemy"
   | "encagedBeastEnemy"
   | "coalConvoyGuardian"
+  | "silverKeeperEnemy"
   | "freezeTurretEnemy"
   | "bigGun"
   | "laserTurretEnemy"
@@ -84,6 +86,12 @@ export interface EnemyArcAttackConfig {
   readonly statusEffectOptions?: StatusEffectApplicationOptions;
   readonly explosionType?: ExplosionType;
   readonly explosionRadius?: number;
+  /** When set with arcType "chainLightning", damage chains to nearby targets (e.g. other units). */
+  readonly chainRadius?: number;
+  readonly chainJumps?: number;
+  /** Damage per chain hit; used for chain and, when set, for the first target instead of enemy baseDamage. */
+  readonly damage?: number;
+  readonly damageOptions?: DamageApplicationOptions;
 }
 
 export interface EnemyProjectileConfig extends UnitProjectileVisualConfig {
@@ -106,6 +114,8 @@ export interface EnemyConfig {
   readonly attackRange?: number;
   readonly moveSpeed: number;
   readonly physicalSize: number;
+  /** When true, enemy never rotates (e.g. static structures). */
+  readonly lockRotation?: boolean;
   readonly reward?: ResourceAmount;
   readonly emitter?: ParticleEmitterConfig;
   readonly projectile?: EnemyProjectileConfig; // Якщо вказано - ворог стріляє снарядами, якщо ні - instant damage
@@ -880,6 +890,345 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
           { offset: 0, color: { r: 1, g: 0.75, b: 0.6, a: 0.1 } },
           { offset: 0.25, color: { r: 1, g: 0.75, b: 0.6, a: 0.05 } },
           { offset: 1, color: { r: 1, g: 0.75, b: 0.6, a: 0 } },
+        ],
+        noise: {
+          colorAmplitude: 0.0,
+          alphaAmplitude: 0.02,
+          scale: 0.3,
+        },
+      },
+      shape: "circle",
+      maxParticles: 100,
+    },
+    knockBackDistance: 80,
+    knockBackSpeed: 120,
+  },
+  silverKeeperEnemy: {
+    name: "Silver Keeper",
+    renderer: {
+      kind: "composite",
+      fill: { r: 0.95, g: 0.8, b: 1, a: 1 },
+      layers: [
+        // Head
+        {
+          shape: "polygon",
+          fill: { type: "base", brightness: 0.2 },
+          vertices: [
+            { x: 24, y: 0 },
+            { x: 20, y: -5 },
+            { x: 16, y: -5 },
+            { x: 16, y: 5 },
+            { x: 20, y: 5 },
+          ],
+        },
+        // Tentacles Left
+        ...mapLineToPolygonShape<
+          Omit<EnemyRendererLayerConfig, "shape" | "vertices">
+        >(
+          [
+            { x: 18, y: -3, width: 2.5 },
+            { x: 22, y: -8, width: 2.1 },
+            { x: 29, y: -9, width: 1.8 },
+            { x: 34, y: -12, width: 1.4 },
+          ],
+          {
+            fill: { type: "base", brightness: 0.3 },
+            anim: {
+              type: "sway",
+              periodMs: 1500,
+              amplitude: 6,
+              falloff: "tip",
+              axis: "normal",
+              phase: 1.1,
+            },
+            groupId: "silverKeeperLeft",
+            connectionSlots: [{ id: "silverKeeperTentacle_left", mode: "spine", t: 1 }],
+          },
+          { epsilon: 0.25, winding: "CCW" },
+        ),
+        {
+          shape: "circle",
+          radius: 8,
+          segments: 32,
+          offset: { x: 0, y: 0 },
+          join: { anchorId: "silverKeeperTentacle_left", targetGroupId: "silverKeeperLeft" },
+          fill: {
+            type: "gradient",
+
+            fill: {
+              fillType: FILL_TYPES.RADIAL_GRADIENT,
+              start: { x: 0, y: 0 },
+              stops: [
+                { offset: 0, color: { r: 1, g: 0.8, b: 1.0, a: 0.45 } },
+                { offset: 0.6, color: { r: 1, g: 0.8, b: 1, a: 0.3 } },
+                { offset: 1, color: { r: 1.0, g: 0.8, b: 1, a: 0.0 } },
+              ],
+            },
+          },
+        },
+
+        // Tentacles Right
+        ...mapLineToPolygonShape<
+          Omit<EnemyRendererLayerConfig, "shape" | "vertices">
+        >(
+          [
+            { x: 18, y: 3, width: 2.5 },
+            { x: 22, y: 8, width: 2.1 },
+            { x: 29, y: 9, width: 1.8 },
+            { x: 34, y: 12, width: 1.4 },
+          ],
+          {
+            fill: { type: "base", brightness: 0.3 },
+            anim: {
+              type: "sway",
+              periodMs: 1500,
+              amplitude: 6,
+              falloff: "tip",
+              axis: "normal",
+              phase: 1.1,
+            },
+            groupId: "silverKeeperRight",
+            connectionSlots: [{ id: "silverKeeperTentacle_right", mode: "spine", t: 1 }],
+          },
+          { epsilon: 0.25, winding: "CCW" },
+        ),
+        {
+          shape: "circle",
+          radius: 8,
+          segments: 32,
+          offset: { x: 0, y: 0 },
+          join: { anchorId: "silverKeeperTentacle_right", targetGroupId: "silverKeeperRight" },
+          fill: {
+            type: "gradient",
+
+            fill: {
+              fillType: FILL_TYPES.RADIAL_GRADIENT,
+              start: { x: 0, y: 0 },
+              stops: [
+                { offset: 0, color: { r: 1, g: 0.8, b: 1.0, a: 0.45 } },
+                { offset: 0.6, color: { r: 1, g: 0.8, b: 1, a: 0.3 } },
+                { offset: 1, color: { r: 1.0, g: 0.8, b: 1, a: 0.0 } },
+              ],
+            },
+          },
+        },
+        // tail
+        ...mapLineToPolygonShape<
+          Omit<EnemyRendererLayerConfig, "shape" | "vertices">
+        >(
+          [
+            { x: 17, y: 0, width: 3.5 },
+            { x: 10, y: -3, width: 3.1 },
+            { x: -4, y: 3, width: 2.8 },
+            { x: -16, y: -2, width: 2.4 },
+            { x: -25, y: 1, width: 1.2 },
+          ],
+          {
+            fill: { type: "base", brightness: 0.3 },
+            anim: {
+              type: "sway",
+              periodMs: 1500,
+              amplitude: 6,
+              falloff: "tip",
+              axis: "normal",
+              phase: 1.1,
+            },
+            groupId: "silverKeeperTail",
+            connectionSlots: [
+              { id: "silverKeeperTail1", mode: "spine", t: 0.25 },
+              { id: "silverKeeperTail2", mode: "spine", t: 0.5 },
+              { id: "silverKeeperTail3", mode: "spine", t: 0.75 },
+            ],
+          },
+          { epsilon: 0.25, winding: "CCW" },
+        ),
+        // Tail sprout 1 — left
+        ...mapLineToPolygonShape<
+          Omit<EnemyRendererLayerConfig, "shape" | "vertices">
+        >(
+          [
+            { x: 0, y: 0, width: 1.8 },
+            { x: -7, y: -6, width: 1.3 },
+            { x: -9, y: -11, width: 0.8 },
+            { x: -11, y: -16, width: 0.4 },
+          ],
+          {
+            fill: { type: "base", brightness: 0.4 },
+            anim: {
+              type: "sway",
+              periodMs: 1100,
+              amplitude: 4,
+              falloff: "tip",
+              axis: "normal",
+              phase: 0.0,
+            },
+            join: { anchorId: "silverKeeperTail1", targetGroupId: "silverKeeperTail" },
+          },
+          { epsilon: 0.25, winding: "CCW" },
+        ),
+        // Tail sprout 1 — right
+        ...mapLineToPolygonShape<
+          Omit<EnemyRendererLayerConfig, "shape" | "vertices">
+        >(
+          [
+            { x: 0, y: 0, width: 1.8 },
+            { x: -7, y: 6, width: 1.3 },
+            { x: -9, y: 11, width: 0.8 },
+            { x: -11, y: 16, width: 0.4 },
+          ],
+          {
+            fill: { type: "base", brightness: 0.4 },
+            anim: {
+              type: "sway",
+              periodMs: 1100,
+              amplitude: 4,
+              falloff: "tip",
+              axis: "normal",
+              phase: 0.5,
+            },
+            join: { anchorId: "silverKeeperTail1", targetGroupId: "silverKeeperTail" },
+          },
+          { epsilon: 0.25, winding: "CCW" },
+        ),
+        // Tail sprout 2 — left
+        ...mapLineToPolygonShape<
+          Omit<EnemyRendererLayerConfig, "shape" | "vertices">
+        >(
+          [
+            { x: 0, y: 0, width: 1.6 },
+            { x: -7, y: -6, width: 1.3 },
+            { x: -11, y: -11, width: 0.8 },
+            { x: -14, y: -16, width: 0.4 },
+          ],
+          {
+            fill: { type: "base", brightness: 0.45 },
+            anim: {
+              type: "sway",
+              periodMs: 1000,
+              amplitude: 3.5,
+              falloff: "tip",
+              axis: "normal",
+              phase: 0.3,
+            },
+            join: { anchorId: "silverKeeperTail2", targetGroupId: "silverKeeperTail" },
+          },
+          { epsilon: 0.25, winding: "CCW" },
+        ),
+        // Tail sprout 2 — right
+        ...mapLineToPolygonShape<
+          Omit<EnemyRendererLayerConfig, "shape" | "vertices">
+        >(
+          [
+            { x: 0, y: 0, width: 1.6 },
+            { x: -7, y: 6, width: 1.3 },
+            { x: -11, y: 11, width: 0.8 },
+            { x: -14, y: 16, width: 0.4 },
+          ],
+          {
+            fill: { type: "base", brightness: 0.45 },
+            anim: {
+              type: "sway",
+              periodMs: 1000,
+              amplitude: 3.5,
+              falloff: "tip",
+              axis: "normal",
+              phase: 0.8,
+            },
+            join: { anchorId: "silverKeeperTail2", targetGroupId: "silverKeeperTail" },
+          },
+          { epsilon: 0.25, winding: "CCW" },
+        ),
+        // Tail sprout 3 — left
+        ...mapLineToPolygonShape<
+          Omit<EnemyRendererLayerConfig, "shape" | "vertices">
+        >(
+          [
+            { x: 0, y: 0, width: 1.4 },
+            { x: -7, y: -4, width: 1.3 },
+            { x: -11, y: -9, width: 0.8 },
+            { x: -14, y: -13, width: 0.4 },
+          ],
+          {
+            fill: { type: "base", brightness: 0.5 },
+            anim: {
+              type: "sway",
+              periodMs: 900,
+              amplitude: 3,
+              falloff: "tip",
+              axis: "normal",
+              phase: 0.6,
+            },
+            join: { anchorId: "silverKeeperTail3", targetGroupId: "silverKeeperTail" },
+          },
+          { epsilon: 0.25, winding: "CCW" },
+        ),
+        // Tail sprout 3 — right
+        ...mapLineToPolygonShape<
+          Omit<EnemyRendererLayerConfig, "shape" | "vertices">
+        >(
+          [
+            { x: 0, y: 0, width: 1.4 },
+            { x: -7, y: 4, width: 1.3 },
+            { x: -11, y: 9, width: 0.8 },
+            { x: -14, y: 13, width: 0.4 },
+          ],
+          {
+            fill: { type: "base", brightness: 0.5 },
+            anim: {
+              type: "sway",
+              periodMs: 900,
+              amplitude: 3,
+              falloff: "tip",
+              axis: "normal",
+              phase: 1.1,
+            },
+            join: { anchorId: "silverKeeperTail3", targetGroupId: "silverKeeperTail" },
+          },
+          { epsilon: 0.25, winding: "CCW" },
+        ),
+        
+      ],
+    },
+    maxHp: 12500,
+    armor: 1000,
+    baseDamage: 0,
+    attackInterval: 1.8,
+    attackRange: 280,
+    moveSpeed: 60,
+    physicalSize: 30,
+    reward: {
+      silver: 10,
+    },
+    arcAttack: {
+      arcType: "silverKeeper",
+      spawnOffset: { x: 20, y: 0 },
+      chainRadius: 150,
+      chainJumps: 3,
+      damage: 750,
+      damageOptions: {
+        rewardMultiplier: 1.0,
+        armorPenetration: 0,
+        skipKnockback: true,
+      },
+    },
+    emitter: {
+      particlesPerSecond: 90,
+      particleLifetimeMs: 750,
+      fadeStartMs: 200,
+      baseSpeed: 0.05,
+      speedVariation: 0.01,
+      sizeRange: { min: 14.2, max: 28.4 },
+      sizeEvolutionMult: 1.75, // Particles grow from 1x to 1.25x size over lifetime
+      spread: Math.PI / 5.5,
+      offset: { x: -0.75, y: 0 },
+      color: { r: 0.2, g: 0.85, b: 0.95, a: 0.4 },
+      fill: {
+        fillType: FILL_TYPES.RADIAL_GRADIENT,
+        start: { x: 0, y: 0 },
+        stops: [
+          { offset: 0, color: { r: 1, g: 0.75, b: 1, a: 0.1 } },
+          { offset: 0.25, color: { r: 1, g: 0.75, b: 1, a: 0.05 } },
+          { offset: 1, color: { r: 1, g: 0.75, b: 1, a: 0 } },
         ],
         noise: {
           colorAmplitude: 0.0,
@@ -1939,31 +2288,85 @@ const ENEMIES_DB: Record<EnemyType, EnemyConfig> = {
   portalSpawnerEnemy: {
     name: "Portal Spawner",
     renderer: {
-      kind: "polygon",
-      fill: { r: 0.4, g: 0.6, b: 0.95, a: 0.9 },
-      stroke: {
-        color: { r: 0.6, g: 0.8, b: 1, a: 1 },
-        width: 2,
-      },
-      vertices: PORTAL_SPAWNER_VERTICES,
+      kind: "composite",
+      fill: { r: 0.65, g: 0.6, b: 0.7, a: 1 },
+      layers: [
+        {
+          shape: "circle",
+          radius: 47,
+          fill: {
+            type: "gradient",
+            fill: {
+              fillType: FILL_TYPES.RADIAL_GRADIENT,
+              stops: [
+                { offset: 0, color: { r: 0.84, g: 0.76, b: 0.95, a: 0.1 } },
+                { offset: 0.75, color: { r: 0.84, g: 0.76, b: 0.95, a: 0.9 } },
+                { offset: 1, color: { r: 0.84, g: 0.76, b: 0.95, a: 0 } },
+              ],
+            }
+          }
+        },
+        ...mapLineToPolygonShape<
+          Omit<EnemyRendererLayerConfig, "shape" | "vertices">
+        >(
+          [
+            { x: 0, y: -44.8, width: 10 },
+            { x: 38.8, y: -22.4, width: 10 },
+            { x: 38.8, y: 22.4, width: 10 },
+            { x: 0, y: 44.8, width: 10 },
+            { x: -38.8, y: 22.4, width: 10 },
+            { x: -38.8, y: -22.4, width: 10 },
+            { x: 0, y: -44.8, width: 10 },
+          ],          
+          {
+            fill: { type: "base", brightness: 0.1 },
+          },
+          { epsilon: 0.25, winding: "CCW" }
+        ),
+      ],
     },
-    maxHp: 500,
-    armor: 5,
+    maxHp: 50000,
+    armor: 5000,
     baseDamage: 0,
     attackInterval: 9999,
     attackRange: 0,
     moveSpeed: 0,
     physicalSize: 32,
+    lockRotation: true,
     requireDestruction: true,
     spawner: {
       spawnRate: 0.2,
       enemyTypes: [
         {
-          type: "basicEnemy",
+          type: "silverKeeperEnemy",
           weight: 1,
         },
       ],
-      maxConcurrent: 6,
+      maxConcurrent: 3,
+    },
+    reward: normalizeResourceAmount({
+      silver: 150,
+    }),
+    emitter: {
+      color: { r: 0.9, g: 0.6, b: 0.9, a: 0.9 },
+      particlesPerSecond: 190,
+      particleLifetimeMs: 450,
+      fadeStartMs: 200,
+      baseSpeed: 0.12,
+      speedVariation: 0.01,
+      sizeRange: { min: 5, max: 15 },
+      sizeEvolutionMult: 1.0, // Particles grow from 1x to 1.25x size over lifetime
+      shape: "circle",
+      maxParticles: 1000,
+      spread: Math.PI * 2,
+      fill: {
+        fillType: FILL_TYPES.RADIAL_GRADIENT,
+        stops: [
+          { offset: 0, color: { r: 0.9, g: 0.8, b: 0.9, a: 0.4 } },
+          { offset: 0.25, color: { r: 0.9, g: 0.8, b: 0.9, a: 0.15 } },
+          { offset: 1, color: { r: 0.9, g: 0.8, b: 0.9, a: 0 } },
+        ],
+      },
     },
   },
 };

--- a/src/db/maps/map-definitions/portalRing.ts
+++ b/src/db/maps/map-definitions/portalRing.ts
@@ -7,11 +7,11 @@ const mapConfig = (() => {
   const spawnPoint: SceneVector2 = { x: center.x - 650, y: center.y };
   const levelOffset = 0;
   const portalOffsets: SceneVector2[] = [
-    { x: -180, y: -120 },
-    { x: 180, y: -120 },
-    { x: -180, y: 120 },
-    { x: 180, y: 120 },
-    { x: 0, y: 0 },
+    { x: 0, y: -400 },        // top
+    { x: 380.4, y: -123.6 },  // top-right
+    { x: 235.1, y: 323.6 },   // bottom-right
+    { x: -235.1, y: 323.6 },  // bottom-left
+    { x: -380.4, y: -123.6 }, // top-left
   ];
 
   return {

--- a/src/db/maps/map-definitions/portalRing.ts
+++ b/src/db/maps/map-definitions/portalRing.ts
@@ -1,0 +1,52 @@
+import type { SceneSize, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { MapConfig } from "../maps-db.types";
+
+const mapConfig = (() => {
+  const size: SceneSize = { width: 1500, height: 1500 };
+  const center: SceneVector2 = { x: size.width / 2, y: size.height / 2 };
+  const spawnPoint: SceneVector2 = { x: center.x - 650, y: center.y };
+  const levelOffset = 0;
+  const portalOffsets: SceneVector2[] = [
+    { x: -180, y: -120 },
+    { x: 180, y: -120 },
+    { x: -180, y: 120 },
+    { x: 180, y: 120 },
+    { x: 0, y: 0 },
+  ];
+
+  return {
+    name: "Portal Ring",
+    size,
+    spawnPoints: [spawnPoint],
+    nodePosition: { x: 5, y: 0 },
+    bricks: () => [],
+    enemies: ({ mapLevel }) => {
+      const level = Math.max(1, Math.floor(mapLevel + levelOffset));
+      return portalOffsets.map((offset) => ({
+        type: "portalSpawnerEnemy",
+        level,
+        position: {
+          x: center.x + offset.x,
+          y: center.y + offset.y,
+        },
+      }));
+    },
+    playerUnits: [
+      {
+        type: "bluePentagon",
+        position: { ...spawnPoint },
+      },
+    ],
+    unlockedBy: [
+      {
+        type: "map",
+        id: "silverRing",
+        level: 1,
+      },
+    ],
+    mapsRequired: { silverRing: 1 },
+    maxLevel: 1,
+  } satisfies MapConfig;
+})();
+
+export default mapConfig;

--- a/src/db/maps/maps-db.ts
+++ b/src/db/maps/maps-db.ts
@@ -15,6 +15,7 @@ import initial from "./map-definitions/initial";
 import megaBrick from "./map-definitions/megaBrick";
 import mine from "./map-definitions/mine";
 import oldForge from "./map-definitions/oldForge";
+import portalRing from "./map-definitions/portalRing";
 import silverRing from "./map-definitions/silverRing";
 import sphinx from "./map-definitions/sphinx";
 import spruce from "./map-definitions/spruce";
@@ -59,6 +60,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
   mine,
   adit,
   silverRing,
+  portalRing,
   frozenForest,
   volcano,
   gear,

--- a/src/db/maps/maps-db.types.ts
+++ b/src/db/maps/maps-db.types.ts
@@ -27,6 +27,7 @@ export type MapId =
   | "mine"
   | "adit"
   | "silverRing"
+  | "portalRing"
   | "frozenForest"
   | "volcano"
   | "megaBrick"

--- a/src/logic/modules/active-map/bricks/bricks.module.ts
+++ b/src/logic/modules/active-map/bricks/bricks.module.ts
@@ -194,6 +194,13 @@ export class BricksModule implements GameModule {
     return this.cloneState(state);
   }
 
+  public getBrickTotals(): { count: number; totalHp: number } {
+    return {
+      count: this.bricks.size,
+      totalHp: Math.max(0, this.totalHpCached),
+    };
+  }
+
   public getBrickPositionIfAlive(brickId: string): SceneVector2 | null {
     const state = this.bricks.get(brickId);
     if (!state) {
@@ -491,9 +498,6 @@ export class BricksModule implements GameModule {
     this.bricksWithKnockback.delete(brick.id);
     this.totalHpCached -= brick.hp;
     this.pushStats();
-    if (this.bricks.size === 0) {
-      this.runState.complete(true);
-    }
   }
 
   private applyEffectDamage(

--- a/src/logic/modules/active-map/chain-lightning.helpers.ts
+++ b/src/logic/modules/active-map/chain-lightning.helpers.ts
@@ -6,9 +6,11 @@ import type { ArcType } from "../../../db/arcs-db";
 import type { ExplosionType } from "../../../db/explosions-db";
 import { subtractVectors, vectorHasLength } from "@/shared/helpers/vector.helper";
 
+export type ChainLightningTargetType = "brick" | "enemy" | "unit";
+
 export interface ChainLightningTarget {
   id: string;
-  type: "brick" | "enemy";
+  type: ChainLightningTargetType;
   position: SceneVector2;
 }
 
@@ -49,12 +51,14 @@ export interface ChainLightningOptions {
   dependencies: ChainLightningDependencies;
   arcType?: ArcType;
   explosionType?: ExplosionType;
+  /** Target types to chain to (default ["brick", "enemy"]; use ["unit"] for enemy→unit chain). */
+  chainTargetTypes?: readonly ChainLightningTargetType[];
 }
 
-const isChainTarget = (
-  candidate: TargetSnapshot,
-): candidate is TargetSnapshot<"brick" | "enemy"> =>
-  candidate.type === "brick" || candidate.type === "enemy";
+const DEFAULT_CHAIN_TARGET_TYPES: readonly ChainLightningTargetType[] = [
+  "brick",
+  "enemy",
+];
 
 export const executeChainLightning = ({
   startTarget,
@@ -65,6 +69,7 @@ export const executeChainLightning = ({
   dependencies,
   arcType,
   explosionType,
+  chainTargetTypes = DEFAULT_CHAIN_TARGET_TYPES,
 }: ChainLightningOptions): boolean => {
   if (chainRadius <= 0 || chainJumps <= 0 || damage <= 0) {
     return false;
@@ -73,16 +78,17 @@ export const executeChainLightning = ({
     return false;
   }
 
+  const allowedTypes: readonly string[] = chainTargetTypes;
   let currentTarget = startTarget;
   const visited = new Set<string>([`${startTarget.type}:${startTarget.id}`]);
   let chained = false;
 
   for (let i = 0; i < chainJumps; i += 1) {
     const candidates = dependencies
-      .getTargetsInRadius(currentTarget.position, chainRadius, ["brick", "enemy"])
-      .filter((candidate): candidate is TargetSnapshot<"brick" | "enemy"> => {
+      .getTargetsInRadius(currentTarget.position, chainRadius, [...chainTargetTypes])
+      .filter((candidate): candidate is TargetSnapshot<ChainLightningTargetType> => {
         const key = `${candidate.type}:${candidate.id}`;
-        return !visited.has(key) && isChainTarget(candidate);
+        return !visited.has(key) && allowedTypes.includes(candidate.type);
       });
 
     if (candidates.length === 0) {
@@ -107,11 +113,13 @@ export const executeChainLightning = ({
       dependencies.applyBrickDamage?.(nextTarget.id, damage, resolvedOptions);
     }
 
+    const sourceRef = { type: currentTarget.type, id: currentTarget.id };
+    const targetRef = { type: nextTarget.type, id: nextTarget.id };
     if (dependencies.spawnArcBetweenTargets && arcType) {
       dependencies.spawnArcBetweenTargets(
         arcType,
-        { type: currentTarget.type, id: currentTarget.id },
-        { type: nextTarget.type, id: nextTarget.id },
+        sourceRef,
+        targetRef,
         {
           persistOnDeath: true,
           sourcePosition: currentTarget.position,

--- a/src/logic/modules/active-map/enemies/enemies.module.ts
+++ b/src/logic/modules/active-map/enemies/enemies.module.ts
@@ -65,6 +65,7 @@ import type { StatusEffectsModule } from "../status-effects/status-effects.modul
 import type { ArcModule } from "../../scene/arc/arc.module";
 import type { BonusesModule } from "../../shared/bonuses/bonuses.module";
 import { EnemySpawnSourceController } from "./enemy-spawn-source-controller";
+import { executeChainLightning } from "../chain-lightning.helpers";
 
 const ENEMY_PASSABILITY: PassabilityTag = "enemy";
 const ENEMY_COLLISION_RESOLUTION_ITERATIONS = 4;
@@ -271,22 +272,25 @@ export class EnemiesModule implements GameModule {
         anyChanged = true;
       }
 
-      // Update rotation based on movement direction or target direction
       const target = activeTargets.get(enemy.id);
-      const desiredRotation = this.computeEnemyRotation(
-        enemy,
-        target ?? null,
-        resolvedMovementState,
-      );
-      const newRotation = this.applyRotationSpeedLimit(
-        enemy.rotation,
-        desiredRotation,
-        deltaSeconds,
-        resolvedMovementState.velocity,
-      );
-      if (newRotation !== enemy.rotation) {
-        enemy.rotation = newRotation;
-        anyChanged = true;
+
+      // Update rotation based on movement direction or target direction (skip if locked)
+      if (!enemy.lockRotation) {
+        const desiredRotation = this.computeEnemyRotation(
+          enemy,
+          target ?? null,
+          resolvedMovementState,
+        );
+        const newRotation = this.applyRotationSpeedLimit(
+          enemy.rotation,
+          desiredRotation,
+          deltaSeconds,
+          resolvedMovementState.velocity,
+        );
+        if (newRotation !== enemy.rotation) {
+          enemy.rotation = newRotation;
+          anyChanged = true;
+        }
       }
 
       const knockbackOffset = this.updateEnemyKnockback(enemy, deltaMs);
@@ -777,12 +781,29 @@ export class EnemiesModule implements GameModule {
 
     if (config.arcAttack) {
       const arcAttack = config.arcAttack;
+      const isChain =
+        (arcAttack.chainRadius ?? 0) > 0 &&
+        (arcAttack.chainJumps ?? 0) > 0;
+      const chainDamage = arcAttack.damage ?? enemy.baseDamage;
+
+      // Rotate spawnOffset by the enemy's current rotation so it stays
+      // relative to the enemy's facing direction instead of world-space.
+      let rotatedOffset = arcAttack.spawnOffset;
+      if (rotatedOffset && (rotatedOffset.x !== 0 || rotatedOffset.y !== 0)) {
+        const cos = Math.cos(enemy.rotation);
+        const sin = Math.sin(enemy.rotation);
+        rotatedOffset = {
+          x: rotatedOffset.x * cos - rotatedOffset.y * sin,
+          y: rotatedOffset.x * sin + rotatedOffset.y * cos,
+        };
+      }
+
       this.arcs?.spawnArcBetweenTargets(
         arcAttack.arcType,
         { type: "enemy", id: enemy.id },
         { type: "unit", id: target.id },
-        { 
-          sourceOffset: arcAttack.spawnOffset,
+        {
+          sourceOffset: rotatedOffset,
           persistOnDeath: true,
         },
       );
@@ -798,17 +819,40 @@ export class EnemiesModule implements GameModule {
           );
         }
       }
-      if (this.damage && enemy.baseDamage > 0) {
-        const knockBackDirection = toTarget;
-        this.damage.applyTargetDamage(target.id, enemy.baseDamage, {
-          armorPenetration: 0,
-          knockBackDistance: config.knockBackDistance,
-          knockBackSpeed: config.knockBackSpeed,
-          knockBackDirection:
-            vectorLength(knockBackDirection) > 0
-              ? knockBackDirection
-              : normalizeVector(toTarget) || { x: 1, y: 0 },
-        });
+      if (this.damage && chainDamage > 0) {
+        const knockBackDirection =
+          vectorLength(toTarget) > 0
+            ? toTarget
+            : normalizeVector(toTarget) || { x: 1, y: 0 };
+        if (isChain) {
+          this.damage.applyTargetDamage(target.id, chainDamage, {
+            ...arcAttack.damageOptions,
+            knockBackDirection,
+          });
+          executeChainLightning({
+            startTarget: { id: target.id, type: "unit", position: target.position },
+            chainRadius: arcAttack.chainRadius!,
+            chainJumps: arcAttack.chainJumps!,
+            damage: chainDamage,
+            damageOptions: arcAttack.damageOptions,
+            dependencies: {
+              getTargetsInRadius: (position, radius, types) =>
+                this.targeting?.findTargetsNear(position, radius, types?.length ? { types: [...types] } : undefined) ?? [],
+              applyTargetDamage: (targetId, damageValue, options) =>
+                this.damage!.applyTargetDamage(targetId, damageValue, options ?? {}),
+              spawnArcBetweenTargets: this.arcs?.spawnArcBetweenTargets?.bind(this.arcs),
+            },
+            arcType: arcAttack.arcType,
+            chainTargetTypes: ["unit"],
+          });
+        } else {
+          this.damage.applyTargetDamage(target.id, enemy.baseDamage, {
+            armorPenetration: 0,
+            knockBackDistance: config.knockBackDistance,
+            knockBackSpeed: config.knockBackSpeed,
+            knockBackDirection,
+          });
+        }
       }
       // Spawn explosion at target position if configured
       if (arcAttack.explosionType && this.explosions) {
@@ -1202,16 +1246,22 @@ export class EnemiesModule implements GameModule {
       return ZERO_VECTOR;
     }
 
-    // Desired speed - slow down as we approach
+    // Desired speed - slow down as we approach.
+    // desiredSpeed drops linearly from moveSpeed down to 0 as we reach the
+    // attack range boundary.  With the proportional steering controller the
+    // effective stopping distance from speed v ≈ v * mass, so we scale the
+    // ramp by 1/mass so the enemy starts decelerating early enough.
     const approachDistance = Math.min(
       distanceOutsideRange,
       distanceToDestination,
     );
     const moveSpeed = this.getEffectiveMoveSpeed(enemy);
-    const desiredSpeed = Math.max(
-      Math.min(moveSpeed, approachDistance),
-      moveSpeed * 0.25,
-    );
+    const mass = this.getEnemyMass(enemy);
+    const rampDistance = moveSpeed * mass; // distance needed to stop from full speed
+    const speedRatio = rampDistance > 0
+      ? Math.min(approachDistance / rampDistance, 1)
+      : 1;
+    const desiredSpeed = moveSpeed * speedRatio;
     let desiredVelocity = scaleVector(direction, desiredSpeed);
 
     const avoidance = this.computeObstacleAvoidance(enemy, desiredVelocity);
@@ -1642,6 +1692,7 @@ export class EnemiesModule implements GameModule {
       attackRange: enemy.attackRange,
       moveSpeed: enemy.moveSpeed,
       physicalSize: enemy.physicalSize,
+      lockRotation: enemy.lockRotation,
       selfKnockBackDistance: enemy.selfKnockBackDistance,
       selfKnockBackSpeed: enemy.selfKnockBackSpeed,
       reward: enemy.reward

--- a/src/logic/modules/active-map/enemies/enemies.module.ts
+++ b/src/logic/modules/active-map/enemies/enemies.module.ts
@@ -42,7 +42,7 @@ import type {
   EnemySpawnData,
   InternalEnemyState,
 } from "./enemies.types";
-import { scaleEnemyResourceStockpile } from "./enemies.helpers";
+import { sanitizeEnemyLevel, scaleEnemyResourceStockpile } from "./enemies.helpers";
 import { EnemyTargetingProvider } from "./enemies.targeting-provider";
 import type { ExplosionModule } from "../../scene/explosion/explosion.module";
 import { getEnemyConfig, type EnemyConfig } from "../../../../db/enemies-db";
@@ -64,6 +64,7 @@ import { BrickObstacleProvider } from "./brick-obstacle-provider";
 import type { StatusEffectsModule } from "../status-effects/status-effects.module";
 import type { ArcModule } from "../../scene/arc/arc.module";
 import type { BonusesModule } from "../../shared/bonuses/bonuses.module";
+import { EnemySpawnSourceController } from "./enemy-spawn-source-controller";
 
 const ENEMY_PASSABILITY: PassabilityTag = "enemy";
 const ENEMY_COLLISION_RESOLUTION_ITERATIONS = 4;
@@ -110,6 +111,7 @@ export class EnemiesModule implements GameModule {
     ENEMY_SPATIAL_GRID_CELL_SIZE,
   );
   private readonly statusEffects: StatusEffectsModule;
+  private readonly spawnSourceController = new EnemySpawnSourceController();
 
   private enemies = new Map<string, InternalEnemyState>();
   private enemyOrder: InternalEnemyState[] = [];
@@ -117,6 +119,7 @@ export class EnemiesModule implements GameModule {
   private totalHpCached = 0;
   private lastPushedCount = -1;
   private lastPushedTotalHp = -1;
+  private spawnerTimers = new Map<string, number>();
 
   constructor(options: EnemiesModuleOptions) {
     this.scene = options.scene;
@@ -327,6 +330,10 @@ export class EnemiesModule implements GameModule {
       this.trackNavigationProgress(enemy, deltaSeconds);
     });
 
+    const spawns: EnemySpawnData[] = [];
+    this.collectSpawnerSpawns(deltaMs, spawns);
+    spawns.forEach((spawn) => this.spawnEnemy(spawn));
+
     if (anyChanged) {
       this.pushStats();
     }
@@ -369,6 +376,20 @@ export class EnemiesModule implements GameModule {
     }
     return { ...enemy.position };
   };
+
+  public getObjectiveTotals(): { count: number; totalHp: number } {
+    let count = 0;
+    let totalHp = 0;
+    this.enemyOrder.forEach((enemy) => {
+      const config = getEnemyConfig(enemy.type);
+      if (!config.requireDestruction || enemy.hp <= 0) {
+        return;
+      }
+      count += 1;
+      totalHp += Math.max(enemy.hp, 0);
+    });
+    return { count, totalHp };
+  }
 
   public findNearestEnemy(position: SceneVector2): EnemyRuntimeState | null {
     const nearest = this.spatialIndex.queryNearest(position, {
@@ -474,6 +495,7 @@ export class EnemiesModule implements GameModule {
     this.totalHpCached = 0;
     this.lastPushedCount = -1;
     this.lastPushedTotalHp = -1;
+    this.spawnerTimers.clear();
 
     enemies.forEach((enemy) => {
       const input: EnemyStateInput = {
@@ -506,6 +528,7 @@ export class EnemiesModule implements GameModule {
   }
 
   private destroyEnemy(enemy: InternalEnemyState, rewardMultiplier = 1): void {
+    this.spawnerTimers.delete(enemy.id);
     if (enemy.reward && hasAnyResources(enemy.reward)) {
       let rewards = this.applyEnemyRewardBonuses(enemy.reward);
       const multiplier = Math.max(rewardMultiplier, 0);
@@ -1546,6 +1569,63 @@ export class EnemiesModule implements GameModule {
     }
   }
 
+  private collectSpawnerSpawns(deltaMs: number, queue: EnemySpawnData[]): void {
+    if (deltaMs <= 0) {
+      return;
+    }
+    const currentEnemies = [...this.enemyOrder];
+    currentEnemies.forEach((enemy) => {
+      if (enemy.hp <= 0) {
+        return;
+      }
+      const config = getEnemyConfig(enemy.type);
+      const spawner = config.spawner;
+      if (!spawner || spawner.spawnRate <= 0) {
+        return;
+      }
+      const timer = this.spawnerTimers.get(enemy.id) ?? 0;
+      const nextTimer = timer - deltaMs;
+      if (nextTimer > 0) {
+        this.spawnerTimers.set(enemy.id, nextTimer);
+        return;
+      }
+      if (!this.canSpawnFromSpawner(enemy.id, spawner.maxConcurrent)) {
+        const intervalMs = this.spawnSourceController.getSpawnIntervalMs(spawner.spawnRate);
+        this.spawnerTimers.set(enemy.id, intervalMs);
+        return;
+      }
+      const selectedType = this.spawnSourceController.selectEnemyType(
+        spawner.enemyTypes,
+        enemy.level,
+      );
+      if (selectedType) {
+        const levelOffset = spawner.levelOffset ?? 0;
+        const spawnLevel = sanitizeEnemyLevel(enemy.level + levelOffset);
+        queue.push({
+          type: selectedType,
+          level: spawnLevel,
+          position: { ...enemy.position },
+          spawnSourceId: enemy.id,
+        });
+      }
+      const intervalMs = this.spawnSourceController.getSpawnIntervalMs(spawner.spawnRate);
+      this.spawnerTimers.set(enemy.id, intervalMs);
+    });
+  }
+
+  private canSpawnFromSpawner(sourceId: string, maxConcurrent?: number): boolean {
+    if (maxConcurrent === undefined) {
+      return true;
+    }
+    let count = 0;
+    this.enemyOrder.forEach((enemy) => {
+      if (enemy.spawnSourceId === sourceId && enemy.hp > 0) {
+        count += 1;
+      }
+    });
+    return count < maxConcurrent;
+  }
+
   private cloneState(enemy: InternalEnemyState): EnemyRuntimeState {
     return {
       id: enemy.id,
@@ -1567,6 +1647,7 @@ export class EnemiesModule implements GameModule {
       reward: enemy.reward
         ? cloneResourceStockpile(normalizeResourceAmount(enemy.reward))
         : undefined,
+      spawnSourceId: enemy.spawnSourceId,
     };
   }
 }

--- a/src/logic/modules/active-map/enemies/enemies.spawn-controller.ts
+++ b/src/logic/modules/active-map/enemies/enemies.spawn-controller.ts
@@ -1,13 +1,14 @@
 import type { SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
-import type { MapEnemySpawnPointConfig, MapEnemySpawnTypeConfig } from "../../../../db/maps/maps-db";
-import type { EnemyType } from "../../../../db/enemies-db";
+import type { MapEnemySpawnPointConfig } from "../../../../db/maps/maps-db";
 import type { EnemiesModule } from "./enemies.module";
 import type { EnemySpawnData } from "./enemies.types";
 import { sanitizeEnemyLevel } from "./enemies.helpers";
 import { clampNumber } from "@shared/helpers/numbers.helper";
+import { EnemySpawnSourceController } from "./enemy-spawn-source-controller";
 
 export class EnemySpawnController {
   private spawnTimers = new Map<string, number>(); // spawnPoint index -> time until next spawn
+  private spawnSource = new EnemySpawnSourceController();
 
   /**
    * Updates spawn timers and spawns enemies if needed
@@ -36,7 +37,7 @@ export class EnemySpawnController {
 
       if (newTimer <= 0) {
         this.trySpawnEnemy(spawnPoint, enemiesModule, mapLevel, index.toString());
-        const spawnIntervalMs = (1 / spawnPoint.spawnRate) * 1000;
+        const spawnIntervalMs = this.spawnSource.getSpawnIntervalMs(spawnPoint.spawnRate);
         this.spawnTimers.set(index.toString(), spawnIntervalMs);
       } else {
         this.spawnTimers.set(index.toString(), newTimer);
@@ -75,7 +76,7 @@ export class EnemySpawnController {
     }
 
     // Select enemy type based on weights and level constraints
-    const selectedType = this.selectEnemyType(spawnPoint.enemyTypes, mapLevel);
+    const selectedType = this.spawnSource.selectEnemyType(spawnPoint.enemyTypes, mapLevel);
     if (!selectedType) {
       return; // No valid enemy type for current level
     }
@@ -93,46 +94,5 @@ export class EnemySpawnController {
 
     // Spawn the enemy
     enemiesModule.spawnEnemy(spawnData);
-  }
-
-  /**
-   * Selects an enemy type based on weights and level constraints
-   */
-  private selectEnemyType(
-    enemyTypes: readonly MapEnemySpawnTypeConfig[],
-    mapLevel: number
-  ): EnemyType | null {
-    // Filter by level constraints
-    const validTypes = enemyTypes.filter((config) => {
-      if (config.minLevel !== undefined && mapLevel < config.minLevel) {
-        return false;
-      }
-      if (config.maxLevel !== undefined && mapLevel > config.maxLevel) {
-        return false;
-      }
-      return true;
-    });
-
-    if (validTypes.length === 0) {
-      return null;
-    }
-
-    // Calculate total weight
-    const totalWeight = validTypes.reduce((sum, config) => sum + Math.max(config.weight, 0), 0);
-    if (totalWeight <= 0) {
-      return validTypes[0]?.type ?? null;
-    }
-
-    // Select based on weighted random
-    let random = Math.random() * totalWeight;
-    for (const config of validTypes) {
-      random -= Math.max(config.weight, 0);
-      if (random <= 0) {
-        return config.type;
-      }
-    }
-
-    // Fallback to last type
-    return validTypes[validTypes.length - 1]?.type ?? null;
   }
 }

--- a/src/logic/modules/active-map/enemies/enemies.state-factory.ts
+++ b/src/logic/modules/active-map/enemies/enemies.state-factory.ts
@@ -51,6 +51,7 @@ export class EnemyStateFactory extends StateFactory<InternalEnemyState, EnemySta
     
     const position = clampToMap(enemy.position);
     const rotation = sanitizeRotation(enemy.rotation ?? 0);
+    const spawnSourceId = enemy.spawnSourceId;
 
     const maxHp = stats.maxHp;
     const hp = clampNumber(enemy.hp ?? maxHp, 0, maxHp);
@@ -127,6 +128,7 @@ export class EnemyStateFactory extends StateFactory<InternalEnemyState, EnemySta
       selfKnockBackDistance,
       selfKnockBackSpeed,
       reward: stats.rewards,
+      spawnSourceId,
       fill,
       stroke,
       movementId,

--- a/src/logic/modules/active-map/enemies/enemies.state-factory.ts
+++ b/src/logic/modules/active-map/enemies/enemies.state-factory.ts
@@ -62,6 +62,7 @@ export class EnemyStateFactory extends StateFactory<InternalEnemyState, EnemySta
     const attackRange = clampNumber(config.attackRange ?? 240, 0, Number.POSITIVE_INFINITY);
     const moveSpeed = clampNumber(config.moveSpeed, 0, Number.POSITIVE_INFINITY);
     const physicalSize = clampNumber(config.physicalSize, 0, Number.POSITIVE_INFINITY);
+    const lockRotation = Boolean(config.lockRotation);
     const DEFAULT_SELF_KNOCKBACK_DISTANCE = 6;
     const DEFAULT_SELF_KNOCKBACK_SPEED = 30;
     const selfKnockBackDistance = clampNumber(
@@ -125,6 +126,7 @@ export class EnemyStateFactory extends StateFactory<InternalEnemyState, EnemySta
       attackSeriesState: undefined,
       moveSpeed,
       physicalSize,
+      lockRotation,
       selfKnockBackDistance,
       selfKnockBackSpeed,
       reward: stats.rewards,

--- a/src/logic/modules/active-map/enemies/enemies.targeting-provider.ts
+++ b/src/logic/modules/active-map/enemies/enemies.targeting-provider.ts
@@ -43,7 +43,7 @@ export class EnemyTargetingProvider implements TargetingProvider<"enemy", EnemyR
     return {
       id: enemy.id,
       type: "enemy",
-      position: enemy.position,
+      position: { ...enemy.position },
       hp: enemy.hp,
       maxHp: enemy.maxHp,
       armor: enemy.armor,

--- a/src/logic/modules/active-map/enemies/enemies.types.ts
+++ b/src/logic/modules/active-map/enemies/enemies.types.ts
@@ -52,6 +52,7 @@ export interface EnemyRuntimeState {
   attackSeriesState?: AttackSeriesState;
   moveSpeed: number;
   physicalSize: number;
+  lockRotation: boolean;
   selfKnockBackDistance: number;
   selfKnockBackSpeed: number;
   reward?: ResourceStockpile;

--- a/src/logic/modules/active-map/enemies/enemies.types.ts
+++ b/src/logic/modules/active-map/enemies/enemies.types.ts
@@ -33,6 +33,7 @@ export interface EnemySpawnData {
   readonly rotation?: number;
   readonly hp?: number;
   readonly attackCooldown?: number;
+  readonly spawnSourceId?: string;
 }
 
 export interface EnemyRuntimeState {
@@ -54,6 +55,7 @@ export interface EnemyRuntimeState {
   selfKnockBackDistance: number;
   selfKnockBackSpeed: number;
   reward?: ResourceStockpile;
+  spawnSourceId?: string;
 }
 
 export interface EnemyResourceCollector {

--- a/src/logic/modules/active-map/enemies/enemy-spawn-source-controller.ts
+++ b/src/logic/modules/active-map/enemies/enemy-spawn-source-controller.ts
@@ -1,0 +1,49 @@
+import type { MapEnemySpawnTypeConfig } from "../../../../db/maps/maps-db";
+import type { EnemyType } from "../../../../db/enemies-db";
+
+export interface EnemySpawnSourceConfig {
+  readonly spawnRate: number;
+  readonly enemyTypes: readonly MapEnemySpawnTypeConfig[];
+  readonly levelOffset?: number;
+  readonly maxConcurrent?: number;
+}
+
+export class EnemySpawnSourceController {
+  public getSpawnIntervalMs(spawnRate: number): number {
+    return (1 / spawnRate) * 1000;
+  }
+
+  public selectEnemyType(
+    enemyTypes: readonly MapEnemySpawnTypeConfig[],
+    mapLevel: number
+  ): EnemyType | null {
+    const validTypes = enemyTypes.filter((config) => {
+      if (config.minLevel !== undefined && mapLevel < config.minLevel) {
+        return false;
+      }
+      if (config.maxLevel !== undefined && mapLevel > config.maxLevel) {
+        return false;
+      }
+      return true;
+    });
+
+    if (validTypes.length === 0) {
+      return null;
+    }
+
+    const totalWeight = validTypes.reduce((sum, config) => sum + Math.max(config.weight, 0), 0);
+    if (totalWeight <= 0) {
+      return validTypes[0]?.type ?? null;
+    }
+
+    let random = Math.random() * totalWeight;
+    for (const config of validTypes) {
+      random -= Math.max(config.weight, 0);
+      if (random <= 0) {
+        return config.type;
+      }
+    }
+
+    return validTypes[validTypes.length - 1]?.type ?? null;
+  }
+}

--- a/src/logic/modules/active-map/map/map.module.ts
+++ b/src/logic/modules/active-map/map/map.module.ts
@@ -76,6 +76,7 @@ import { isDemoBuild } from "@shared/helpers/demo.helper";
 import { trackAnalyticsEvent } from "@shared/helpers/google-analytics.helper";
 import { calculateBrickStatsForLevel } from "../bricks/bricks.helpers";
 import { calculateEnemyStatsForLevel, sanitizeEnemyLevel } from "../enemies/enemies.helpers";
+import { ObjectiveIntegrityService } from "../objective-integrity/objective-integrity.service";
 
 export class MapModule implements GameModule {
   public readonly id = "maps";
@@ -105,6 +106,7 @@ export class MapModule implements GameModule {
   private mapEffectsLastPublishMs = 0;
   private lastMapEffectsSnapshot: MapEffectsBridgeState | null = null;
   private mapResourcePreviewCache: MapResourcePreviewCache | null = null;
+  private readonly objectiveIntegrity: ObjectiveIntegrityService;
 
   constructor(options: MapModuleOptions) {
     this.options = options;
@@ -113,6 +115,11 @@ export class MapModule implements GameModule {
     this.getSkillLevel = options.getSkillLevel;
     this.newUnlocks = options.newUnlocks;
     this.selection = new MapSelectionState(DEFAULT_MAP_ID);
+    this.objectiveIntegrity = new ObjectiveIntegrityService(
+      options.bridge,
+      options.bricks,
+      options.enemies
+    );
     const mapEffects = new MapEffectsModule({
       playerUnits: options.playerUnits,
       enemies: options.enemies,
@@ -145,6 +152,7 @@ export class MapModule implements GameModule {
     this.pushMapResourcePreviewCache();
     this.pushMapSelectViewTransform();
     this.pushControlHintsState();
+    this.objectiveIntegrity.reset();
     this.resetInspectedTargetState();
     this.resetMapEffectsState();
     this.ensureSelection();
@@ -156,6 +164,7 @@ export class MapModule implements GameModule {
     this.autoRestartEnabled = false;
     this.refreshAutoRestartState();
     this.pushAutoRestartState();
+    this.objectiveIntegrity.reset();
     this.resetInspectedTargetState();
     this.resetMapEffectsState();
     this.ensureSelection();
@@ -214,6 +223,14 @@ export class MapModule implements GameModule {
     this.inspectedTargetElapsedMs += Math.max(deltaMs, 0);
     this.mapEffectsElapsedMs += Math.max(deltaMs, 0);
     this.runLifecycle.tick(deltaMs);
+    const objectiveSnapshot = this.objectiveIntegrity.refresh();
+    if (
+      this.runLifecycle.isRunActive() &&
+      !objectiveSnapshot.bricksRemaining &&
+      !objectiveSnapshot.requiredEnemiesRemaining
+    ) {
+      this.options.runState.complete(true);
+    }
     this.publishInspectedTarget();
     this.publishMapEffects();
     const changed = this.refreshAutoRestartState();
@@ -649,6 +666,7 @@ export class MapModule implements GameModule {
       mapEffects: config.mapEffects ?? [],
       visualEffects: config.visualEffects,
     });
+    this.objectiveIntegrity.refresh();
 
     this.pushSelectedMap();
     this.pushSelectedMapLevel();
@@ -670,6 +688,7 @@ export class MapModule implements GameModule {
     if (event.type === "reset") {
       this.resetInspectedTargetState();
       this.resetMapEffectsState();
+      this.objectiveIntegrity.reset();
       this.sceneCleanup.resetAfterRun();
       return;
     }

--- a/src/logic/modules/active-map/objective-integrity/objective-integrity.const.ts
+++ b/src/logic/modules/active-map/objective-integrity/objective-integrity.const.ts
@@ -1,0 +1,1 @@
+export const OBJECTIVE_TOTAL_HP_BRIDGE_KEY = "objectives/totalHp" as const;

--- a/src/logic/modules/active-map/objective-integrity/objective-integrity.service.ts
+++ b/src/logic/modules/active-map/objective-integrity/objective-integrity.service.ts
@@ -1,0 +1,42 @@
+import type { DataBridge } from "@/core/logic/ui/DataBridge";
+import { DataBridgeHelpers } from "@/core/logic/ui/DataBridgeHelpers";
+import type { BricksModule } from "../bricks/bricks.module";
+import type { EnemiesModule } from "../enemies/enemies.module";
+import { OBJECTIVE_TOTAL_HP_BRIDGE_KEY } from "./objective-integrity.const";
+
+export interface ObjectiveIntegritySnapshot {
+  readonly totalHp: number;
+  readonly bricksRemaining: boolean;
+  readonly requiredEnemiesRemaining: boolean;
+}
+
+export class ObjectiveIntegrityService {
+  private lastPushedTotalHp = -1;
+
+  constructor(
+    private readonly bridge: DataBridge,
+    private readonly bricks: BricksModule,
+    private readonly enemies: EnemiesModule,
+  ) {}
+
+  public reset(): void {
+    this.lastPushedTotalHp = -1;
+    DataBridgeHelpers.pushState(this.bridge, OBJECTIVE_TOTAL_HP_BRIDGE_KEY, 0);
+  }
+
+  public refresh(): ObjectiveIntegritySnapshot {
+    const brickTotals = this.bricks.getBrickTotals();
+    const enemyTotals = this.enemies.getObjectiveTotals();
+    const totalHp = Math.max(0, brickTotals.totalHp + enemyTotals.totalHp);
+    const clampedTotalHp = Math.max(0, Math.floor(totalHp));
+    if (clampedTotalHp !== this.lastPushedTotalHp) {
+      DataBridgeHelpers.pushState(this.bridge, OBJECTIVE_TOTAL_HP_BRIDGE_KEY, clampedTotalHp);
+      this.lastPushedTotalHp = clampedTotalHp;
+    }
+    return {
+      totalHp,
+      bricksRemaining: brickTotals.count > 0,
+      requiredEnemiesRemaining: enemyTotals.count > 0,
+    };
+  }
+}

--- a/src/logic/modules/active-map/player-units/abilities/implementations/ChainLightningAbility.ts
+++ b/src/logic/modules/active-map/player-units/abilities/implementations/ChainLightningAbility.ts
@@ -45,7 +45,7 @@ const evaluateChainLightning = (
   if (context.event !== "hit") {
     return null;
   }
-  if (context.targetType !== "brick" || !context.targetId || !context.targetPosition) {
+  if ((context.targetType !== "brick" && context.targetType !== "enemy") || !context.targetId || !context.targetPosition) {
     return null;
   }
 
@@ -76,7 +76,7 @@ const evaluateChainLightning = (
     priority: 1,
     target: {
       id: context.targetId,
-      type: "brick",
+      type: context.targetType as "brick" | "enemy",
       position: context.targetPosition,
     },
   };
@@ -86,9 +86,6 @@ const executeChainLightningAbility = (
   context: AbilityExecutionContext<ChainLightningState, ChainLightningTarget>,
 ): AbilityExecutionResult => {
   const { unit, state, dependencies, services, target } = context;
-  if (target.type !== "brick") {
-    return { success: false };
-  }
 
   const chainDamage = Math.max(unit.baseAttackDamage, 0) * Math.max(state.damagePercent, 0);
   if (chainDamage <= 0 || state.chainRadius <= 0 || state.chainJumps <= 0) {

--- a/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
+++ b/src/ui/renderers/objects/implementations/enemy/composite-primitives.helpers.ts
@@ -78,7 +78,9 @@ export const createCompositePrimitives = (
   };
   const joinTargets = new Set<string>();
   renderer.layers.forEach((layer) => {
-    if (layer.join && !supportsGpuJoin(layer)) {
+    if (layer.join && (!supportsGpuJoin(layer) || layer.anim)) {
+      // Animated layers can't use GPU join (canUseGpuJoin requires !layer.anim),
+      // so their parent group must write CPU anchors.
       joinTargets.add(normalizeGroupId(layer.join.targetGroupId));
     }
   });

--- a/src/ui/screens/Scene/components/toolbar/SceneToolbar.tsx
+++ b/src/ui/screens/Scene/components/toolbar/SceneToolbar.tsx
@@ -4,7 +4,7 @@ import { Button } from "@ui-shared/Button";
 import { ProgressBar } from "@ui-shared/ProgressBar";
 import { formatNumber } from "@ui-shared/format/number";
 import { useBridgeValue } from "@ui-shared/useBridgeValue";
-import { BRICK_TOTAL_HP_BRIDGE_KEY } from "@logic/modules/active-map/bricks/bricks.const";
+import { OBJECTIVE_TOTAL_HP_BRIDGE_KEY } from "@logic/modules/active-map/objective-integrity/objective-integrity.const";
 import {
   PLAYER_UNIT_COUNT_BRIDGE_KEY,
   PLAYER_UNIT_TOTAL_HP_BRIDGE_KEY,
@@ -31,7 +31,7 @@ export const SceneToolbar: React.FC<SceneToolbarProps> = ({
   onScaleChange,
   cameraPosition,
 }) => {
-  const brickTotalHp = useBridgeValue(bridge, BRICK_TOTAL_HP_BRIDGE_KEY, 0);
+  const brickTotalHp = useBridgeValue(bridge, OBJECTIVE_TOTAL_HP_BRIDGE_KEY, 0);
   const unitCount = useBridgeValue(bridge, PLAYER_UNIT_COUNT_BRIDGE_KEY, 0);
   const unitTotalHp = useBridgeValue(bridge, PLAYER_UNIT_TOTAL_HP_BRIDGE_KEY, 0);
   const [brickInitialHp, setBrickInitialHp] = useState(0);

--- a/tests/BricksModule.test.ts
+++ b/tests/BricksModule.test.ts
@@ -261,7 +261,7 @@ describe("BricksModule", () => {
     });
   });
 
-  test("notifies when the final brick is destroyed", () => {
+  test("does not complete run when the final brick is destroyed", () => {
     const scene = new SceneObjectManager();
     const bridge = new DataBridge();
     const runState = new MapRunState();
@@ -287,7 +287,7 @@ describe("BricksModule", () => {
 
     module.applyDamage(brick.id, 999);
 
-    assert.strictEqual(callbackCount, 1, "should notify once when all bricks are gone");
+    assert.strictEqual(callbackCount, 0, "run completion is handled by map objectives");
   });
 
   test("brick knockback registers scene object as movable", () => {

--- a/tests/MapModule.test.ts
+++ b/tests/MapModule.test.ts
@@ -181,6 +181,7 @@ const createEnemiesStub = (): EnemiesModule =>
     setEnemies: () => {},
     spawnEnemy: () => {},
     getEnemies: () => [],
+    getObjectiveTotals: () => ({ count: 0, totalHp: 0 }),
     findNearestEnemy: () => null,
     getEnemyState: () => null,
   } as unknown as EnemiesModule);
@@ -572,6 +573,7 @@ describe("Map run control", () => {
       setBricks: () => {
         setBricksCalls += 1;
       },
+      getBrickTotals: () => ({ count: 0, totalHp: 0 }),
     } as unknown as BricksModule;
     let prepareForMapCalls = 0;
     let setUnitsCalls = 0;
@@ -705,6 +707,7 @@ describe("Map run control", () => {
       setBricks: (input: unknown) => {
         lastBricks = input;
       },
+      getBrickTotals: () => ({ count: 0, totalHp: 0 }),
     } as unknown as BricksModule;
     let lastUnits: unknown = null;
     const playerUnits = {
@@ -1186,7 +1189,10 @@ describe("Last played map tracking", () => {
     const bridge = new DataBridge();
     const runState = new MapRunState();
     const bonuses = createBonuses();
-    const bricks = { setBricks: () => {} } as unknown as BricksModule;
+    const bricks = {
+      setBricks: () => {},
+      getBrickTotals: () => ({ count: 0, totalHp: 0 }),
+    } as unknown as BricksModule;
     const playerUnits = {
       prepareForMap: () => {},
       setUnits: () => {},


### PR DESCRIPTION
### Motivation
- Ensure map completion requires clearing both bricks and enemies that are marked as required to destroy, and provide a single progress value for the UI to show overall objective integrity.
- Add a per-enemy flag to mark enemies that must be destroyed for map completion so maps can include required targets beyond bricks.

### Description
- Added `requireDestruction?: boolean` to `EnemyConfig` and added a sample `portalSpawnerEnemy` entry in `src/db/enemies-db.ts` to demonstrate spawners and required-enemy semantics.
- Implemented `ObjectiveIntegrityService` that aggregates brick HP and HP of enemies flagged with `requireDestruction` and publishes the combined value to the bridge under `objectives/totalHp` (`src/logic/modules/active-map/objective-integrity/*`).
- Exposed brick totals via `BricksModule.getBrickTotals()` and required-enemy totals via `EnemiesModule.getObjectiveTotals()` so the aggregator can compute counts and HP (`src/logic/modules/active-map/bricks/bricks.module.ts`, `src/logic/modules/active-map/enemies/enemies.module.ts`).
- Wired the service into `MapModule` to refresh objective totals on start/tick/reset and updated completion logic so the run completes only when there are no bricks and no required enemies remaining (`src/logic/modules/active-map/map/map.module.ts`).
- Updated UI to read the new `objectives/totalHp` bridge key for the scene toolbar progress bar (`src/ui/screens/Scene/components/toolbar/SceneToolbar.tsx`) and added the new key to `BridgeSchema` (`src/core/logic/ui/BridgeSchema.ts`).
- Added small spawn/selection helper `EnemySpawnSourceController` and integrated it where spawn interval/selection logic is shared (`src/logic/modules/active-map/enemies/enemy-spawn-source-controller.ts`) and threaded spawnSourceId through enemy spawn data and state factory (`enemies.*` changes).
- Adjusted bricks behaviour to stop auto-completing runs when bricks reach zero (map should handle completion via objectives) and updated tests/stubs to provide `getBrickTotals` / `getObjectiveTotals` where needed (`tests/*`).

### Testing
- Ran the automated test suite with `npm test`; all tests passed: `67 tests passed`.
- Updated unit tests to reflect the new objective-driven completion flow (modified `tests/BricksModule.test.ts` and `tests/MapModule.test.ts`) and added small stubs for `getBrickTotals` / `getObjectiveTotals` used by `MapModule` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875cc2a6288320a856f1daa3f1f154)