### PR TITLE
Add Hot Corridors map with magma bezier corridors and fire defenses

### DIFF
--- a/src/db/enemies/enemies.types.ts
+++ b/src/db/enemies/enemies.types.ts
@@ -48,7 +48,8 @@ export type EnemyType =
   | "carGuardianPortalSpawnerEnemy"
   | "greatOctopusBody"
   | "greatOctopusSegment"
-  | "fireParasiteEnemy";
+  | "fireParasiteEnemy"
+  | "hotCorridorTurretEnemy";
 
 export interface EnemyAuraConfig {
   petalCount: number;

--- a/src/db/enemies/turrets.ts
+++ b/src/db/enemies/turrets.ts
@@ -1098,4 +1098,87 @@ export const TURRETS_ENEMIES: Partial<Record<EnemyType, EnemyConfig>> = {
       spawnOffset: { x: 2, y: 0 },
     },
   },
+  hotCorridorTurretEnemy: {
+    name: "Hot Corridor Turret",
+    renderer: {
+      kind: "composite",
+      fill: { r: 0.85, g: 0.35, b: 0.15, a: 1 },
+      layers: [
+        {
+          shape: "circle",
+          radius: 32,
+          segments: 40,
+          fill: {
+            type: "gradient",
+            fill: {
+              fillType: FILL_TYPES.RADIAL_GRADIENT,
+              start: { x: 0, y: 0 },
+              end: 32,
+              stops: [
+                { offset: 0, color: { r: 1, g: 0.75, b: 0.35, a: 0.5 } },
+                { offset: 0.65, color: { r: 0.95, g: 0.35, b: 0.12, a: 0.28 } },
+                { offset: 1, color: { r: 0.7, g: 0.15, b: 0.08, a: 0 } },
+              ],
+            },
+          },
+        },
+        {
+          shape: "polygon",
+          vertices: [
+            { x: 18, y: -4 },
+            { x: 4, y: -6 },
+            { x: 4, y: 6 },
+            { x: 18, y: 4 },
+          ],
+          fill: { type: "base", brightness: -0.1 },
+        },
+        {
+          shape: "polygon",
+          vertices: [
+            { x: 4, y: -8 },
+            { x: -11, y: -12 },
+            { x: -11, y: 12 },
+            { x: 4, y: 8 },
+          ],
+          fill: { type: "base", brightness: 0.18 },
+        },
+      ],
+      auras: [
+        {
+          petalCount: 12,
+          innerRadius: 20,
+          outerRadius: 34,
+          petalWidth: 0.5,
+          rotationSpeed: 0.4,
+          color: { r: 1, g: 0.55, b: 0.2, a: 0.25 },
+          alpha: 0.22,
+        },
+      ],
+    },
+    maxHp: 98000,
+    armor: 1900,
+    baseDamage: 2500,
+    attackInterval: 2.2,
+    attackRange: 560,
+    moveSpeed: 0,
+    physicalSize: 32,
+    reward: normalizeResourceAmount({
+      copper: 120,
+      coal: 50,
+      stone: 85,
+    }),
+    arcAttack: {
+      arcType: "hotPlasmaBeam",
+      explosionType: "hotPlasmaExplosion",
+      explosionRadius: 52,
+      spawnOffset: { x: 14, y: 0 },
+      statusEffectId: "burn",
+      statusEffectOptions: {
+        damagePerSecond: 1236,
+        durationMs: 3500,
+      },
+    },
+    knockBackDistance: 160,
+    knockBackSpeed: 190,
+  },
 };

