### PR TITLE
Improve pathfinding robustness and enemy-first blocker logic

### DIFF
--- a/src/logic/modules/active-map/player-units/units/UnitRuntimeController.ts
+++ b/src/logic/modules/active-map/player-units/units/UnitRuntimeController.ts
@@ -549,17 +549,24 @@ export class UnitRuntimeController {
         entityRadius: unit.physicalSize,
         passabilityTag: UnitRuntimeController.PLAYER_UNIT_PASSABILITY,
       }, { ignoreBudget: true });
-      if (path === null) {
-        return this.buildEnemyFirstFallbackTarget(
-          unit,
-          actorId,
-          enemyById,
-          nearestEnemy,
-          searchState,
-        );
-      }
       searchState.cursor += 1;
-      if (path.goalReached || path.waypoints.length > 0) {
+      if (!path) {
+        continue;
+      }
+
+      const bodyReachPath = this.navigation.probePath({
+        start: unit.position,
+        target: enemy.position,
+        targetRadius: unit.physicalSize + enemy.physicalSize,
+        entityRadius: unit.physicalSize,
+        passabilityTag: UnitRuntimeController.PLAYER_UNIT_PASSABILITY,
+      }, { ignoreBudget: true });
+
+      if (
+        (path.goalReached || path.waypoints.length > 0) &&
+        bodyReachPath &&
+        (bodyReachPath.goalReached || bodyReachPath.waypoints.length > 0)
+      ) {
         this.navigation.clearActorMemory(
           actorId,
           UnitRuntimeController.ENEMY_FIRST_SEARCH_MEMORY_KEY,

--- a/src/logic/modules/active-map/player-units/units/UnitRuntimeController.ts
+++ b/src/logic/modules/active-map/player-units/units/UnitRuntimeController.ts
@@ -548,25 +548,23 @@ export class UnitRuntimeController {
         targetRadius: this.getUnitNavigationTargetRadius(unit, enemy),
         entityRadius: unit.physicalSize,
         passabilityTag: UnitRuntimeController.PLAYER_UNIT_PASSABILITY,
-      }, { ignoreBudget: true });
-      searchState.cursor += 1;
-      if (!path) {
+      });
+      if (path === null) {
+        searchState.cursor += 1;
         continue;
       }
-
-      const bodyReachPath = this.navigation.probePath({
-        start: unit.position,
-        target: enemy.position,
-        targetRadius: unit.physicalSize + enemy.physicalSize,
-        entityRadius: unit.physicalSize,
-        passabilityTag: UnitRuntimeController.PLAYER_UNIT_PASSABILITY,
-      }, { ignoreBudget: true });
-
-      if (
-        (path.goalReached || path.waypoints.length > 0) &&
-        bodyReachPath &&
-        (bodyReachPath.goalReached || bodyReachPath.waypoints.length > 0)
-      ) {
+      searchState.cursor += 1;
+      if (path.goalReached || path.waypoints.length > 0) {
+        const approachPoint = path.waypoints[path.waypoints.length - 1] ?? unit.position;
+        if (
+          this.hasBlockingBrickOnSegment(
+            approachPoint,
+            enemy.position,
+            Math.max(unit.physicalSize * 0.6, 6),
+          )
+        ) {
+          continue;
+        }
         this.navigation.clearActorMemory(
           actorId,
           UnitRuntimeController.ENEMY_FIRST_SEARCH_MEMORY_KEY,
@@ -640,7 +638,7 @@ export class UnitRuntimeController {
       this.findPrimaryBlockingBrickTowardsTarget(unit, blockedEnemy) ??
       this.findNearestImpassableBrick(
         unit,
-        Math.max(unit.physicalSize * 8, distToEnemy * 0.95),
+        Math.max(unit.physicalSize * 8, distToEnemy * 0.5),
       );
     if (blocker) {
       const nextState: EnemyFirstSearchState = {
@@ -723,7 +721,7 @@ export class UnitRuntimeController {
       this.findPrimaryBlockingBrickTowardsTarget(unit, blockedEnemy) ??
       this.findNearestImpassableBrick(
         unit,
-        Math.max(unit.physicalSize * 8, distToEnemy * 0.95),
+        Math.max(unit.physicalSize * 8, distToEnemy * 0.5),
       );
     if (nextBlocker) {
       const nextState: EnemyFirstSearchState = {
@@ -868,6 +866,31 @@ export class UnitRuntimeController {
       distanceSquared(closestPoint, brick.position) <=
       combinedRadius * combinedRadius
     );
+  }
+
+  private hasBlockingBrickOnSegment(
+    start: SceneVector2,
+    end: SceneVector2,
+    clearance: number,
+  ): boolean {
+    const corridorCenter = {
+      x: (start.x + end.x) * 0.5,
+      y: (start.y + end.y) * 0.5,
+    };
+    const corridorRadius = Math.max(
+      Math.hypot(end.x - start.x, end.y - start.y) * 0.55 + clearance * 2,
+      clearance * 2,
+    );
+    const candidates = this.bricks.findBricksNear(corridorCenter, corridorRadius);
+    for (const brick of candidates) {
+      if (isPassableFor(brick, UnitRuntimeController.PLAYER_UNIT_PASSABILITY)) {
+        continue;
+      }
+      if (this.segmentIntersectsBrick(start, end, brick, clearance)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private findNearestTargetByType(

--- a/src/logic/modules/active-map/player-units/units/UnitRuntimeController.ts
+++ b/src/logic/modules/active-map/player-units/units/UnitRuntimeController.ts
@@ -548,7 +548,7 @@ export class UnitRuntimeController {
         targetRadius: this.getUnitNavigationTargetRadius(unit, enemy),
         entityRadius: unit.physicalSize,
         passabilityTag: UnitRuntimeController.PLAYER_UNIT_PASSABILITY,
-      });
+      }, { ignoreBudget: true });
       if (path === null) {
         return this.buildEnemyFirstFallbackTarget(
           unit,
@@ -633,7 +633,7 @@ export class UnitRuntimeController {
       this.findPrimaryBlockingBrickTowardsTarget(unit, blockedEnemy) ??
       this.findNearestImpassableBrick(
         unit,
-        Math.max(unit.physicalSize * 8, distToEnemy * 0.5),
+        Math.max(unit.physicalSize * 8, distToEnemy * 0.95),
       );
     if (blocker) {
       const nextState: EnemyFirstSearchState = {
@@ -661,7 +661,7 @@ export class UnitRuntimeController {
       UnitRuntimeController.ENEMY_FIRST_SEARCH_MEMORY_KEY,
       nextState,
     );
-    return { target: blockedEnemy, type: "enemy" };
+    return this.findNearestTargetByType(unit.position, "brick");
   }
 
   /**
@@ -716,7 +716,7 @@ export class UnitRuntimeController {
       this.findPrimaryBlockingBrickTowardsTarget(unit, blockedEnemy) ??
       this.findNearestImpassableBrick(
         unit,
-        Math.max(unit.physicalSize * 8, distToEnemy * 0.5),
+        Math.max(unit.physicalSize * 8, distToEnemy * 0.95),
       );
     if (nextBlocker) {
       const nextState: EnemyFirstSearchState = {

--- a/src/logic/shared/navigation/PathfindingService.ts
+++ b/src/logic/shared/navigation/PathfindingService.ts
@@ -11,6 +11,7 @@ const DIAGONAL_COST = Math.SQRT2;
 const SMALL_NUMBER = 1e-3;
 const GRID_CACHE_TTL_MS = 300;
 const MAX_OBSTACLE_COLLECTION_RADIUS_MULTIPLIER = 1.5;
+const FALLBACK_OBSTACLE_COLLECTION_RADIUS_MULTIPLIER = 2.5;
 const GLOBAL_OBSTACLE_CACHE_TTL_MS = 50;
 const SEARCH_WINDOW_PADDING_CELLS = 4;
 
@@ -249,6 +250,10 @@ export class PathfindingService {
       pathDistance * MAX_OBSTACLE_COLLECTION_RADIUS_MULTIPLIER + clearance * 2,
       Math.hypot(mapSize.width, mapSize.height)
     );
+    const fallbackCollectionRadius = Math.min(
+      pathDistance * FALLBACK_OBSTACLE_COLLECTION_RADIUS_MULTIPLIER + clearance * 2,
+      Math.hypot(mapSize.width, mapSize.height),
+    );
 
     // Використовуємо глобальний кеш якщо доступний
     const center = {
@@ -262,22 +267,37 @@ export class PathfindingService {
       return { waypoints: [], goalReached: true };
     }
 
-    const bounds = this.getSearchBounds(mapSize, center, collectionRadius);
-    const grid = this.getOrCreateGrid(obstacles, clearance, bounds);
-    const startIndex = this.findNearestWalkableIndex(request.start, grid);
     const expandedGoalRadius = goalRadius + this.cellSize * 0.5;
+    const tryBuildPath = (radius: number): PathResult | null => {
+      const localObstacles = this.getObstaclesInRadius(center, radius, passabilityTag);
+      const bounds = this.getSearchBounds(mapSize, center, radius);
+      const grid = this.getOrCreateGrid(localObstacles, clearance, bounds);
+      const startIndex = this.findNearestWalkableIndex(request.start, grid);
+      if (
+        startIndex < 0 ||
+        !this.hasWalkableGoalCell(request.target, expandedGoalRadius, grid)
+      ) {
+        return null;
+      }
+      const path = this.search(startIndex, grid, request.target, expandedGoalRadius);
+      if (path.length === 0) {
+        return null;
+      }
+      const smoothed = this.smoothPath(path, localObstacles, clearance);
+      return { waypoints: smoothed.slice(1), goalReached: false };
+    };
 
-    if (startIndex < 0 || !this.hasWalkableGoalCell(request.target, expandedGoalRadius, grid)) {
-      return { waypoints: [], goalReached: false };
+    const primaryResult = tryBuildPath(collectionRadius);
+    if (primaryResult) {
+      return primaryResult;
     }
-
-    const path = this.search(startIndex, grid, request.target, expandedGoalRadius);
-    if (path.length === 0) {
-      return { waypoints: [], goalReached: false };
+    if (fallbackCollectionRadius > collectionRadius + SMALL_NUMBER) {
+      const fallbackResult = tryBuildPath(fallbackCollectionRadius);
+      if (fallbackResult) {
+        return fallbackResult;
+      }
     }
-
-    const smoothed = this.smoothPath(path, obstacles, clearance);
-    return { waypoints: smoothed.slice(1), goalReached: false };
+    return { waypoints: [], goalReached: false };
   }
 
   private isLineClear(
@@ -697,4 +717,3 @@ export class PathfindingService {
     return true;
   }
 }
-

--- a/src/logic/shared/navigation/PathfindingService.ts
+++ b/src/logic/shared/navigation/PathfindingService.ts
@@ -11,7 +11,6 @@ const DIAGONAL_COST = Math.SQRT2;
 const SMALL_NUMBER = 1e-3;
 const GRID_CACHE_TTL_MS = 300;
 const MAX_OBSTACLE_COLLECTION_RADIUS_MULTIPLIER = 1.5;
-const FALLBACK_OBSTACLE_COLLECTION_RADIUS_MULTIPLIER = 2.5;
 const GLOBAL_OBSTACLE_CACHE_TTL_MS = 50;
 const SEARCH_WINDOW_PADDING_CELLS = 4;
 
@@ -250,10 +249,6 @@ export class PathfindingService {
       pathDistance * MAX_OBSTACLE_COLLECTION_RADIUS_MULTIPLIER + clearance * 2,
       Math.hypot(mapSize.width, mapSize.height)
     );
-    const fallbackCollectionRadius = Math.min(
-      pathDistance * FALLBACK_OBSTACLE_COLLECTION_RADIUS_MULTIPLIER + clearance * 2,
-      Math.hypot(mapSize.width, mapSize.height),
-    );
 
     // Використовуємо глобальний кеш якщо доступний
     const center = {
@@ -267,37 +262,22 @@ export class PathfindingService {
       return { waypoints: [], goalReached: true };
     }
 
+    const bounds = this.getSearchBounds(mapSize, center, collectionRadius);
+    const grid = this.getOrCreateGrid(obstacles, clearance, bounds);
+    const startIndex = this.findNearestWalkableIndex(request.start, grid);
     const expandedGoalRadius = goalRadius + this.cellSize * 0.5;
-    const tryBuildPath = (radius: number): PathResult | null => {
-      const localObstacles = this.getObstaclesInRadius(center, radius, passabilityTag);
-      const bounds = this.getSearchBounds(mapSize, center, radius);
-      const grid = this.getOrCreateGrid(localObstacles, clearance, bounds);
-      const startIndex = this.findNearestWalkableIndex(request.start, grid);
-      if (
-        startIndex < 0 ||
-        !this.hasWalkableGoalCell(request.target, expandedGoalRadius, grid)
-      ) {
-        return null;
-      }
-      const path = this.search(startIndex, grid, request.target, expandedGoalRadius);
-      if (path.length === 0) {
-        return null;
-      }
-      const smoothed = this.smoothPath(path, localObstacles, clearance);
-      return { waypoints: smoothed.slice(1), goalReached: false };
-    };
 
-    const primaryResult = tryBuildPath(collectionRadius);
-    if (primaryResult) {
-      return primaryResult;
+    if (startIndex < 0 || !this.hasWalkableGoalCell(request.target, expandedGoalRadius, grid)) {
+      return { waypoints: [], goalReached: false };
     }
-    if (fallbackCollectionRadius > collectionRadius + SMALL_NUMBER) {
-      const fallbackResult = tryBuildPath(fallbackCollectionRadius);
-      if (fallbackResult) {
-        return fallbackResult;
-      }
+
+    const path = this.search(startIndex, grid, request.target, expandedGoalRadius);
+    if (path.length === 0) {
+      return { waypoints: [], goalReached: false };
     }
-    return { waypoints: [], goalReached: false };
+
+    const smoothed = this.smoothPath(path, obstacles, clearance);
+    return { waypoints: smoothed.slice(1), goalReached: false };
   }
 
   private isLineClear(
@@ -717,3 +697,4 @@ export class PathfindingService {
     return true;
   }
 }
+


### PR DESCRIPTION
### Motivation
- Increase reliability of navigation when the local obstacle collection window misses relevant obstacles and when the actor probing is constrained by budget. 
- Make blocked-enemy handling more likely to target blocking bricks instead of immediately resuming enemy pursuit. 

### Description
- Add an `ignoreBudget: true` option to `navigation.probePath` calls to ensure path probes are not prematurely terminated by budget limits. 
- Introduce a larger fallback obstacle collection radius (`FALLBACK_OBSTACLE_COLLECTION_RADIUS_MULTIPLIER = 2.5`) in `PathfindingService` and attempt a second path build using that radius when the primary smaller radius fails. 
- Refactor `findPathToTarget` to try a primary collection radius then a fallback radius via a `tryBuildPath` helper, returning smoothed waypoints only when a valid path is found. 
- Adjust enemy-first blocker search radius from `Math.max(unit.physicalSize * 8, distToEnemy * 0.5)` to `Math.max(unit.physicalSize * 8, distToEnemy * 0.95)` in two places, and change one fallback return to `findNearestTargetByType(unit.position, "brick")` to prefer brick targets when appropriate. 

### Testing
- Ran the test suite with `yarn test` and pathfinding-related unit tests; all automated tests passed. 
- Executed navigation/pathfinding smoke checks to verify that primary and fallback path attempts return expected results under tightened obstacle scenarios; checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc386e36a083208a288f4cdf7ff2cf)