### PR TITLE
Allow bonus formulas to depend on other bonuses and resolve them with cycle detection

### DIFF
--- a/src/db/buildings-db.ts
+++ b/src/db/buildings-db.ts
@@ -111,7 +111,8 @@ const BUILDING_DB: Record<BuildingId, BuildingConfig> = {
       "Forest of steel and soul. Increase your eaters HP",
     effects: {
       all_units_hp_multiplier: {
-        multiplier: (level) => 1 + 0.1 * level,
+        multiplier: (level, _context, dependencies) =>
+          1 + 0.1 * level * (dependencies?.getBonusValue("iron_forest_hp_effectiveness") ?? 1),
       },
     },
     cost: createScalingCost({ iron: 200, wood: 100 }, 1.75),
@@ -264,7 +265,7 @@ const BUILDING_DB: Record<BuildingId, BuildingConfig> = {
       "Raise a lattice of tempered arches and frost-hardened vines. (Iron Forest effectiveness bonus — placeholder, no gameplay effect yet.)",
     effects: {
       iron_forest_hp_effectiveness: {
-        multiplier: () => 1,
+        multiplier: (level) => 1 + 0.05 * level,
       },
     },
     cost: createScalingCost({ silver: 20_000, ice: 1000 }, 1.75),

--- a/src/logic/modules/shared/bonuses/bonuses.calculator.ts
+++ b/src/logic/modules/shared/bonuses/bonuses.calculator.ts
@@ -7,6 +7,7 @@ import type {
   BonusValueMap,
 } from "./bonuses.types";
 import { createBonusValueMap, sanitizeEffectValue } from "./bonuses.helpers";
+import type { BonusEffectFormula } from "@shared/types/bonuses";
 
 export interface BonusCalculatorInput {
   sources: Iterable<BonusSourceState>;
@@ -22,9 +23,10 @@ export class BonusCalculator {
     rules,
     ruleContext,
   }: BonusCalculatorInput): BonusValueMap {
-    const incomes = createBonusValueMap(() => 0);
-    const multipliers = createBonusValueMap(() => 1);
-    const baseOverrides = createBonusValueMap(() => Number.NaN);
+    const effectEntriesByBonus = new Map<
+      BonusId,
+      Array<{ readonly effectType: string; readonly level: number; readonly formula: BonusEffectFormula }>
+    >();
 
     for (const source of sources) {
       const level = source.level;
@@ -33,61 +35,98 @@ export class BonusCalculator {
           return;
         }
         const id = bonusId as BonusId;
+        const entries = effectEntriesByBonus.get(id) ?? [];
         Object.entries(effectTypes).forEach(([effectType, formula]) => {
-          const value = sanitizeEffectValue(formula(level, effectContext), effectType);
-          switch (effectType as BonusEffectType) {
-            case "income":
-              incomes[id] += value;
-              break;
-            case "multiplier":
-              multipliers[id] *= value;
-              break;
-            case "base":
-              baseOverrides[id] = value;
-              break;
-            default:
-              incomes[id] += value;
-              break;
-          }
+          entries.push({
+            effectType,
+            level,
+            formula,
+          });
         });
+        effectEntriesByBonus.set(id, entries);
       });
     }
 
-    BonusCalculator.applyRuleEffects(incomes, multipliers, rules, ruleContext);
+    const memo = new Map<BonusId, number>();
+    const visiting = new Set<BonusId>();
+    const progression = new Set<string>(ruleContext.progressionKeys ?? []);
+    const runtimeFlags = new Set<string>(ruleContext.runtimeFlags ?? []);
 
-    return createBonusValueMap((config, id) => {
-      const override = baseOverrides[id];
-      const base = Number.isNaN(override) ? config.defaultValue : override;
-      return (base + incomes[id]) * multipliers[id];
-    });
+    const resolveBonusValue = (id: BonusId): number => {
+      const cached = memo.get(id);
+      if (cached !== undefined) {
+        return cached;
+      }
+      if (visiting.has(id)) {
+        const trail = [...visiting, id].join(" -> ");
+        throw new Error(`Cyclic bonus dependency detected: ${trail}`);
+      }
+      visiting.add(id);
+
+      let income = 0;
+      let multiplier = 1;
+      let baseOverride = Number.NaN;
+      const entries = effectEntriesByBonus.get(id) ?? [];
+      entries.forEach(({ effectType, level, formula }) => {
+        const value = sanitizeEffectValue(
+          formula(level, effectContext, { getBonusValue: resolveBonusValue }),
+          effectType
+        );
+        switch (effectType as BonusEffectType) {
+          case "income":
+            income += value;
+            break;
+          case "multiplier":
+            multiplier *= value;
+            break;
+          case "base":
+            baseOverride = value;
+            break;
+          default:
+            income += value;
+            break;
+        }
+      });
+
+      const ruleEffects = BonusCalculator.getRuleEffectsForBonus(
+        id,
+        rules,
+        progression,
+        runtimeFlags,
+      );
+      income += ruleEffects.addFlat;
+      multiplier *= 1 + ruleEffects.addMultiplier;
+
+      const config = getBonusConfig(id);
+      const base = Number.isNaN(baseOverride) ? config.defaultValue : baseOverride;
+      const resolved = (base + income) * multiplier;
+      visiting.delete(id);
+      memo.set(id, resolved);
+      return resolved;
+    };
+
+    return createBonusValueMap((_config, id) => resolveBonusValue(id));
   }
 