--- a/src/db/maps/map-definitions/hotCorridors.ts
+++ b/src/db/maps/map-definitions/hotCorridors.ts
@@ -1,0 +1,169 @@
+import type { SceneSize, SceneVector2 } from "@core/logic/provided/services/scene-object-manager/scene-object-manager.types";
+import type { EnemySpawnData } from "../../../logic/modules/active-map/enemies/enemies.types";
+import { bezierCurveWithBricks } from "../../../logic/services/brick-layout/BrickLayoutService";
+import type { BezierCurveSegment } from "../../../logic/services/brick-layout/brick-layout.types";
+import type { MapConfig } from "../maps-db.types";
+
+const CIRCLE_KAPPA = 0.5522847498307936;
+
+const createRoundedLoopSegments = (
+  size: SceneSize,
+  inset: number,
+  cornerRadius: number,
+): readonly BezierCurveSegment[] => {
+  const left = inset;
+  const right = size.width - inset;
+  const top = inset;
+  const bottom = size.height - inset;
+  const radius = Math.min(cornerRadius, (right - left) / 2, (bottom - top) / 2);
+  const handle = radius * CIRCLE_KAPPA;
+
+  return [
+    {
+      start: { x: left + radius, y: top },
+      control1: { x: left + radius + handle, y: top },
+      control2: { x: right - radius - handle, y: top },
+      end: { x: right - radius, y: top },
+    },
+    {
+      start: { x: right - radius, y: top },
+      control1: { x: right - radius + handle, y: top },
+      control2: { x: right, y: top + radius - handle },
+      end: { x: right, y: top + radius },
+    },
+    {
+      start: { x: right, y: top + radius },
+      control1: { x: right, y: top + radius + handle },
+      control2: { x: right, y: bottom - radius - handle },
+      end: { x: right, y: bottom - radius },
+    },
+    {
+      start: { x: right, y: bottom - radius },
+      control1: { x: right, y: bottom - radius + handle },
+      control2: { x: right - radius + handle, y: bottom },
+      end: { x: right - radius, y: bottom },
+    },
+    {
+      start: { x: right - radius, y: bottom },
+      control1: { x: right - radius - handle, y: bottom },
+      control2: { x: left + radius + handle, y: bottom },
+      end: { x: left + radius, y: bottom },
+    },
+    {
+      start: { x: left + radius, y: bottom },
+      control1: { x: left + radius - handle, y: bottom },
+      control2: { x: left, y: bottom - radius + handle },
+      end: { x: left, y: bottom - radius },
+    },
+    {
+      start: { x: left, y: bottom - radius },
+      control1: { x: left, y: bottom - radius - handle },
+      control2: { x: left, y: top + radius + handle },
+      end: { x: left, y: top + radius },
+    },
+    {
+      start: { x: left, y: top + radius },
+      control1: { x: left, y: top + radius - handle },
+      control2: { x: left + radius - handle, y: top },
+      end: { x: left + radius, y: top },
+    },
+  ];
+};
+
+const mapConfig = (() => {
+  const size: SceneSize = { width: 2000, height: 2000 };
+  const spawnPoint: SceneVector2 = { x: 320, y: 1000 };
+
+  const enemyPositions: readonly SceneVector2[] = [
+    { x: 520, y: 1000 },
+    { x: 860, y: 320 },
+    { x: 1360, y: 360 },
+    { x: 1680, y: 1000 },
+    { x: 1360, y: 1640 },
+    { x: 880, y: 1690 },
+    { x: 520, y: 1200 },
+  ];
+
+  const turretPositions: readonly SceneVector2[] = [
+    { x: 1000, y: 260 },
+    { x: 1720, y: 1000 },
+    { x: 1000, y: 1740 },
+    { x: 280, y: 1000 },
+  ];
+
+  const outerWallSegments = createRoundedLoopSegments(size, 180, 280);
+  const innerWallSegments = createRoundedLoopSegments(size, 460, 220);
+
+  return {
+    name: "Hot Corridors",
+    size,
+    icon: "volcano.png",
+    spawnPoints: [spawnPoint],
+    nodePosition: { x: 6, y: 5 },
+    bricks: ({ mapLevel }) => {
+      const baseLevel = Math.max(0, Math.floor(mapLevel));
+
+      return [
+        bezierCurveWithBricks(
+          "smallMagma",
+          {
+            segments: outerWallSegments,
+            spacing: 1,
+            sampleStep: 8,
+            thickness: 120,
+          },
+          { level: baseLevel + 2 },
+        ),
+        bezierCurveWithBricks(
+          "smallMagma",
+          {
+            segments: innerWallSegments,
+            spacing: 1,
+            sampleStep: 8,
+            thickness: 110,
+          },
+          { level: baseLevel + 2 },
+        ),
+      ];
+    },
+    enemies: ({ mapLevel }) => {
+      const level = Math.max(1, Math.floor(mapLevel));
+
+      return [
+        ...enemyPositions.map(
+          (position) =>
+            ({
+              type: "fireParasiteEnemy",
+              level,
+              position,
+            }) satisfies EnemySpawnData,
+        ),
+        ...turretPositions.map(
+          (position) =>
+            ({
+              type: "hotCorridorTurretEnemy",
+              level: level + 1,
+              position,
+            }) satisfies EnemySpawnData,
+        ),
+      ];
+    },
+    playerUnits: [
+      {
+        type: "bluePentagon",
+        position: { ...spawnPoint },
+      },
+    ],
+    unlockedBy: [
+      {
+        type: "map",
+        id: "volcano",
+        level: 1,
+      },
+    ],
+    mapsRequired: { volcano: 1 },
+    maxLevel: 1,
+  } satisfies MapConfig;
+})();
+
+export default mapConfig;

