### PR TITLE
Increase hotCorridors spacing and add chaotic Bezier distortion

### DIFF
--- a/src/db/maps/map-definitions/hotCorridors.ts
+++ b/src/db/maps/map-definitions/hotCorridors.ts
@@ -99,7 +99,7 @@ const createChaoticLoopSegments = (
   });
 };
 
-const createInnerLoopWithLeftChamberSegments = (
+const createOuterLoopWithLeftChamberSegments = (
   size: SceneSize,
   inset: number,
   cornerRadius: number,
@@ -112,22 +112,22 @@ const createInnerLoopWithLeftChamberSegments = (
     6,
     1,
     {
-      start: { x: left, y: 1320 },
-      control1: { x: left + 12, y: 1230 },
-      control2: { x: left + 92, y: 1135 },
-      end: { x: left + 150, y: 1080 },
+      start: { x: left, y: 1420 },
+      control1: { x: left - 12, y: 1320 },
+      control2: { x: left - 95, y: 1210 },
+      end: { x: left - 150, y: 1140 },
     },
     {
-      start: { x: left + 150, y: 1080 },
-      control1: { x: left + 240, y: 1020 },
-      control2: { x: left + 240, y: 980 },
-      end: { x: left + 150, y: 920 },
+      start: { x: left - 150, y: 1140 },
+      control1: { x: left - 230, y: 1060 },
+      control2: { x: left - 230, y: 940 },
+      end: { x: left - 150, y: 860 },
     },
     {
-      start: { x: left + 150, y: 920 },
-      control1: { x: left + 92, y: 865 },
-      control2: { x: left + 12, y: 770 },
-      end: { x: left, y: 680 },
+      start: { x: left - 150, y: 860 },
+      control1: { x: left - 95, y: 790 },
+      control2: { x: left - 12, y: 680 },
+      end: { x: left, y: 580 },
     },
   );
 
@@ -155,8 +155,8 @@ const mapConfig = (() => {
     { x: 280, y: 1000 },
   ];
 
-  const outerWallSegments = createChaoticLoopSegments(size, 180, 280, 120);
-  const innerWallSegments = createInnerLoopWithLeftChamberSegments(size, 460, 220, 90);
+  const outerWallSegments = createOuterLoopWithLeftChamberSegments(size, 180, 280, 120);
+  const innerWallSegments = createChaoticLoopSegments(size, 460, 220, 90);
 
   return {
     name: "Hot Corridors",

--- a/src/db/maps/map-definitions/hotCorridors.ts
+++ b/src/db/maps/map-definitions/hotCorridors.ts
@@ -5,6 +5,7 @@ import type { BezierCurveSegment } from "../../../logic/services/brick-layout/br
 import type { MapConfig } from "../maps-db.types";
 
 const CIRCLE_KAPPA = 0.5522847498307936;
+const TAU = Math.PI * 2;
 
 const createRoundedLoopSegments = (
   size: SceneSize,
@@ -70,6 +71,34 @@ const createRoundedLoopSegments = (
   ];
 };
 
+const createChaoticLoopSegments = (
+  size: SceneSize,
+  inset: number,
+  cornerRadius: number,
+  distortion: number,
+): readonly BezierCurveSegment[] => {
+  const baseSegments = createRoundedLoopSegments(size, inset, cornerRadius);
+
+  return baseSegments.map((segment, index) => {
+    const indexRatio = index / baseSegments.length;
+    const angleA = indexRatio * TAU;
+    const angleB = (indexRatio + 0.37) * TAU;
+    const angleC = (indexRatio + 0.73) * TAU;
+
+    return {
+      ...segment,
+      control1: {
+        x: segment.control1.x + Math.cos(angleA) * distortion * 0.7,
+        y: segment.control1.y + Math.sin(angleB) * distortion,
+      },
+      control2: {
+        x: segment.control2.x + Math.sin(angleC) * distortion * 0.9,
+        y: segment.control2.y + Math.cos(angleA) * distortion * 0.8,
+      },
+    };
+  });
+};
+
 const mapConfig = (() => {
   const size: SceneSize = { width: 2000, height: 2000 };
   const spawnPoint: SceneVector2 = { x: 320, y: 1000 };
@@ -91,8 +120,8 @@ const mapConfig = (() => {
     { x: 280, y: 1000 },
   ];
 
-  const outerWallSegments = createRoundedLoopSegments(size, 180, 280);
-  const innerWallSegments = createRoundedLoopSegments(size, 460, 220);
+  const outerWallSegments = createChaoticLoopSegments(size, 180, 280, 120);
+  const innerWallSegments = createChaoticLoopSegments(size, 460, 220, 90);
 
   return {
     name: "Hot Corridors",
@@ -108,7 +137,7 @@ const mapConfig = (() => {
           "smallMagma",
           {
             segments: outerWallSegments,
-            spacing: 1,
+            spacing: 14,
             sampleStep: 8,
             thickness: 120,
           },
@@ -118,7 +147,7 @@ const mapConfig = (() => {
           "smallMagma",
           {
             segments: innerWallSegments,
-            spacing: 1,
+            spacing: 14,
             sampleStep: 8,
             thickness: 110,
           },

--- a/src/db/maps/map-definitions/hotCorridors.ts
+++ b/src/db/maps/map-definitions/hotCorridors.ts
@@ -99,7 +99,7 @@ const createChaoticLoopSegments = (
   });
 };
 
-const createOuterLoopWithLeftChamberSegments = (
+const createInnerLoopWithLeftChamberSegments = (
   size: SceneSize,
   inset: number,
   cornerRadius: number,
@@ -112,22 +112,22 @@ const createOuterLoopWithLeftChamberSegments = (
     6,
     1,
     {
-      start: { x: left, y: 1420 },
-      control1: { x: left - 12, y: 1320 },
-      control2: { x: left - 95, y: 1210 },
-      end: { x: left - 150, y: 1140 },
+      start: { x: left, y: 1320 },
+      control1: { x: left + 12, y: 1230 },
+      control2: { x: left + 92, y: 1135 },
+      end: { x: left + 150, y: 1080 },
     },
     {
-      start: { x: left - 150, y: 1140 },
-      control1: { x: left - 230, y: 1060 },
-      control2: { x: left - 230, y: 940 },
-      end: { x: left - 150, y: 860 },
+      start: { x: left + 150, y: 1080 },
+      control1: { x: left + 240, y: 1020 },
+      control2: { x: left + 240, y: 980 },
+      end: { x: left + 150, y: 920 },
     },
     {
-      start: { x: left - 150, y: 860 },
-      control1: { x: left - 95, y: 790 },
-      control2: { x: left - 12, y: 680 },
-      end: { x: left, y: 580 },
+      start: { x: left + 150, y: 920 },
+      control1: { x: left + 92, y: 865 },
+      control2: { x: left + 12, y: 770 },
+      end: { x: left, y: 680 },
     },
   );
 
@@ -139,13 +139,13 @@ const mapConfig = (() => {
   const spawnPoint: SceneVector2 = { x: 320, y: 1000 };
 
   const enemyPositions: readonly SceneVector2[] = [
-    { x: 320, y: 1000 },
-    { x: 620, y: 620 },
-    { x: 1000, y: 320 },
-    { x: 1380, y: 620 },
-    { x: 1680, y: 1000 },
-    { x: 1380, y: 1380 },
-    { x: 620, y: 1380 },
+    { x: 340, y: 1000 },
+    { x: 720, y: 300 },
+    { x: 1000, y: 300 },
+    { x: 1280, y: 300 },
+    { x: 1660, y: 1000 },
+    { x: 1280, y: 1700 },
+    { x: 720, y: 1700 },
   ];
 
   const turretPositions: readonly SceneVector2[] = [
@@ -155,8 +155,8 @@ const mapConfig = (() => {
     { x: 280, y: 1000 },
   ];
 
-  const outerWallSegments = createOuterLoopWithLeftChamberSegments(size, 180, 280, 120);
-  const innerWallSegments = createChaoticLoopSegments(size, 460, 220, 90);
+  const outerWallSegments = createChaoticLoopSegments(size, 180, 280, 120);
+  const innerWallSegments = createInnerLoopWithLeftChamberSegments(size, 460, 220, 90);
 
   return {
     name: "Hot Corridors",

--- a/src/db/maps/map-definitions/hotCorridors.ts
+++ b/src/db/maps/map-definitions/hotCorridors.ts
@@ -99,18 +99,53 @@ const createChaoticLoopSegments = (
   });
 };
 
+const createInnerLoopWithLeftChamberSegments = (
+  size: SceneSize,
+  inset: number,
+  cornerRadius: number,
+  distortion: number,
+): readonly BezierCurveSegment[] => {
+  const chaoticSegments = [...createChaoticLoopSegments(size, inset, cornerRadius, distortion)];
+  const left = inset;
+
+  chaoticSegments.splice(
+    6,
+    1,
+    {
+      start: { x: left, y: 1320 },
+      control1: { x: left + 12, y: 1230 },
+      control2: { x: left + 92, y: 1135 },
+      end: { x: left + 150, y: 1080 },
+    },
+    {
+      start: { x: left + 150, y: 1080 },
+      control1: { x: left + 240, y: 1020 },
+      control2: { x: left + 240, y: 980 },
+      end: { x: left + 150, y: 920 },
+    },
+    {
+      start: { x: left + 150, y: 920 },
+      control1: { x: left + 92, y: 865 },
+      control2: { x: left + 12, y: 770 },
+      end: { x: left, y: 680 },
+    },
+  );
+
+  return chaoticSegments;
+};
+
 const mapConfig = (() => {
   const size: SceneSize = { width: 2000, height: 2000 };
   const spawnPoint: SceneVector2 = { x: 320, y: 1000 };
 
   const enemyPositions: readonly SceneVector2[] = [
-    { x: 520, y: 1000 },
-    { x: 860, y: 320 },
-    { x: 1360, y: 360 },
+    { x: 320, y: 1000 },
+    { x: 620, y: 620 },
+    { x: 1000, y: 320 },
+    { x: 1380, y: 620 },
     { x: 1680, y: 1000 },
-    { x: 1360, y: 1640 },
-    { x: 880, y: 1690 },
-    { x: 520, y: 1200 },
+    { x: 1380, y: 1380 },
+    { x: 620, y: 1380 },
   ];
 
   const turretPositions: readonly SceneVector2[] = [
@@ -121,7 +156,7 @@ const mapConfig = (() => {
   ];
 
   const outerWallSegments = createChaoticLoopSegments(size, 180, 280, 120);
-  const innerWallSegments = createChaoticLoopSegments(size, 460, 220, 90);
+  const innerWallSegments = createInnerLoopWithLeftChamberSegments(size, 460, 220, 90);
 
   return {
     name: "Hot Corridors",


### PR DESCRIPTION
### Motivation
- Make the `hotCorridors` brick layout less dense by increasing corridor brick spacing so corridors read more like open paths. 
- Break the overly-regular loop geometry so corridor outlines feel more organic and chaotic without introducing runtime randomness. 

### Description
- Added `TAU = Math.PI * 2` and a new helper `createChaoticLoopSegments(size, inset, cornerRadius, distortion)` which deterministically distorts Bezier `control1`/`control2` points using trigonometric offsets. 
- Replaced original calls to `createRoundedLoopSegments` with `createChaoticLoopSegments` for the outer and inner walls and tuned distortions to `120` (outer) and `90` (inner). 
- Increased brick spacing for both `bezierCurveWithBricks` calls in `hotCorridors` from `spacing: 1` to `spacing: 14`. 

### Testing
- Ran type check with `npx tsc -p tsconfig.json --noEmit` which completed successfully. 
- The repository built type-checked code with no TypeScript errors (only an unrelated npm warning was emitted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca5cc0e8e08320897207068a50f73e)