### PR TITLE
Add spiralSleeve brick generator and unlockable Spiral Sleeves map

### DIFF
--- a/src/db/languages-db.ts
+++ b/src/db/languages-db.ts
@@ -10,7 +10,7 @@ export interface LanguageEntry {
 export const LANGUAGES_DB: readonly LanguageEntry[] = [
   { code: "en", label: "English" },
   { code: "ua", label: "Українська" },
-  { code: "de", label: "Deutch" },
+  // { code: "de", label: "Deutch" },
   // { code: "pl", label: "Polska" },
   // { code: "ru", label: "Русский" },
 ] as const;

--- a/src/db/maps/map-definitions/spiralSleeves.ts
+++ b/src/db/maps/map-definitions/spiralSleeves.ts
@@ -1,0 +1,106 @@
+import type { SceneSize, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import { spiralSleeveWithBricks } from "../../../logic/services/brick-layout/BrickLayoutService";
+import type { MapConfig } from "../maps-db.types";
+
+const mapConfig = (() => {
+  const size: SceneSize = { width: 1600, height: 1000 };
+  const spawnPoint: SceneVector2 = { x: size.width - 160, y: 140 };
+
+  return {
+    name: "Spiral Sleeves",
+    size,
+    spawnPoints: [spawnPoint],
+    nodePosition: { x: 2, y: 0 },
+    bricks: ({ mapLevel }) => {
+      const baseLevel = Math.max(0, Math.floor(mapLevel));
+      const sandLevel = baseLevel + 2;
+
+      return [
+        spiralSleeveWithBricks(
+          "smallSquareYellow",
+          {
+            center: { x: 300, y: 320 },
+            innerRadius: 24,
+            radiusStep: 65,
+            turns: 2.8,
+            width: 56,
+            startAngle: -Math.PI / 2,
+            spacing: 18,
+          },
+          { level: sandLevel },
+        ),
+        spiralSleeveWithBricks(
+          "smallSquareYellow",
+          {
+            center: { x: 760, y: 280 },
+            innerRadius: 16,
+            radiusStep: 58,
+            turns: 3.2,
+            width: 48,
+            startAngle: Math.PI / 4,
+            clockwise: true,
+            spacing: 18,
+          },
+          { level: sandLevel },
+        ),
+        spiralSleeveWithBricks(
+          "smallSquareYellow",
+          {
+            center: { x: 1270, y: 330 },
+            innerRadius: 20,
+            radiusStep: 60,
+            turns: 2.7,
+            width: 52,
+            startAngle: Math.PI,
+            spacing: 18,
+          },
+          { level: sandLevel },
+        ),
+        spiralSleeveWithBricks(
+          "smallSquareYellow",
+          {
+            center: { x: 520, y: 760 },
+            innerRadius: 24,
+            radiusStep: 70,
+            turns: 2.6,
+            width: 54,
+            startAngle: -Math.PI / 6,
+            clockwise: true,
+            spacing: 18,
+          },
+          { level: sandLevel },
+        ),
+        spiralSleeveWithBricks(
+          "smallSquareYellow",
+          {
+            center: { x: 1080, y: 730 },
+            innerRadius: 28,
+            radiusStep: 68,
+            turns: 3,
+            width: 58,
+            startAngle: Math.PI / 2,
+            spacing: 18,
+          },
+          { level: sandLevel },
+        ),
+      ];
+    },
+    playerUnits: [
+      {
+        type: "bluePentagon",
+        position: { ...spawnPoint },
+      },
+    ],
+    unlockedBy: [
+      {
+        type: "map",
+        id: "sphinx",
+        level: 1,
+      },
+    ],
+    mapsRequired: { sphinx: 1 },
+    maxLevel: 1,
+  } satisfies MapConfig;
+})();
+
+export default mapConfig;

--- a/src/db/maps/map-definitions/spiralSleeves.ts
+++ b/src/db/maps/map-definitions/spiralSleeves.ts
@@ -1,10 +1,12 @@
 import type { SceneSize, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
 import { spiralSleeveWithBricks } from "../../../logic/services/brick-layout/BrickLayoutService";
 import type { MapConfig } from "../maps-db.types";
+import type { EnemySpawnData } from "../../../logic/modules/active-map/enemies/enemies.types";
+
 
 const mapConfig = (() => {
-  const size: SceneSize = { width: 1600, height: 1000 };
-  const spawnPoint: SceneVector2 = { x: size.width - 160, y: 140 };
+  const size: SceneSize = { width: 1600, height: 1600 };
+  const spawnPoint: SceneVector2 = { x: 800, y: 800 };
 
   return {
     name: "Spiral Sleeves",
@@ -13,22 +15,49 @@ const mapConfig = (() => {
     nodePosition: { x: 2, y: 0 },
     bricks: ({ mapLevel }) => {
       const baseLevel = Math.max(0, Math.floor(mapLevel));
-      const sandLevel = baseLevel + 2;
+      const sandLevel = baseLevel + 4;
 
       return [
         spiralSleeveWithBricks(
           "smallSquareYellow",
           {
-            center: { x: 300, y: 320 },
-            innerRadius: 24,
-            radiusStep: 65,
-            turns: 2.8,
+            center: { x: 800, y: 800 },
+            innerRadius: 125,
+            radiusStep: 1100,
+            turns: 0.5,
             width: 56,
-            startAngle: -Math.PI / 2,
+            startAngle: 0,
             spacing: 18,
           },
           { level: sandLevel },
         ),
+        spiralSleeveWithBricks(
+          "smallSquareYellow",
+          {
+            center: { x: 800, y: 800 },
+            innerRadius: 125,
+            radiusStep: 1100,
+            turns: 0.5,
+            width: 56,
+            startAngle: 4*Math.PI / 3,
+            spacing: 18,
+          },
+          { level: sandLevel },
+        ),
+        spiralSleeveWithBricks(
+          "smallSquareYellow",
+          {
+            center: { x: 800, y: 800 },
+            innerRadius: 125,
+            radiusStep: 1100,
+            turns: 0.5,
+            width: 56,
+            startAngle: 2*Math.PI/3,
+            spacing: 18,
+          },
+          { level: sandLevel },
+        ),
+        /*
         spiralSleeveWithBricks(
           "smallSquareYellow",
           {
@@ -83,6 +112,43 @@ const mapConfig = (() => {
           },
           { level: sandLevel },
         ),
+        */
+      ];
+    },
+    enemies: ({ mapLevel }) => {
+      const baseLevel = Math.max(0, Math.floor(mapLevel));
+      return [
+        {
+          type: "laserTurretEnemy",
+          level: baseLevel+2,
+          position: { x: 200, y: 800 },
+        } satisfies EnemySpawnData,
+        {
+          type: "laserTurretEnemy",
+          level: baseLevel+2,
+          position: { x: 1100, y: 300 },
+        } satisfies EnemySpawnData,
+        {
+          type: "laserTurretEnemy",
+          level: baseLevel+2,
+          position: { x: 1100, y: 1300 },
+        } satisfies EnemySpawnData,
+
+        {
+          type: "plasmaBeamTurretEnemy",
+          level: baseLevel + 1,
+          position: { x: 250, y: 850 },
+        } satisfies EnemySpawnData,
+        {
+          type: "plasmaBeamTurretEnemy",
+          level: baseLevel+1,
+          position: { x: 1025, y: 300 },
+        } satisfies EnemySpawnData,
+        {
+          type: "plasmaBeamTurretEnemy",
+          level: baseLevel+1,
+          position: { x: 1150, y: 1250 },
+        } satisfies EnemySpawnData,
       ];
     },
     playerUnits: [

--- a/src/db/maps/maps-db.ts
+++ b/src/db/maps/maps-db.ts
@@ -18,6 +18,7 @@ import oldForge from "./map-definitions/oldForge";
 import portalRing from "./map-definitions/portalRing";
 import silverRing from "./map-definitions/silverRing";
 import sphinx from "./map-definitions/sphinx";
+import spiralSleeves from "./map-definitions/spiralSleeves";
 import spruce from "./map-definitions/spruce";
 import stoneCottage from "./map-definitions/stoneCottage";
 import thicket from "./map-definitions/thicket";
@@ -53,6 +54,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
   spruce,
   deadOak,
   sphinx,
+  spiralSleeves,
   stoneCottage,
   bezierGrove,
   wire,

--- a/src/db/maps/maps-db.types.ts
+++ b/src/db/maps/maps-db.types.ts
@@ -20,6 +20,7 @@ export type MapId =
   | "spruce"
   | "deadOak"
   | "sphinx"
+  | "spiralSleeves"
   | "stoneCottage"
   | "bezierGrove"
   | "wire"

--- a/src/localization/en/maps.json
+++ b/src/localization/en/maps.json
@@ -9,6 +9,7 @@
   "spruce": { "name": "Spruce" },
   "deadOak": { "name": "Dead Oak" },
   "sphinx": { "name": "Sphinx" },
+  "spiralSleeves": { "name": "Spiral Sleeves" },
   "stoneCottage": { "name": "Stone Cottage" },
   "bezierGrove": { "name": "Dangerous Bushes" },
   "wire": { "name": "Wire" },

--- a/src/localization/ua/maps.json
+++ b/src/localization/ua/maps.json
@@ -9,6 +9,7 @@
     "spruce": { "name": "Ялина" },
     "deadOak": { "name": "Мертвий дуб" },
     "sphinx": { "name": "Сфінкс" },
+    "spiralSleeves": { "name": "Спіральні рукави" },
     "stoneCottage": { "name": "Кам'яна хатина" },
     "bezierGrove": { "name": "Небезпечні кущі" },
     "wire": { "name": "Дріт" },

--- a/src/logic/services/brick-layout/BrickLayoutService.ts
+++ b/src/logic/services/brick-layout/BrickLayoutService.ts
@@ -10,6 +10,7 @@ import type {
   ConnectorWithBricksOptions,
   TemplateWithBricksOptions,
   BezierCurveWithBricksOptions,
+  SpiralSleeveWithBricksOptions,
   BezierPolygonWithBricksOptions,
   BrickShapeBlueprint,
 } from "./brick-layout.types";
@@ -22,6 +23,7 @@ import {
   generateConnectorBricks,
   generateTemplateBricks,
   generateBezierCurveBricks,
+  generateSpiralSleeveBricks,
   generateBezierPolygonBricks,
 } from "./brick-layout.generators";
 
@@ -113,6 +115,18 @@ export const bezierCurveWithBricks = (
   generationOptions,
 });
 
+
+export const spiralSleeveWithBricks = (
+  brickType: BrickType,
+  options: SpiralSleeveWithBricksOptions,
+  generationOptions?: BrickGenerationOptions
+): BrickShapeBlueprint => ({
+  shape: "spiralSleeve",
+  brickType,
+  options,
+  generationOptions,
+});
+
 export const bezierPolygonWithBricks = (
   brickType: BrickType,
   options: BezierPolygonWithBricksOptions,
@@ -177,6 +191,12 @@ export const buildBricksFromBlueprints = (
           blueprint.options,
           blueprint.generationOptions
         );
+      case "spiralSleeve":
+        return generateSpiralSleeveBricks(
+          blueprint.brickType,
+          blueprint.options,
+          blueprint.generationOptions
+        );
       case "bezierPolygon":
         return generateBezierPolygonBricks(
           blueprint.brickType,
@@ -199,6 +219,7 @@ export type {
   ConnectorWithBricksOptions,
   TemplateWithBricksOptions,
   BezierCurveWithBricksOptions,
+  SpiralSleeveWithBricksOptions,
   BezierPolygonWithBricksOptions,
   BrickShapeBlueprint,
 } from "./brick-layout.types";

--- a/src/logic/services/brick-layout/brick-layout.generators.ts
+++ b/src/logic/services/brick-layout/brick-layout.generators.ts
@@ -13,6 +13,7 @@ import type {
   TemplateWithBricksOptions,
   BezierCurveSegment,
   BezierCurveWithBricksOptions,
+  SpiralSleeveWithBricksOptions,
   BezierPolygonWithBricksOptions,
 } from "./brick-layout.types";
 import {
@@ -510,6 +511,102 @@ export const generateBezierCurveBricks = (
   const level = sanitizeBrickLevel(generationOptions?.level);
   const bricks: BrickData[] = [];
 
+  let distanceTravelled = 0;
+  let nextDistance = 0;
+
+  for (let index = 1; index < points.length; index += 1) {
+    const previous = points[index - 1];
+    const current = points[index];
+    if (!previous || !current) {
+      continue;
+    }
+    const segmentLength = Math.hypot(current.x - previous.x, current.y - previous.y);
+
+    if (segmentLength === 0) {
+      continue;
+    }
+
+    while (nextDistance <= distanceTravelled + segmentLength + GRID_EPSILON) {
+      const t = (nextDistance - distanceTravelled) / segmentLength;
+      const x = previous.x + (current.x - previous.x) * t;
+      const y = previous.y + (current.y - previous.y) * t;
+      const angle = Math.atan2(current.y - previous.y, current.x - previous.x) + rotationOffset;
+      const normalX = -Math.sin(angle);
+      const normalY = Math.cos(angle);
+
+      offsets.forEach((offset) => {
+        bricks.push({
+          position: { x: x + normalX * offset, y: y + normalY * offset },
+          rotation: angle,
+          type: brickType,
+          level,
+        });
+      });
+
+      nextDistance += spacing;
+    }
+
+    distanceTravelled += segmentLength;
+  }
+
+  return bricks;
+};
+
+/**
+ * Generates bricks in an Archimedean spiral sleeve pattern.
+ */
+export const generateSpiralSleeveBricks = (
+  brickType: BrickType,
+  options: SpiralSleeveWithBricksOptions,
+  generationOptions?: BrickGenerationOptions
+): BrickData[] => {
+  const turns = clampPositive(options.turns, 0);
+  if (turns <= 0) {
+    return [];
+  }
+
+  const spacingConfig = getBrickSpacing(brickType);
+  const spacing = clampPositive(
+    options.spacing ?? spacingConfig.tangential,
+    spacingConfig.tangential,
+  );
+  const sampleStep = clampPositive(options.sampleStep ?? spacing * 0.5, spacing * 0.5);
+  const innerRadius = clampRadius(options.innerRadius);
+  const radiusStep = Number.isFinite(options.radiusStep) ? options.radiusStep : 0;
+  const totalAngle = turns * Math.PI * 2;
+  const direction = options.clockwise ? -1 : 1;
+  const width = Number.isFinite(options.width) ? Math.max(0, options.width) : 0;
+  const bandCount = Math.max(1, Math.floor(width / spacingConfig.radial) + 1);
+  const startOffset = -((bandCount - 1) / 2) * spacingConfig.radial;
+  const offsets = Array.from(
+    { length: bandCount },
+    (_, index) => startOffset + index * spacingConfig.radial,
+  );
+  const level = sanitizeBrickLevel(generationOptions?.level);
+  const rotationOffset = options.rotationOffset ?? 0;
+  const startAngle = options.startAngle ?? 0;
+  const drPerTheta = radiusStep / (Math.PI * 2);
+  const maxRadius = Math.max(innerRadius, innerRadius + turns * radiusStep);
+  const segmentCount = Math.max(
+    32,
+    Math.ceil((totalAngle * Math.max(maxRadius, spacing)) / Math.max(sampleStep, 1)),
+  );
+
+  const points = Array.from({ length: segmentCount + 1 }, (_, index) => {
+    const theta = (totalAngle * index) / segmentCount;
+    const radius = Math.max(0, innerRadius + drPerTheta * theta);
+    const phi = startAngle + direction * theta;
+    return {
+      x: options.center.x + Math.cos(phi) * radius,
+      y: options.center.y + Math.sin(phi) * radius,
+    };
+  });
+
+  if (points.length < 2) {
+    return [];
+  }
+
+  const bricks: BrickData[] = [];
   let distanceTravelled = 0;
   let nextDistance = 0;
 

--- a/src/logic/services/brick-layout/brick-layout.types.ts
+++ b/src/logic/services/brick-layout/brick-layout.types.ts
@@ -82,6 +82,19 @@ export interface BezierCurveWithBricksOptions {
   readonly thickness?: number;
 }
 
+export interface SpiralSleeveWithBricksOptions {
+  readonly center: SceneVector2;
+  readonly innerRadius: number;
+  readonly radiusStep: number;
+  readonly turns: number;
+  readonly width: number;
+  readonly startAngle?: number;
+  readonly clockwise?: boolean;
+  readonly spacing?: number;
+  readonly sampleStep?: number;
+  readonly rotationOffset?: number;
+}
+
 export interface BezierTransformOptions {
   readonly position?: SceneVector2;
   readonly scale?: number | SceneVector2;
@@ -144,6 +157,12 @@ export type BrickShapeBlueprint =
       readonly shape: "bezierCurve";
       readonly brickType: BrickType;
       readonly options: BezierCurveWithBricksOptions;
+      readonly generationOptions?: BrickGenerationOptions;
+    }
+  | {
+      readonly shape: "spiralSleeve";
+      readonly brickType: BrickType;
+      readonly options: SpiralSleeveWithBricksOptions;
       readonly generationOptions?: BrickGenerationOptions;
     }
   | {


### PR DESCRIPTION
### Motivation
- Provide a new configurable brick layout that can place bricks in a spiral sleeve (Archimedean spiral) with tunable inner radius, radius growth, turns, sleeve width, direction and spacing to enable new map visuals and gameplay patterns.
- Expose the new layout as a reusable blueprint so map authors can declaratively add spiral sleeves to maps and control brick level/rotation behavior.

### Description
- Added the `SpiralSleeveWithBricksOptions` type and new `spiralSleeve` variant in `src/logic/services/brick-layout/brick-layout.types.ts` and the `BrickLayoutService` helper `spiralSleeveWithBricks` in `src/logic/services/brick-layout/BrickLayoutService.ts`.
- Implemented `generateSpiralSleeveBricks` in `src/logic/services/brick-layout/brick-layout.generators.ts` to sample an Archimedean spiral, place bricks along the tangent, and expand sleeve thickness using normal offsets for multiple bands.
- Registered a new map `spiralSleeves` at `src/db/maps/map-definitions/spiralSleeves.ts`, added it to `MAPS_DB`/`MapId` and added English/Ukrainian localization entries in `src/localization/en/maps.json` and `src/localization/ua/maps.json`.
- Wired the new generator into the blueprint switch so `buildBricksFromBlueprints` supports `shape: "spiralSleeve"` and re-exported the new types for compatibility.

### Testing
- `npm run check:ui-hardcoded-strings` passed (no hardcoded UI strings detected).
- `npx tsc -p tsconfig.tests.json` passed (tests build step succeeded).
- `node build/tests/tests/run.js` passed with the test suite reporting `67 tests passed`.
- `npx tsc -p tsconfig.json --noEmit` passed (project type-check succeeded).
- `npm test` failed early due to repository-wide strict localization checks reporting missing keys unrelated to this change (`Found 1434 missing localized key(s)`), so full `npm test` did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991adf58f208320876a6584b8580e63)