--- a/src/db/maps/maps-db.ts
+++ b/src/db/maps/maps-db.ts
@@ -41,6 +41,7 @@ import turretRings from "./map-definitions/turretRings";
 import tutorialZone from "./map-definitions/tutorialZone";
 import uraniumFields from "./map-definitions/uranium_fields";
 import volcano from "./map-definitions/volcano";
+import hotCorridors from "./map-definitions/hotCorridors";
 import wire from "./map-definitions/wire";
 
 export type {
@@ -87,6 +88,7 @@ const MAPS_DB: Record<MapId, MapConfig> = {
   silverChalice,
   frozenForest,
   volcano,
+  hotCorridors,
   gear,
   twinbladeAxe,
   automobile,

--- a/src/db/maps/maps-db.types.ts
+++ b/src/db/maps/maps-db.types.ts
@@ -38,6 +38,7 @@ export type MapId =
   | "silverChalice"
   | "frozenForest"
   | "volcano"
+  | "hotCorridors"
   | "megaBrick"
   | "ancientPyramids"
   | "deathfulGuns"

--- a/src/localization/de/maps.json
+++ b/src/localization/de/maps.json
@@ -7,5 +7,8 @@
   },
   "nautilusShell": {
     "name": "Ammonitschale"
+  },
+  "hotCorridors": {
+    "name": "Hot Corridors"
   }
 }

--- a/src/localization/en/maps.json
+++ b/src/localization/en/maps.json
@@ -115,5 +115,8 @@
   },
   "automobile": {
     "name": "Automobile"
+  },
+  "hotCorridors": {
+    "name": "Hot Corridors"
   }
 }

--- a/src/localization/pl/maps.json
+++ b/src/localization/pl/maps.json
@@ -7,5 +7,8 @@
   },
   "nautilusShell": {
     "name": "Muszla ammonitu"
+  },
+  "hotCorridors": {
+    "name": "Hot Corridors"
   }
 }

--- a/src/localization/ru/maps.json
+++ b/src/localization/ru/maps.json
@@ -10,5 +10,8 @@
   },
   "automobile": {
     "name": "Автомобиль"
+  },
+  "hotCorridors": {
+    "name": "Hot Corridors"
   }
 }

--- a/src/localization/ua/maps.json
+++ b/src/localization/ua/maps.json
@@ -118,5 +118,8 @@
   },
   "automobile": {
     "name": "Автомобіль"
+  },
+  "hotCorridors": {
+    "name": "Hot Corridors"
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a new map composed of enclosed magma-lined corridors to sit to the right of the existing `volcano` map and offer a fire-themed encounter area. 
- Make corridor walls procedurally generated with bezier paths so bricks form continuous curved passages that units can spawn and move inside. 

### Description
- Added a new map definition `src/db/maps/map-definitions/hotCorridors.ts` implementing a 2000x2000 map that builds an outer and inner bezier loop with `bezierCurveWithBricks` to form closed magma corridor walls and places the player `spawnPoint` inside the corridor. 
- Populated the map with roaming `fireParasiteEnemy` spawns and static turrets at set positions, and added a new turret enemy `hotCorridorTurretEnemy` (defined in `src/db/enemies/turrets.ts`) which uses the same hot plasma arc profile (`hotPlasmaBeam` / `hotPlasmaExplosion` + `burn`) as `coalFlameGuardian`. 
- Wired the new map and enemy into project types and registries by updating `src/db/maps/maps-db.ts`, `src/db/maps/maps-db.types.ts`, and `src/db/enemies/enemies.types.ts`, and added localization keys for `hotCorridors` in all locale files. 
- Fixed typings in the map enemy generator using `satisfies EnemySpawnData` so TypeScript accepts the inline spawn objects. 

### Testing
- Ran the project test suite with `npm run test` which completed successfully and shows `118 tests passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca5373f8b88320b8f6c3fbb74ce97f)