-  private static applyRuleEffects(
-    incomes: BonusValueMap,
-    multipliers: BonusValueMap,
+  private static getRuleEffectsForBonus(
+    bonusId: BonusId,
     rules: BonusRule[],
-    ruleContext: BonusRuleContextInput,
-  ): void {
-    if (!rules.length) {
-      return;
-    }
-    const progression = new Set(ruleContext.progressionKeys ?? []);
-    const runtimeFlags = new Set(ruleContext.runtimeFlags ?? []);
-
+    progression: ReadonlySet<string>,
+    runtimeFlags: ReadonlySet<string>,
+  ): { addFlat: number; addMultiplier: number } {
+    let addFlat = 0;
+    let addMultiplier = 0;
     rules.forEach((rule) => {
+      if (rule.bonusId !== bonusId) {
+        return;
+      }
       if (!BonusCalculator.areRuleRequirementsMet(rule, progression, runtimeFlags)) {
         return;
       }
-      const bonusId = rule.bonusId;
-      getBonusConfig(bonusId);
-      const { addFlat = 0, addMultiplier = 0 } = rule.effects;
-      if (addFlat !== 0) {
-        incomes[bonusId] += addFlat;
-      }
-      if (addMultiplier !== 0) {
-        multipliers[bonusId] *= 1 + addMultiplier;
-      }
+      addFlat += rule.effects.addFlat ?? 0;
+      addMultiplier += rule.effects.addMultiplier ?? 0;
     });
+    return { addFlat, addMultiplier };
   }
 
   private static areRuleRequirementsMet(

--- a/src/logic/modules/shared/bonuses/bonuses.module.ts
+++ b/src/logic/modules/shared/bonuses/bonuses.module.ts
@@ -142,7 +142,7 @@ export class BonusesModule extends BaseGameModule<BonusValuesListener> implement
       const level = source.level;
       Object.entries(effectTypes).forEach(([effectType, formula]) => {
         const value = sanitizeEffectValue(
-          formula(level, this.effectContext),
+          formula(level, this.effectContext, { getBonusValue: (id) => this.getBonusValue(id) }),
           effectType
         );
         entries.push({
@@ -184,11 +184,11 @@ export class BonusesModule extends BaseGameModule<BonusValuesListener> implement
       const config = getBonusConfig(bonusId as BonusId);
       Object.entries(effectTypes).forEach(([effectType, formula]) => {
         const currentValue = sanitizeEffectValue(
-          formula(level, this.effectContext),
+          formula(level, this.effectContext, { getBonusValue: (id) => this.getBonusValue(id) }),
           effectType
         );
         const nextValue = sanitizeEffectValue(
-          formula(nextLevel, this.effectContext),
+          formula(nextLevel, this.effectContext, { getBonusValue: (id) => this.getBonusValue(id) }),
           effectType
         );
         previews.push({

--- a/src/shared/types/bonuses.ts
+++ b/src/shared/types/bonuses.ts
@@ -4,7 +4,15 @@ export type BonusEffectType = "income" | "multiplier" | "base";
 
 export type BonusEffectContext = Record<string, number>;
 
-export type BonusEffectFormula = (level: number, context?: BonusEffectContext) => number;
+export interface BonusFormulaDependencies {
+  readonly getBonusValue: (id: BonusId) => number;
+}
+
+export type BonusEffectFormula = (
+  level: number,
+  context?: BonusEffectContext,
+  dependencies?: BonusFormulaDependencies,
+) => number;
 
 export type BonusEffectTypeMap = Partial<Record<BonusEffectType | string, BonusEffectFormula>>;
 

--- a/tests/BonusCalculator.test.ts
+++ b/tests/BonusCalculator.test.ts
@@ -48,4 +48,69 @@ describe("BonusCalculator", () => {
     });
     assert(Math.abs(withRule.mana_cap - 39.6) < 1e-6);
   });
+
+  test("supports cross-bonus dependencies in formulas", () => {
+    const sources: BonusSourceState[] = [
+      {
+        id: "canopy",
+        category: "building",
+        level: 2,
+        effects: {
+          iron_forest_hp_effectiveness: {
+            multiplier: (level) => 1 + 0.05 * level,
+          },
+        },
+      },
+      {
+        id: "forest",
+        category: "building",
+        level: 3,
+        effects: {
+          all_units_hp_multiplier: {
+            multiplier: (level, _context, deps) =>
+              1 + 0.1 * level * (deps?.getBonusValue("iron_forest_hp_effectiveness") ?? 1),
+          },
+        },
+      },
+    ];
+
+    const values = BonusCalculator.calculate({
+      sources,
+      effectContext: {},
+      rules: [],
+      ruleContext: {},
+    });
+
+    assert(Math.abs(values.iron_forest_hp_effectiveness - 1.1) < 1e-6);
+    assert(Math.abs(values.all_units_hp_multiplier - 1.33) < 1e-6);
+  });
+
+  test("throws on cyclic bonus dependencies", () => {
+    const sources: BonusSourceState[] = [
+      {
+        id: "cycle",
+        category: "misc",
+        level: 1,
+        effects: {
+          mana_cap: {
+            base: (_level, _context, deps) => deps?.getBonusValue("sanity_cap") ?? 0,
+          },
+          sanity_cap: {
+            base: (_level, _context, deps) => deps?.getBonusValue("mana_cap") ?? 0,
+          },
+        },
+      },
+    ];
+
+    assert.throws(
+      () =>
+        BonusCalculator.calculate({
+          sources,
+          effectContext: {},
+          rules: [],
+          ruleContext: {},
+        }),
+      /Cyclic bonus dependency detected/
+    );
+  });
 });

--- a/tests/BonusesModule.test.ts
+++ b/tests/BonusesModule.test.ts
@@ -77,4 +77,36 @@ describe("BonusesModule", () => {
       /already registered/
     );
   });
+
+  test("applies Iron Canopy effectiveness to Iron Forest HP multiplier", () => {
+    const bonuses = new BonusesModule();
+    bonuses.initialize();
+
+    bonuses.registerSource(
+      "iron_forest",
+      {
+        all_units_hp_multiplier: {
+          multiplier: (level, _context, deps) =>
+            1 + 0.1 * level * (deps?.getBonusValue("iron_forest_hp_effectiveness") ?? 1),
+        },
+      },
+      "building"
+    );
+    bonuses.registerSource(
+      "iron_canopy",
+      {
+        iron_forest_hp_effectiveness: {
+          multiplier: (level) => 1 + 0.05 * level,
+        },
+      },
+      "building"
+    );
+
+    bonuses.setSourceLevel("iron_forest", 3);
+    bonuses.setSourceLevel("iron_canopy", 2);
+
+    const values = bonuses.getAllValues();
+    assert(Math.abs(values.iron_forest_hp_effectiveness - 1.1) < 1e-6);
+    assert(Math.abs(values.all_units_hp_multiplier - 1.33) < 1e-6);
+  });
 });


### PR DESCRIPTION
### Motivation

- Enable bonus effect formulas to read values of other bonuses so building/skill effects can interact (e.g. Iron Canopy modifying Iron Forest HP). 
- Replace the previous flat two-pass accumulation with a resolution that supports inter-dependent formulas and rule-based adjustments. 

### Description

- Extend `BonusEffectFormula` to accept a `dependencies` argument exposing `getBonusValue` and update type definitions in `src/shared/types/bonuses.ts`.  
- Rewrite the bonus calculation in `BonusCalculator.calculate` to collect effect entries, resolve bonus values recursively with memoization, apply rule effects per bonus, and detect/report cyclic dependencies.  
- Update `bonuses.module.ts` to pass `dependencies` (`{ getBonusValue: ... }`) into formula calls in `getBreakdown` and `getBonusEffects`.  
- Update `buildings-db.ts` to make `all_units_hp_multiplier` depend on `iron_forest_hp_effectiveness` and change `iron_canopy` to scale its effectiveness by level.  
- Add unit tests covering cross-bonus dependencies, cycle detection in bonus resolution, and the Iron Canopy/Iron Forest interaction (`tests/BonusCalculator.test.ts` and `tests/BonusesModule.test.ts`).

### Testing

- Ran unit tests in `tests/BonusCalculator.test.ts` which include dependency resolution and cycle detection tests, and they passed.  
- Ran `tests/BonusesModule.test.ts` which covers API usage and the new Iron Canopy -> Iron Forest interaction, and it passed.  
- Existing bonus-related tests were executed as part of the suite and reported no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9227bb60483209e45719467343f36)